### PR TITLE
feat(selecao): operadores de exclusão, avaliação ternária e gate de fase

### DIFF
--- a/src/selecao/Unifesspa.UniPlus.Selecao.API/Errors/SelecaoDomainErrorRegistration.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.API/Errors/SelecaoDomainErrorRegistration.cs
@@ -299,6 +299,12 @@ internal sealed class SelecaoDomainErrorRegistration : IDomainErrorRegistration
         new("DocumentoExigido.FaseNaoPertenceAoProcesso", new DomainErrorMapping(StatusCodes.Status422UnprocessableEntity, "uniplus.selecao.documento_exigido.fase_nao_pertence_ao_processo", "A fase informada não pertence ao cronograma deste processo")),
         new("DocumentoExigido.CondicionalVaziaDeterminaResultado", new DomainErrorMapping(StatusCodes.Status422UnprocessableEntity, "uniplus.selecao.documento_exigido.condicional_vazia_determina_resultado", "Exigência CONDICIONAL sem condição viva que determina resultado nunca seria cobrada de ninguém")),
         new("DocumentoExigido.TipoDocumentoNaoEncontrado", new DomainErrorMapping(StatusCodes.Status422UnprocessableEntity, "uniplus.selecao.documento_exigido.tipo_documento_nao_encontrado", "Tipo de documento não encontrado ou não está mais vivo")),
+        // Gate de fase (Story #916): uma condição de gatilho não pode citar um fato cujo
+        // PontoResolucao é uma fase posterior à fase em que o documento é exigido — os dois
+        // erros são diagnósticos distintos (fase do PontoResolucao ausente do cronograma vs.
+        // presente, mas posterior), não reaproveitam o mesmo código.
+        new("DocumentoExigido.PontoResolucaoForaDoCronograma", new DomainErrorMapping(StatusCodes.Status422UnprocessableEntity, "uniplus.selecao.documento_exigido.ponto_resolucao_fora_do_cronograma", "A fase em que o fato citado na condição de gatilho é conhecido não pertence ao cronograma deste processo")),
+        new("DocumentoExigido.FatoResolvidoEmFasePosterior", new DomainErrorMapping(StatusCodes.Status422UnprocessableEntity, "uniplus.selecao.documento_exigido.fato_resolvido_em_fase_posterior", "O fato citado na condição de gatilho só é conhecido numa fase posterior à fase em que o documento é exigido")),
         // ProcessoSeletivo.ExigenciasDocumentaisNaoMaterializadas (guarda B-01) removido —
         // Story #554, PR #903, issue #548: o bloco deixou de ser stub, o gate real decide.
         new("FaseCronograma.ReferenciadaPorExigenciaViva", new DomainErrorMapping(StatusCodes.Status422UnprocessableEntity, "uniplus.selecao.fase_cronograma.referenciada_por_exigencia_viva", "A fase removida do cronograma é referenciada por um documento exigido configurado")),

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Application/Commands/ProcessosSeletivos/DefinirDocumentosExigidosCommandHandler.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Application/Commands/ProcessosSeletivos/DefinirDocumentosExigidosCommandHandler.cs
@@ -65,9 +65,14 @@ public static class DefinirDocumentosExigidosCommandHandler
         // O vocabulário só é resolvido (I/O cross-módulo) quando algum item declara
         // gatilho — mesmo princípio de DefinirCriteriosDesempateCommandHandler.
         bool existeGatilho = command.Itens.Any(static i => i.Condicoes.Count > 0);
-        IReadOnlyDictionary<string, DescritorFatoCandidato>? vocabularioFatos = existeGatilho
-            ? await ResolverVocabularioFatosAsync(fatoCandidatoReader, cancellationToken).ConfigureAwait(false)
-            : null;
+        IReadOnlyDictionary<string, DescritorFatoCandidato>? vocabularioFatos = null;
+        IReadOnlyDictionary<string, string>? pontoResolucaoPorFato = null;
+        if (existeGatilho)
+        {
+            (vocabularioFatos, pontoResolucaoPorFato) = await ResolverVocabularioFatosAsync(fatoCandidatoReader, cancellationToken)
+                .ConfigureAwait(false);
+        }
+
         IReadOnlyDictionary<string, IReadOnlySet<string>>? dominiosDinamicos = existeGatilho
             ? ResolverDominiosDinamicos(processo)
             : null;
@@ -97,6 +102,20 @@ public static class DefinirDocumentosExigidosCommandHandler
             if (condicoesResult.IsFailure)
             {
                 return Result<MutacaoAceita>.Failure(condicoesResult.Error!);
+            }
+
+            // Gate de fase (Story #916): uma condição de gatilho não pode citar um fato cujo
+            // PontoResolucao é uma fase posterior à fase em que o documento é exigido — não há
+            // como o gatilho já ter sido resolvido para o candidato quando a exigência entra
+            // em jogo.
+            if (condicoesResult.Value!.Count > 0)
+            {
+                Result gateDeFaseResult = ValidarGateDeFase(
+                    condicoesResult.Value!, input.ExigidoNaFaseId, processo, pontoResolucaoPorFato!);
+                if (gateDeFaseResult.IsFailure)
+                {
+                    return Result<MutacaoAceita>.Failure(gateDeFaseResult.Error!);
+                }
             }
 
             Result<IReadOnlyList<DocumentoExigidoBaseLegal>> basesLegaisResult = ResolverBasesLegais(input.BasesLegais);
@@ -213,6 +232,55 @@ public static class DefinirDocumentosExigidosCommandHandler
     }
 
     /// <summary>
+    /// Gate de fase (Story #916): recusa uma condição de gatilho cujo fato só é conhecido
+    /// (<c>PontoResolucao</c>) numa fase posterior à fase em que o documento é exigido — o
+    /// gatilho nunca teria como ter sido resolvido para o candidato a essa altura do
+    /// certame. A fase da PRÓPRIA exigência é localizada com <c>SingleOrDefault</c> (nunca
+    /// <c>Single</c>, para não estourar exceção em vez de 500): quando não encontrada, este
+    /// método não recusa de novo — <see cref="ProcessoSeletivo.DefinirDocumentosExigidos"/>
+    /// já garante, eagerly, que toda fase referenciada pertence ao cronograma
+    /// (<c>DocumentoExigido.FaseNaoPertenceAoProcesso</c>), e é essa checagem que decide o caso.
+    /// </summary>
+    private static Result ValidarGateDeFase(
+        IReadOnlyList<CondicaoGatilho> condicoes,
+        Guid exigidoNaFaseId,
+        ProcessoSeletivo processo,
+        IReadOnlyDictionary<string, string> pontoResolucaoPorFato)
+    {
+        FaseCronograma? faseDaExigencia = processo.CronogramaFases.SingleOrDefault(f => f.Id == exigidoNaFaseId);
+
+        foreach (CondicaoGatilho condicao in condicoes)
+        {
+            if (!pontoResolucaoPorFato.TryGetValue(condicao.Fato, out string? pontoResolucao))
+            {
+                // O fato já passou por PredicadoDnfValidador (vocabulário fechado) antes de
+                // chegar aqui — não deveria faltar no mapa construído junto do mesmo
+                // vocabulário. Defensivo: nada a comparar, não bloqueia.
+                continue;
+            }
+
+            FaseCronograma? faseDoPontoResolucao = processo.CronogramaFases
+                .SingleOrDefault(f => string.Equals(f.Codigo, pontoResolucao, StringComparison.Ordinal));
+
+            if (faseDoPontoResolucao is null)
+            {
+                return Result.Failure(new DomainError(
+                    "DocumentoExigido.PontoResolucaoForaDoCronograma",
+                    $"O fato '{condicao.Fato}' resolve na fase '{pontoResolucao}', que não pertence ao cronograma deste processo."));
+            }
+
+            if (faseDaExigencia is not null && faseDoPontoResolucao.Ordem > faseDaExigencia.Ordem)
+            {
+                return Result.Failure(new DomainError(
+                    "DocumentoExigido.FatoResolvidoEmFasePosterior",
+                    $"O fato '{condicao.Fato}' só é conhecido na fase '{pontoResolucao}' (ordem {faseDoPontoResolucao.Ordem}), posterior à fase em que o documento é exigido (ordem {faseDaExigencia.Ordem})."));
+            }
+        }
+
+        return Result.Success();
+    }
+
+    /// <summary>
     /// Resolve as bases legais de um item (Story #554, PR #898, issue #549) — só a forma de
     /// cada base é validada aqui (referência não vazia, abrangência/status no domínio
     /// fechado); o gate "≥1 RESOLVIDO por exigência que determina resultado" é da
@@ -268,9 +336,12 @@ public static class DefinirDocumentosExigidosCommandHandler
     /// Mapeia <see cref="FatoCandidatoView"/> para <see cref="DescritorFatoCandidato"/>,
     /// estendendo <c>DefinirCriteriosDesempateCommandHandler.ResolverVocabularioFatosAsync</c>
     /// (#846/#847) para incluir os fatos categóricos de escopo-processo (Story #554, PR #896) —
-    /// antes deliberadamente fora do vocabulário fechado.
+    /// antes deliberadamente fora do vocabulário fechado. Devolve, na mesma passada, a projeção
+    /// <c>PontoResolucao</c> por fato (Story #916) que o gate de fase usa — vive como projeção
+    /// própria deste handler, e não em <see cref="DescritorFatoCandidato"/> (VO mínimo
+    /// compartilhado com <c>DefinirCriteriosDesempateCommandHandler</c>, que não precisa dela).
     /// </summary>
-    private static async Task<IReadOnlyDictionary<string, DescritorFatoCandidato>> ResolverVocabularioFatosAsync(
+    private static async Task<(IReadOnlyDictionary<string, DescritorFatoCandidato> Vocabulario, IReadOnlyDictionary<string, string> PontoResolucaoPorFato)> ResolverVocabularioFatosAsync(
         IFatoCandidatoReader fatoCandidatoReader, CancellationToken cancellationToken)
     {
         IReadOnlyList<FatoCandidatoView> fatos = await fatoCandidatoReader
@@ -278,6 +349,7 @@ public static class DefinirDocumentosExigidosCommandHandler
             .ConfigureAwait(false);
 
         Dictionary<string, DescritorFatoCandidato> vocabulario = [];
+        Dictionary<string, string> pontoResolucaoPorFato = new(StringComparer.Ordinal);
         foreach (FatoCandidatoView fato in fatos)
         {
             TipoDominioFato? tipoDominio = fato switch
@@ -298,10 +370,11 @@ public static class DefinirDocumentosExigidosCommandHandler
             if (descritorResult.IsSuccess)
             {
                 vocabulario[fato.Codigo] = descritorResult.Value!;
+                pontoResolucaoPorFato[fato.Codigo] = fato.PontoResolucao;
             }
         }
 
-        return vocabulario;
+        return (vocabulario, pontoResolucaoPorFato);
     }
 
     /// <summary>

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Application/Validators/ProcessosSeletivos/DefinirDocumentosExigidosCommandValidator.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Application/Validators/ProcessosSeletivos/DefinirDocumentosExigidosCommandValidator.cs
@@ -22,7 +22,8 @@ public sealed class DefinirDocumentosExigidosCommandValidator : AbstractValidato
         "PENDENCIA_REENVIO",
     ];
 
-    private static readonly string[] OperadoresValidos = ["IGUAL", "EM", "MAIOR_IGUAL", "MENOR_IGUAL"];
+    // Story #916: DIFERENTE/NAO_EM (operadores de exclusão) somam-se aos 4 originais.
+    private static readonly string[] OperadoresValidos = ["IGUAL", "EM", "MAIOR_IGUAL", "MENOR_IGUAL", "DIFERENTE", "NAO_EM"];
 
     private static readonly string[] AbrangenciasValidas = ["FEDERAL", "ESTADUAL", "MUNICIPAL", "INTERNA_NORMA", "INTERNA_EDITAL"];
 

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Domain/Entities/DocumentoExigido.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Domain/Entities/DocumentoExigido.cs
@@ -296,27 +296,29 @@ public sealed class DocumentoExigido : EntityBase
         _basesLegais.Where(static b => b.Status == StatusBaseLegal.Resolvido);
 
     /// <summary>
-    /// A exigência se aplica a um candidato com estes fatos? GERAL sempre se aplica — o
-    /// gatilho nunca é avaliado. CONDICIONAL depende do predicado DNF (PR #896): zero
-    /// cláusulas vivas nunca casa com ninguém, mesma semântica de
-    /// <see cref="PredicadoDnf.Avaliar"/> e de CA-01 ("exigida de ninguém"). Usado tanto
-    /// pelo resolvedor de exigências documentais (PR #903, por candidato real) quanto pelo
-    /// gate de conformidade legal (PR #903, <see cref="Services.AvaliadorConformidadeLegal"/>
+    /// A exigência se aplica a um candidato com estes fatos? GERAL sempre é
+    /// <see cref="Ternario.Verdadeiro"/> — o gatilho nunca é avaliado. CONDICIONAL depende
+    /// do predicado DNF ternário (PR #896, Story #916): zero cláusulas vivas nunca casa com
+    /// ninguém (<see cref="Ternario.Falso"/>, estado estrutural — CA-01 "exigida de
+    /// ninguém"), e um fato citado que não está resolvido para este candidato produz
+    /// <see cref="Ternario.Indeterminado"/>, nunca <see cref="Ternario.Falso"/> (fail-closed).
+    /// Usado tanto pelo resolvedor de exigências documentais (PR #903, por candidato real)
+    /// quanto pelo gate de conformidade legal (PR #903, <see cref="Services.AvaliadorConformidadeLegal"/>
     /// — por um fato sintético fixo, ex. só <c>MODALIDADE</c>, para provar cobertura
     /// incondicional de uma modalidade inteira).
     /// </summary>
-    public bool AplicavelPara(IReadOnlyDictionary<string, JsonElement> fatosResolvidos)
+    public Ternario AplicavelPara(IReadOnlyDictionary<string, JsonElement> fatosResolvidos)
     {
         ArgumentNullException.ThrowIfNull(fatosResolvidos);
 
         if (Aplicabilidade == Aplicabilidade.Geral)
         {
-            return true;
+            return Ternario.Verdadeiro;
         }
 
         if (_condicoes.Count == 0)
         {
-            return false;
+            return Ternario.Falso;
         }
 
         // O dado já foi validado quando a exigência foi escrita (CondicaoGatilho.Criar) —
@@ -370,6 +372,14 @@ public sealed class DocumentoExigido : EntityBase
                 .All(c => CondicaoDeModalidadeSatisfeitaPor(c.ParaCondicaoDnf(), modalidadeCodigo)));
     }
 
+    /// <summary>
+    /// Story #916: <see cref="Operador.Diferente"/>/<see cref="Operador.NaoEm"/> espelham a
+    /// negação de <see cref="Operador.Igual"/>/<see cref="Operador.Em"/> — sem os dois braços
+    /// novos, um gatilho <c>MODALIDADE DIFERENTE X</c>/<c>NAO_EM [...]</c> seria aceito pelo
+    /// validador (matriz operador × domínio) mas escaparia silenciosamente do gate estrutural
+    /// CA-05 (esta checagem tem switch PRÓPRIO, à parte de <see cref="PredicadoDnf.Avaliar"/> —
+    /// não migra sozinho quando um operador novo é adicionado).
+    /// </summary>
     private static bool CondicaoDeModalidadeSatisfeitaPor(CondicaoDnf condicao, string modalidadeCodigo) =>
         condicao.Operador switch
         {
@@ -377,6 +387,12 @@ public sealed class DocumentoExigido : EntityBase
                 && string.Equals(condicao.Valor.GetString(), modalidadeCodigo, StringComparison.Ordinal),
             Operador.Em => condicao.Valor.ValueKind == JsonValueKind.Array
                 && condicao.Valor.EnumerateArray().Any(item =>
+                    item.ValueKind == JsonValueKind.String
+                    && string.Equals(item.GetString(), modalidadeCodigo, StringComparison.Ordinal)),
+            Operador.Diferente => condicao.Valor.ValueKind == JsonValueKind.String
+                && !string.Equals(condicao.Valor.GetString(), modalidadeCodigo, StringComparison.Ordinal),
+            Operador.NaoEm => condicao.Valor.ValueKind == JsonValueKind.Array
+                && !condicao.Valor.EnumerateArray().Any(item =>
                     item.ValueKind == JsonValueKind.String
                     && string.Equals(item.GetString(), modalidadeCodigo, StringComparison.Ordinal)),
             _ => false,

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Domain/Enums/Operador.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Domain/Enums/Operador.cs
@@ -3,8 +3,9 @@ namespace Unifesspa.UniPlus.Selecao.Domain.Enums;
 /// <summary>
 /// Operador de uma <see cref="ValueObjects.CondicaoDnf"/> — a tripla
 /// <c>{ Fato, Operador, Valor }</c> que compõe a forma normal disjuntiva de um
-/// predicado sobre o candidato (ADR-0111, Story #847). Conjunto fechado por
-/// design: os quatro operadores espelham exatamente a matriz operador ×
+/// predicado sobre o candidato (ADR-0111, Story #847; operadores de exclusão
+/// <see cref="Diferente"/>/<see cref="NaoEm"/>, Story #916). Conjunto fechado por
+/// design: os seis operadores espelham exatamente a matriz operador ×
 /// domínio da ADR-0111.
 /// </summary>
 public enum Operador
@@ -22,4 +23,10 @@ public enum Operador
 
     /// <summary>Menor ou igual — só aceito para domínio numérico.</summary>
     MenorIgual = 4,
+
+    /// <summary>Negação de <see cref="Igual"/> (Story #916) — aceito em todo domínio onde <see cref="Igual"/> vale.</summary>
+    Diferente = 5,
+
+    /// <summary>Negação de <see cref="Em"/> (Story #916) — só aceito onde <see cref="Em"/> vale.</summary>
+    NaoEm = 6,
 }

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Domain/Enums/OperadorCodigo.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Domain/Enums/OperadorCodigo.cs
@@ -13,10 +13,12 @@ public static class OperadorCodigo
     public const string Em = "EM";
     public const string MaiorIgual = "MAIOR_IGUAL";
     public const string MenorIgual = "MENOR_IGUAL";
+    public const string Diferente = "DIFERENTE";
+    public const string NaoEm = "NAO_EM";
 
     /// <summary>
     /// Converte o operador para o código canônico. O <c>switch</c> é
-    /// exaustivo: um 5º operador quebra a build (CS8509 promovido a erro por
+    /// exaustivo: um 7º operador quebra a build (CS8509 promovido a erro por
     /// <c>TreatWarningsAsErrors</c>) até este mapeamento absorvê-lo.
     /// </summary>
     public static string ToCodigo(this Operador operador) => operador switch
@@ -25,6 +27,8 @@ public static class OperadorCodigo
         Operador.Em => Em,
         Operador.MaiorIgual => MaiorIgual,
         Operador.MenorIgual => MenorIgual,
+        Operador.Diferente => Diferente,
+        Operador.NaoEm => NaoEm,
         Operador.Nenhuma => throw new ArgumentOutOfRangeException(
             nameof(operador), operador, "Operador.Nenhuma é sentinela e não tem código canônico."),
         _ => throw new ArgumentOutOfRangeException(nameof(operador), operador, "Operador desconhecido."),
@@ -42,6 +46,8 @@ public static class OperadorCodigo
         Em => Operador.Em,
         MaiorIgual => Operador.MaiorIgual,
         MenorIgual => Operador.MenorIgual,
+        Diferente => Operador.Diferente,
+        NaoEm => Operador.NaoEm,
         _ => Operador.Nenhuma,
     };
 }

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Domain/Enums/StatusResolucaoExigencia.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Domain/Enums/StatusResolucaoExigencia.cs
@@ -3,7 +3,7 @@ namespace Unifesspa.UniPlus.Selecao.Domain.Enums;
 /// <summary>
 /// Veredicto de <see cref="Services.ResolvedorExigenciasDocumentais"/> sobre uma
 /// <see cref="Entities.DocumentoExigido"/> congelada, para um candidato (Story #554, PR #903,
-/// ADR-0076).
+/// ADR-0076; 4º valor <see cref="AplicabilidadeIndeterminada"/>, Story #916).
 /// </summary>
 public enum StatusResolucaoExigencia
 {
@@ -15,6 +15,16 @@ public enum StatusResolucaoExigencia
     /// <summary>O gatilho DNF casou (ou a exigência é GERAL), mas não há apresentação que a satisfaça ainda.</summary>
     Pendente = 2,
 
-    /// <summary>A exigência é CONDICIONAL e o gatilho não casou para este candidato — não conta contra ele.</summary>
+    /// <summary>A exigência é CONDICIONAL e o gatilho não casou (<see cref="Ternario.Falso"/>) para este candidato — não conta contra ele.</summary>
     NaoAplicavel = 3,
+
+    /// <summary>
+    /// A exigência é CONDICIONAL e o gatilho avaliou <see cref="Ternario.Indeterminado"/> — um
+    /// fato citado no gatilho não está resolvido para este candidato (Story #916). Distinto de
+    /// <see cref="Pendente"/> (que já significa "aplicável, falta apresentação"): aqui não se
+    /// sabe se a exigência é sequer aplicável. Nunca vira <see cref="Satisfeita"/> só porque o
+    /// candidato apresentou algo, e não participa do grupo de satisfação — é resolvida
+    /// fato-a-fato, independente de apresentação já existente.
+    /// </summary>
+    AplicabilidadeIndeterminada = 4,
 }

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Domain/Enums/Ternario.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Domain/Enums/Ternario.cs
@@ -1,0 +1,22 @@
+namespace Unifesspa.UniPlus.Selecao.Domain.Enums;
+
+/// <summary>
+/// Resultado ternário fail-closed da avaliação de um <see cref="ValueObjects.PredicadoDnf"/>
+/// (ou de uma <see cref="ValueObjects.ClausulaDnf"/>) contra os fatos de um candidato
+/// (Story #916, ADR-0111). Um fato citado numa condição que não está resolvido — ausente,
+/// <c>null</c>, ou de tipo incoerente com o operador — nunca é tratado como
+/// <see cref="Falso"/>: o predicado avalia como <see cref="Indeterminado"/>, e quem consome o
+/// veredicto decide o que fazer com a incerteza (nunca decide por omissão).
+/// </summary>
+/// <remarks>
+/// <see cref="Indeterminado"/> é <c>0</c> — o zero-default de C# tem de ser o estado
+/// fail-closed/mais conservador, nunca o mais permissivo. Um <see cref="Ternario"/> não
+/// inicializado (ex.: um campo esquecido) nunca é silenciosamente lido como
+/// <see cref="Verdadeiro"/>.
+/// </remarks>
+public enum Ternario
+{
+    Indeterminado = 0,
+    Verdadeiro = 1,
+    Falso = 2,
+}

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Domain/Services/AvaliadorConformidadeLegal.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Domain/Services/AvaliadorConformidadeLegal.cs
@@ -177,10 +177,13 @@ public static class AvaliadorConformidadeLegal
         // modalidade incondicionalmente, mas não DeterminaResultado() (não é obrigatória
         // nem tem consequência de indeferimento), é meramente opcional — não satisfaz a
         // obrigação legal "a modalidade X DEVE exigir o documento Y".
+        // Story #916: AplicavelPara agora é ternário — só Verdadeiro (certamente aplicável)
+        // prova cobertura incondicional; Indeterminado conta como "não provado", mesma
+        // conclusão que Falso já dava, sem mudança de comportamento observável aqui.
         bool cobertaIncondicionalmente = processo.DocumentosExigidos.Any(e =>
             string.Equals(e.TipoDocumentoCodigo, predicado.TipoDocumento, StringComparison.Ordinal)
             && e.DeterminaResultado()
-            && e.AplicavelPara(fatoDaModalidade));
+            && e.AplicavelPara(fatoDaModalidade) == Ternario.Verdadeiro);
 
         return cobertaIncondicionalmente
             ? (true, null, null)

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Domain/Services/PredicadoDnfValidador.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Domain/Services/PredicadoDnfValidador.cs
@@ -86,12 +86,16 @@ public static class PredicadoDnfValidador
 
     private static Result ValidarOperador(CondicaoDnf condicao, DescritorFatoCandidato descritor)
     {
+        // Story #916: DIFERENTE acompanha IGUAL em todo domínio onde IGUAL já vale — inclusive
+        // booleano/numérico (a letra da spec: "DIFERENTE só onde IGUAL vale", sem exceção de
+        // domínio). NAO_EM acompanha EM, que só vale nos dois ramos categóricos — booleano e
+        // numérico nunca tiveram EM.
         bool operadorCompativel = descritor.TipoDominio switch
         {
-            TipoDominioFato.Booleano => condicao.Operador == Operador.Igual,
-            TipoDominioFato.Numerico => condicao.Operador is Operador.Igual or Operador.MaiorIgual or Operador.MenorIgual,
-            TipoDominioFato.CategoricoEstatico => condicao.Operador is Operador.Igual or Operador.Em,
-            TipoDominioFato.CategoricoDinamico => condicao.Operador is Operador.Igual or Operador.Em,
+            TipoDominioFato.Booleano => condicao.Operador is Operador.Igual or Operador.Diferente,
+            TipoDominioFato.Numerico => condicao.Operador is Operador.Igual or Operador.MaiorIgual or Operador.MenorIgual or Operador.Diferente,
+            TipoDominioFato.CategoricoEstatico => condicao.Operador is Operador.Igual or Operador.Em or Operador.Diferente or Operador.NaoEm,
+            TipoDominioFato.CategoricoDinamico => condicao.Operador is Operador.Igual or Operador.Em or Operador.Diferente or Operador.NaoEm,
             _ => false,
         };
 
@@ -159,7 +163,9 @@ public static class PredicadoDnfValidador
 
     private static Result ValidarValorCategorico(CondicaoDnf condicao, IReadOnlyList<string> dominio)
     {
-        if (condicao.Operador == Operador.Em)
+        // NAO_EM (Story #916) segue a mesma forma de lista de EM — negação, não muda a
+        // validação de valor × domínio.
+        if (condicao.Operador is Operador.Em or Operador.NaoEm)
         {
             return ValidarValorCategoricoEm(condicao, dominio);
         }

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Domain/Services/ResolvedorExigenciasDocumentais.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Domain/Services/ResolvedorExigenciasDocumentais.cs
@@ -64,7 +64,7 @@ public static class ResolvedorExigenciasDocumentais
                 $"O grupo de satisfação '{grupoInvalido}' agrupa exigências de fases diferentes — o escopo do grupo é processo+fase."));
         }
 
-        Dictionary<Guid, bool> aplicavelPorExigencia = bloco.Exigencias.ToDictionary(
+        Dictionary<Guid, Ternario> aplicavelPorExigencia = bloco.Exigencias.ToDictionary(
             static e => e.Id, e => e.AplicavelPara(fatosResolvidos));
 
         Dictionary<Guid, bool> satisfeitaDiretamentePorExigencia = bloco.Exigencias.ToDictionary(
@@ -72,10 +72,13 @@ public static class ResolvedorExigenciasDocumentais
 
         // O grupo de satisfação propaga a satisfação DIRETA para as demais exigências
         // aplicáveis do mesmo grupo — uma única apresentação, dentro do grupo, satisfaz
-        // as outras (DocumentoExigido.GrupoSatisfacaoId, "semântica plena na PR #903").
+        // as outras (DocumentoExigido.GrupoSatisfacaoId, "semântica plena na PR #903"). Só
+        // exigência CERTAMENTE aplicável (Ternario.Verdadeiro) participa/propaga satisfação de
+        // grupo (Story #916) — uma indeterminada não deveria contaminar irmãs de grupo ainda
+        // por resolver.
         Dictionary<Guid, Guid> apresentacaoQueSatisfazOGrupo = [];
         foreach (IGrouping<Guid, DocumentoExigido> grupo in bloco.Exigencias
-            .Where(e => e.GrupoSatisfacaoId is not null && aplicavelPorExigencia[e.Id])
+            .Where(e => e.GrupoSatisfacaoId is not null && aplicavelPorExigencia[e.Id] == Ternario.Verdadeiro)
             .GroupBy(static e => e.GrupoSatisfacaoId!.Value))
         {
             DocumentoExigido? satisfator = grupo.FirstOrDefault(e => satisfeitaDiretamentePorExigencia[e.Id]);
@@ -88,7 +91,16 @@ public static class ResolvedorExigenciasDocumentais
         List<ExigenciaResolvida> resolucoes = [];
         foreach (DocumentoExigido exigencia in bloco.Exigencias)
         {
-            if (!aplicavelPorExigencia[exigencia.Id])
+            // Story #916: Indeterminado é resolvido fato-a-fato, SEMPRE — independentemente de
+            // já existir apresentação para esta exigência (nunca vira Satisfeita só porque o
+            // candidato enviou algo) e sem participar do grupo de satisfação.
+            if (aplicavelPorExigencia[exigencia.Id] == Ternario.Indeterminado)
+            {
+                resolucoes.Add(new ExigenciaResolvida(exigencia.Id, StatusResolucaoExigencia.AplicabilidadeIndeterminada, null));
+                continue;
+            }
+
+            if (aplicavelPorExigencia[exigencia.Id] == Ternario.Falso)
             {
                 resolucoes.Add(new ExigenciaResolvida(exigencia.Id, StatusResolucaoExigencia.NaoAplicavel, null));
                 continue;

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Domain/ValueObjects/ClausulaDnf.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Domain/ValueObjects/ClausulaDnf.cs
@@ -1,6 +1,9 @@
 namespace Unifesspa.UniPlus.Selecao.Domain.ValueObjects;
 
+using System.Text.Json;
+
 using Unifesspa.UniPlus.Kernel.Results;
+using Unifesspa.UniPlus.Selecao.Domain.Enums;
 
 /// <summary>
 /// Conjunção (E) de <see cref="CondicaoDnf"/> — uma cláusula da forma normal
@@ -27,4 +30,187 @@ public sealed record ClausulaDnf
 
         return Result<ClausulaDnf>.Success(new ClausulaDnf([.. condicoes]));
     }
+
+    /// <summary>
+    /// Avalia a cláusula (E lógico ternário, fail-closed — Story #916) contra os fatos já
+    /// resolvidos de um candidato: <see cref="Ternario.Falso"/> se qualquer condição avaliar
+    /// <see cref="Ternario.Falso"/> (vence sobre indeterminação); senão
+    /// <see cref="Ternario.Indeterminado"/> se qualquer uma avaliar indeterminada; senão
+    /// <see cref="Ternario.Verdadeiro"/>.
+    /// </summary>
+    public Ternario Avaliar(IReadOnlyDictionary<string, JsonElement> fatosResolvidos)
+    {
+        ArgumentNullException.ThrowIfNull(fatosResolvidos);
+
+        bool algumaIndeterminada = false;
+        foreach (CondicaoDnf condicao in Condicoes)
+        {
+            Ternario resultado = AvaliarCondicao(condicao, fatosResolvidos);
+            if (resultado == Ternario.Falso)
+            {
+                return Ternario.Falso;
+            }
+
+            if (resultado == Ternario.Indeterminado)
+            {
+                algumaIndeterminada = true;
+            }
+        }
+
+        return algumaIndeterminada ? Ternario.Indeterminado : Ternario.Verdadeiro;
+    }
+
+    /// <summary>
+    /// Avalia uma condição isolada. Um fato citado que não está resolvido — chave ausente de
+    /// <paramref name="fatosResolvidos"/>, ou presente com <see cref="JsonValueKind.Null"/>/
+    /// <see cref="JsonValueKind.Undefined"/> — nunca vira <see cref="Ternario.Falso"/>: é
+    /// sempre <see cref="Ternario.Indeterminado"/> (Story #916, fail-closed). O mesmo vale
+    /// para um valor resolvido de tipo incoerente com o operador (ex.: comparação numérica
+    /// sobre um valor que não é número) — nunca lança, sempre <see cref="Ternario.Indeterminado"/>.
+    /// <see cref="Operador.Diferente"/>/<see cref="Operador.NaoEm"/> são a negação lógica de
+    /// <see cref="Operador.Igual"/>/<see cref="Operador.Em"/> — a negação só se aplica quando o
+    /// fato está efetivamente resolvido e coerente; nunca inverte ausência/indeterminação para
+    /// <see cref="Ternario.Verdadeiro"/>.
+    /// </summary>
+    private static Ternario AvaliarCondicao(CondicaoDnf condicao, IReadOnlyDictionary<string, JsonElement> fatosResolvidos)
+    {
+        if (!fatosResolvidos.TryGetValue(condicao.Fato, out JsonElement valorCandidato)
+            || valorCandidato.ValueKind is JsonValueKind.Null or JsonValueKind.Undefined)
+        {
+            return Ternario.Indeterminado;
+        }
+
+        // Diferente/NaoEm são avaliados como a negação de Igual/Em: o resultado base é
+        // calculado sobre o operador positivo correspondente, e só invertido quando
+        // efetivamente resolvido (Ternario.Verdadeiro/Falso) — Indeterminado nunca inverte.
+        Operador operadorBase = condicao.Operador switch
+        {
+            Operador.Igual => Operador.Igual,
+            Operador.Em => Operador.Em,
+            Operador.MaiorIgual => Operador.MaiorIgual,
+            Operador.MenorIgual => Operador.MenorIgual,
+            Operador.Diferente => Operador.Igual,
+            Operador.NaoEm => Operador.Em,
+            Operador.Nenhuma => throw new ArgumentOutOfRangeException(
+                nameof(condicao), condicao.Operador, "Operador.Nenhuma é sentinela e não é avaliável."),
+            _ => throw new ArgumentOutOfRangeException(nameof(condicao), condicao.Operador, "Operador desconhecido."),
+        };
+
+        Ternario resultadoBase = AvaliarOperadorBase(operadorBase, valorCandidato, condicao.Valor);
+        bool negar = condicao.Operador is Operador.Diferente or Operador.NaoEm;
+        if (!negar || resultadoBase == Ternario.Indeterminado)
+        {
+            return resultadoBase;
+        }
+
+        return resultadoBase == Ternario.Verdadeiro ? Ternario.Falso : Ternario.Verdadeiro;
+    }
+
+    /// <summary>
+    /// Avalia os operadores positivos (<see cref="Operador.Igual"/>/<see cref="Operador.Em"/>/
+    /// <see cref="Operador.MaiorIgual"/>/<see cref="Operador.MenorIgual"/>) contra um valor
+    /// candidato já sabido resolvido (não nulo/ausente). <see cref="Operador.Diferente"/>/
+    /// <see cref="Operador.NaoEm"/> nunca chegam aqui — <see cref="AvaliarCondicao"/> já os
+    /// reduziu ao operador base correspondente.
+    /// </summary>
+    private static Ternario AvaliarOperadorBase(Operador operadorBase, JsonElement valorCandidato, JsonElement valorConfigurado)
+    {
+        // Story #554 (PR #896): fato multivalorado — o candidato resolve para um CONJUNTO
+        // (array JSON), não um escalar. A forma do valor resolvido decide a semântica, sem
+        // precisar de metadado extra aqui: IGUAL passa a significar pertinência do valor
+        // configurado no conjunto do candidato; EM passa a significar interseção não vazia
+        // entre o conjunto do candidato e a lista configurada (ADR-0111). Fatos escalares
+        // (a maioria) continuam pelo ramo original, sem NENHUMA mudança de comportamento.
+        if (valorCandidato.ValueKind == JsonValueKind.Array)
+        {
+            return operadorBase switch
+            {
+                Operador.Igual => BoolParaTernario(valorCandidato.EnumerateArray().Any(item => ValoresIguais(item, valorConfigurado))),
+                Operador.Em => BoolParaTernario(valorConfigurado.EnumerateArray()
+                    .Any(itemConfigurado => valorCandidato.EnumerateArray().Any(item => ValoresIguais(item, itemConfigurado)))),
+                _ => Ternario.Indeterminado,
+            };
+        }
+
+        return operadorBase switch
+        {
+            Operador.Igual => CompararIgualdade(valorCandidato, valorConfigurado),
+            Operador.Em => valorCandidato.ValueKind == JsonValueKind.String
+                ? BoolParaTernario(valorConfigurado.EnumerateArray().Any(item => ValoresIguais(valorCandidato, item)))
+                : Ternario.Indeterminado,
+            Operador.MaiorIgual => CompararNumerico(valorCandidato, valorConfigurado, static comparacao => comparacao >= 0),
+            Operador.MenorIgual => CompararNumerico(valorCandidato, valorConfigurado, static comparacao => comparacao <= 0),
+            _ => Ternario.Indeterminado,
+        };
+    }
+
+    /// <summary>
+    /// Igualdade escalar ternária: tipo (<see cref="JsonValueKind"/>) incoerente entre o valor
+    /// resolvido e o configurado é <see cref="Ternario.Indeterminado"/> (Story #916) — nunca
+    /// <see cref="Ternario.Falso"/> silencioso, que confundiria "resolvido diferente" com
+    /// "resolvido de tipo que este predicado não sabe comparar". <see cref="JsonValueKind.True"/>/
+    /// <see cref="JsonValueKind.False"/> são tratados como o MESMO tipo lógico (booleano) — são
+    /// kinds distintos no <c>System.Text.Json</c>, mas isso é a forma normal de um booleano
+    /// divergir, não uma incoerência de tipo.
+    /// </summary>
+    private static Ternario CompararIgualdade(JsonElement candidato, JsonElement configurado)
+    {
+        bool candidatoBooleano = candidato.ValueKind is JsonValueKind.True or JsonValueKind.False;
+        bool configuradoBooleano = configurado.ValueKind is JsonValueKind.True or JsonValueKind.False;
+        if (candidatoBooleano && configuradoBooleano)
+        {
+            return BoolParaTernario(candidato.GetBoolean() == configurado.GetBoolean());
+        }
+
+        if (candidato.ValueKind != configurado.ValueKind)
+        {
+            return Ternario.Indeterminado;
+        }
+
+        return candidato.ValueKind switch
+        {
+            JsonValueKind.String => BoolParaTernario(string.Equals(candidato.GetString(), configurado.GetString(), StringComparison.Ordinal)),
+            JsonValueKind.Number => BoolParaTernario(candidato.GetDecimal() == configurado.GetDecimal()),
+            _ => Ternario.Indeterminado,
+        };
+    }
+
+    private static bool ValoresIguais(JsonElement candidato, JsonElement configurado)
+    {
+        if (candidato.ValueKind != configurado.ValueKind)
+        {
+            return false;
+        }
+
+        return candidato.ValueKind switch
+        {
+            JsonValueKind.String => string.Equals(candidato.GetString(), configurado.GetString(), StringComparison.Ordinal),
+            JsonValueKind.Number => candidato.GetDecimal() == configurado.GetDecimal(),
+            JsonValueKind.True or JsonValueKind.False => candidato.GetBoolean() == configurado.GetBoolean(),
+            _ => false,
+        };
+    }
+
+    /// <summary>
+    /// Comparação numérica ternária: <see cref="Ternario.Indeterminado"/> (nunca lança) quando
+    /// o valor resolvido — ou, defensivamente, o configurado — não é um número JSON
+    /// representável como <see cref="decimal"/> (Story #916; antes, <c>GetDecimal()</c> direto
+    /// lançava <see cref="InvalidOperationException"/> para um valor não numérico).
+    /// </summary>
+    private static Ternario CompararNumerico(JsonElement candidato, JsonElement configurado, Func<int, bool> satisfaz)
+    {
+        if (candidato.ValueKind != JsonValueKind.Number || !candidato.TryGetDecimal(out decimal candidatoDecimal))
+        {
+            return Ternario.Indeterminado;
+        }
+
+        if (configurado.ValueKind != JsonValueKind.Number || !configurado.TryGetDecimal(out decimal configuradoDecimal))
+        {
+            return Ternario.Indeterminado;
+        }
+
+        return BoolParaTernario(satisfaz(candidatoDecimal.CompareTo(configuradoDecimal)));
+    }
+
+    private static Ternario BoolParaTernario(bool valor) => valor ? Ternario.Verdadeiro : Ternario.Falso;
 }

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Domain/ValueObjects/CondicaoDnf.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Domain/ValueObjects/CondicaoDnf.cs
@@ -15,12 +15,16 @@ using Unifesspa.UniPlus.Selecao.Domain.Enums;
 /// <remarks>
 /// <para>
 /// Validação de <b>forma</b>, sem I/O: <see cref="Fato"/> não vazio,
-/// <see cref="Operador"/> um dos quatro valores do domínio fechado (nunca o
+/// <see cref="Operador"/> um dos valores do domínio fechado (nunca o
 /// sentinela <see cref="Enums.Operador.Nenhuma"/>), e a forma de
-/// <see cref="Valor"/> coerente com o operador — <see cref="Enums.Operador.Em"/>
-/// exige array JSON não vazio; os demais exigem escalar (rejeitam array e
-/// objeto). A validação <b>semântica</b> (fato existe no vocabulário, operador
-/// compatível com o domínio do fato, valor pertence ao domínio) é
+/// <see cref="Valor"/> coerente com o operador — <see cref="Enums.Operador.Em"/> e
+/// <see cref="Enums.Operador.NaoEm"/> (Story #916) exigem array JSON, sem itens de
+/// texto em branco; array <b>vazio</b> é aceito na forma (a semântica de avaliar
+/// <c>EM []</c>/<c>NAO_EM []</c> é de <see cref="PredicadoDnf"/>, não desta factory). Os
+/// demais operadores (<see cref="Enums.Operador.Igual"/>, <see cref="Enums.Operador.Diferente"/>,
+/// <see cref="Enums.Operador.MaiorIgual"/>, <see cref="Enums.Operador.MenorIgual"/>) exigem
+/// escalar (rejeitam array e objeto). A validação <b>semântica</b> (fato existe no
+/// vocabulário, operador compatível com o domínio do fato, valor pertence ao domínio) é
 /// responsabilidade de <see cref="Services.PredicadoDnfValidador"/>, que
 /// recebe o vocabulário como dado — por isso vive separada desta factory.
 /// </para>
@@ -69,17 +73,18 @@ public sealed record CondicaoDnf
                 "CondicaoDnf.OperadorInvalido", "O operador da condição não é reconhecido."));
         }
 
-        bool formaCoerente = operador == Operador.Em
-            ? valor.ValueKind == JsonValueKind.Array && valor.GetArrayLength() > 0 && NenhumItemEmBranco(valor)
+        bool ehOperadorDeLista = operador is Operador.Em or Operador.NaoEm;
+        bool formaCoerente = ehOperadorDeLista
+            ? valor.ValueKind == JsonValueKind.Array && NenhumItemEmBranco(valor)
             : valor.ValueKind is not (JsonValueKind.Array or JsonValueKind.Object) && !EscalarEmBranco(valor);
 
         if (!formaCoerente)
         {
             return Result<CondicaoDnf>.Failure(new DomainError(
                 "CondicaoDnf.FormaIncoerenteComOperador",
-                operador == Operador.Em
-                    ? "O operador EM exige um array JSON não vazio, sem itens de texto em branco."
-                    : "Os operadores IGUAL, MAIOR_IGUAL e MENOR_IGUAL exigem um valor JSON escalar não branco."));
+                ehOperadorDeLista
+                    ? "Os operadores EM e NAO_EM exigem um array JSON, sem itens de texto em branco (array vazio é aceito)."
+                    : "Os operadores IGUAL, DIFERENTE, MAIOR_IGUAL e MENOR_IGUAL exigem um valor JSON escalar não branco."));
         }
 
         return Result<CondicaoDnf>.Success(new CondicaoDnf(fato.Trim(), operador, valor.Clone()));

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Domain/ValueObjects/PredicadoDnf.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Domain/ValueObjects/PredicadoDnf.cs
@@ -14,9 +14,10 @@ using Unifesspa.UniPlus.Selecao.Domain.Enums;
 /// </summary>
 /// <remarks>
 /// Zero cláusulas é um estado <b>estruturalmente válido</b> de construção —
-/// não é erro — mas <see cref="Avaliar"/> retorna <see langword="false"/>
+/// não é erro — mas <see cref="Avaliar"/> retorna <see cref="Ternario.Falso"/>
 /// para qualquer candidato nesse caso: um predicado sem cláusula nunca casa
-/// com ninguém.
+/// com ninguém (estado estrutural, não ausência de dado — não se confunde com
+/// <see cref="Ternario.Indeterminado"/>).
 /// </remarks>
 public sealed record PredicadoDnf
 {
@@ -59,71 +60,36 @@ public sealed record PredicadoDnf
     }
 
     /// <summary>
-    /// Avalia o predicado contra os fatos já resolvidos de um candidato:
-    /// OU sobre as cláusulas, E sobre as condições de cada cláusula. Um fato
-    /// citado numa condição que não está presente em
-    /// <paramref name="fatosResolvidos"/> (o processo não o coletou, ou o
-    /// motor ainda não o derivou) faz a condição avaliar como
-    /// <see langword="false"/> — conservador, nunca lança e nunca trata como
-    /// satisfeita. O restante do predicado continua avaliável normalmente.
+    /// Avalia o predicado contra os fatos já resolvidos de um candidato: OU ternário
+    /// (Story #916) sobre as cláusulas, cada uma um E ternário sobre as suas condições
+    /// (<see cref="ClausulaDnf.Avaliar"/>). <see cref="Ternario.Verdadeiro"/> se qualquer
+    /// cláusula for verdadeira; senão <see cref="Ternario.Indeterminado"/> se qualquer uma
+    /// for indeterminada; senão <see cref="Ternario.Falso"/>. Um fato citado numa condição
+    /// que não está presente em <paramref name="fatosResolvidos"/> (o processo não o
+    /// coletou, ou o motor ainda não o derivou) — ou está presente com valor nulo/de tipo
+    /// incoerente — nunca faz a condição avaliar como <see cref="Ternario.Falso"/>: é
+    /// <see cref="Ternario.Indeterminado"/>, fail-closed — nunca lança, e o restante do
+    /// predicado continua avaliável normalmente.
     /// </summary>
-    public bool Avaliar(IReadOnlyDictionary<string, JsonElement> fatosResolvidos)
+    public Ternario Avaliar(IReadOnlyDictionary<string, JsonElement> fatosResolvidos)
     {
         ArgumentNullException.ThrowIfNull(fatosResolvidos);
 
-        return Clausulas.Any(clausula => clausula.Condicoes.All(condicao => AvaliarCondicao(condicao, fatosResolvidos)));
-    }
-
-    private static bool AvaliarCondicao(CondicaoDnf condicao, IReadOnlyDictionary<string, JsonElement> fatosResolvidos)
-    {
-        if (!fatosResolvidos.TryGetValue(condicao.Fato, out JsonElement valorCandidato))
+        bool algumaIndeterminada = false;
+        foreach (ClausulaDnf clausula in Clausulas)
         {
-            return false;
-        }
-
-        // Story #554 (PR #896): fato multivalorado — o candidato resolve para um CONJUNTO
-        // (array JSON), não um escalar. A forma do valor resolvido decide a semântica, sem
-        // precisar de metadado extra aqui: IGUAL passa a significar pertinência do valor
-        // configurado no conjunto do candidato; EM passa a significar interseção não vazia
-        // entre o conjunto do candidato e a lista configurada (ADR-0111). Fatos escalares
-        // (a maioria) continuam pelo ramo original, sem NENHUMA mudança de comportamento.
-        if (valorCandidato.ValueKind == JsonValueKind.Array)
-        {
-            return condicao.Operador switch
+            Ternario resultado = clausula.Avaliar(fatosResolvidos);
+            if (resultado == Ternario.Verdadeiro)
             {
-                Operador.Igual => valorCandidato.EnumerateArray().Any(item => ValoresIguais(item, condicao.Valor)),
-                Operador.Em => condicao.Valor.EnumerateArray()
-                    .Any(itemConfigurado => valorCandidato.EnumerateArray().Any(item => ValoresIguais(item, itemConfigurado))),
-                _ => false,
-            };
+                return Ternario.Verdadeiro;
+            }
+
+            if (resultado == Ternario.Indeterminado)
+            {
+                algumaIndeterminada = true;
+            }
         }
 
-        return condicao.Operador switch
-        {
-            Operador.Igual => ValoresIguais(valorCandidato, condicao.Valor),
-            Operador.Em => condicao.Valor.EnumerateArray().Any(item => ValoresIguais(valorCandidato, item)),
-            Operador.MaiorIgual => CompararNumerico(valorCandidato, condicao.Valor) >= 0,
-            Operador.MenorIgual => CompararNumerico(valorCandidato, condicao.Valor) <= 0,
-            _ => false,
-        };
+        return algumaIndeterminada ? Ternario.Indeterminado : Ternario.Falso;
     }
-
-    private static bool ValoresIguais(JsonElement candidato, JsonElement configurado)
-    {
-        if (candidato.ValueKind != configurado.ValueKind)
-        {
-            return false;
-        }
-
-        return candidato.ValueKind switch
-        {
-            JsonValueKind.String => string.Equals(candidato.GetString(), configurado.GetString(), StringComparison.Ordinal),
-            JsonValueKind.Number => candidato.GetDecimal() == configurado.GetDecimal(),
-            JsonValueKind.True or JsonValueKind.False => candidato.GetBoolean() == configurado.GetBoolean(),
-            _ => false,
-        };
-    }
-
-    private static int CompararNumerico(JsonElement candidato, JsonElement configurado) =>
-        candidato.GetDecimal().CompareTo(configurado.GetDecimal());
 }

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Domain/ValueObjects/ResultadoResolucaoExigencias.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Domain/ValueObjects/ResultadoResolucaoExigencias.cs
@@ -7,7 +7,10 @@ using Enums;
 /// <see cref="Entities.DocumentoExigido"/> congelada, para um candidato (Story #554, PR #903).
 /// </summary>
 /// <param name="ExigenciaId">O <c>exigenciaId</c> congelado (<c>DocumentoExigido.Id</c>, CA-09) — a chave de correlação.</param>
-/// <param name="Status">Satisfeita, Pendente ou NaoAplicavel — nunca o sentinela <see cref="StatusResolucaoExigencia.Nenhuma"/>.</param>
+/// <param name="Status">
+/// Satisfeita, Pendente, NaoAplicavel ou AplicabilidadeIndeterminada (Story #916) — nunca o
+/// sentinela <see cref="StatusResolucaoExigencia.Nenhuma"/>.
+/// </param>
 /// <param name="ApresentacaoId">
 /// A apresentação que satisfaz a exigência, quando <see cref="Status"/> é
 /// <see cref="StatusResolucaoExigencia.Satisfeita"/> — a PRÓPRIA apresentação da exigência,

--- a/tests/Unifesspa.UniPlus.Selecao.Application.UnitTests/Commands/DefinirDocumentosExigidosCommandHandlerTests.cs
+++ b/tests/Unifesspa.UniPlus.Selecao.Application.UnitTests/Commands/DefinirDocumentosExigidosCommandHandlerTests.cs
@@ -63,6 +63,17 @@ public sealed class DefinirDocumentosExigidosCommandHandlerTests
         Guid.CreateVersion7(), "SEXO", "Sexo", null, "CATEGORICO", "DECLARADO", "ESCALAR",
         ["MASCULINO", "FEMININO", "INTERSEXO"], "INSCRICAO", "CAMPO_INSCRICAO:SEXO", null);
 
+    private static FatoCandidatoView FatoSexoComPontoResolucao(string pontoResolucao) => new(
+        Guid.CreateVersion7(), "SEXO", "Sexo", null, "CATEGORICO", "DECLARADO", "ESCALAR",
+        ["MASCULINO", "FEMININO", "INTERSEXO"], pontoResolucao, "CAMPO_INSCRICAO:SEXO", null);
+
+    private static FaseCronograma FaseComOrdemECodigo(int ordem, string codigo) => FaseCronograma.Criar(
+        ordem, Guid.CreateVersion7(), codigo, "CEPS", OrigemDataFase.Delegada,
+        agrupaEtapas: false, permiteComplementacao: false, produzResultado: false,
+        resultadoDefinitivo: false, coletaInscricao: false, inicio: null, fim: null,
+        atoProduzidoCodigo: null, atoProduzidoEfeitoIrreversivel: false,
+        bancasRequeridas: [], regraRecurso: null).Value!;
+
     private static FatoCandidatoView FatoModalidade() => new(
         Guid.CreateVersion7(), "MODALIDADE", "Modalidade", null, "CATEGORICO", "DECLARADO", "MULTIVALORADO", null,
         "INSCRICAO", "CAMPO_INSCRICAO:MODALIDADE", null);
@@ -360,5 +371,88 @@ public sealed class DefinirDocumentosExigidosCommandHandlerTests
 
         resultado.IsFailure.Should().BeTrue();
         resultado.Error!.Code.Should().Be("IdadeMaximaEmissao.FaseExtremoAusente");
+    }
+
+    // ── Story #916 — gate de fase ──
+
+    [Fact(DisplayName = "Gate de fase: condição sobre fato cujo PontoResolucao é uma fase POSTERIOR à da exigência é recusada")]
+    public async Task Handle_GatilhoFatoDeFasePosterior_RetornaErroNomeado()
+    {
+        ProcessoSeletivo processo = ProcessoSeletivo.Criar("PS Handler", TipoProcesso.SiSU, OrigemCandidatos.ImportacaoExterna);
+        FaseCronograma inscricao = FaseComOrdemECodigo(1, "INSCRICAO");
+        FaseCronograma homologacao = FaseComOrdemECodigo(2, "HOMOLOGACAO");
+        processo.DefinirCronogramaFases([inscricao, homologacao], [], PrecondicaoIfMatch.Ausente).IsSuccess.Should().BeTrue();
+
+        Mocks mocks = NovosMocks(processo, processo.Id);
+        Guid tipoDocumentoId = Guid.CreateVersion7();
+        mocks.TipoDocumentoReader.ObterPorIdAsync(tipoDocumentoId, Arg.Any<CancellationToken>())
+            .Returns(TipoDocumentoResultado(tipoDocumentoId));
+        // SEXO só é conhecido na fase HOMOLOGACAO (ordem 2), mas o documento é exigido na
+        // fase INSCRICAO (ordem 1) — anterior. O gatilho nunca teria como já ter sido
+        // resolvido para o candidato.
+        mocks.FatoCandidatoReader.ListarAsync(Arg.Any<CancellationToken>())
+            .Returns((IReadOnlyList<FatoCandidatoView>)[FatoSexoComPontoResolucao("HOMOLOGACAO")]);
+
+        CondicaoGatilhoInput condicao = new(0, "SEXO", "IGUAL", "\"MASCULINO\"");
+        ItemDocumentoExigidoInput item = new(inscricao.Id, tipoDocumentoId, "CONDICIONAL", true, null, null, [condicao], [], null, null, null);
+        DefinirDocumentosExigidosCommand command = new(processo.Id, [item], PrecondicaoIfMatch.Ausente);
+
+        Result<MutacaoAceita> resultado = await HandleAsync(mocks, command);
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be("DocumentoExigido.FatoResolvidoEmFasePosterior");
+    }
+
+    [Theory(DisplayName = "Gate de fase: condição sobre fato cujo PontoResolucao é a mesma fase ou uma fase ANTERIOR à da exigência é aceita")]
+    [InlineData("INSCRICAO")]
+    [InlineData("HOMOLOGACAO")]
+    public async Task Handle_GatilhoFatoDeFaseIgualOuAnterior_Aceita(string pontoResolucao)
+    {
+        ProcessoSeletivo processo = ProcessoSeletivo.Criar("PS Handler", TipoProcesso.SiSU, OrigemCandidatos.ImportacaoExterna);
+        FaseCronograma inscricao = FaseComOrdemECodigo(1, "INSCRICAO");
+        FaseCronograma homologacao = FaseComOrdemECodigo(2, "HOMOLOGACAO");
+        processo.DefinirCronogramaFases([inscricao, homologacao], [], PrecondicaoIfMatch.Ausente).IsSuccess.Should().BeTrue();
+
+        Mocks mocks = NovosMocks(processo, processo.Id);
+        Guid tipoDocumentoId = Guid.CreateVersion7();
+        mocks.TipoDocumentoReader.ObterPorIdAsync(tipoDocumentoId, Arg.Any<CancellationToken>())
+            .Returns(TipoDocumentoResultado(tipoDocumentoId));
+        mocks.FatoCandidatoReader.ListarAsync(Arg.Any<CancellationToken>())
+            .Returns((IReadOnlyList<FatoCandidatoView>)[FatoSexoComPontoResolucao(pontoResolucao)]);
+
+        // O documento é exigido na fase HOMOLOGACAO (ordem 2) — SEXO conhecido na própria
+        // fase ou numa fase anterior (INSCRICAO, ordem 1) satisfaz o gate.
+        CondicaoGatilhoInput condicao = new(0, "SEXO", "IGUAL", "\"MASCULINO\"");
+        ItemDocumentoExigidoInput item = new(homologacao.Id, tipoDocumentoId, "CONDICIONAL", true, null, null, [condicao], [], null, null, null);
+        DefinirDocumentosExigidosCommand command = new(processo.Id, [item], PrecondicaoIfMatch.Ausente);
+
+        Result<MutacaoAceita> resultado = await HandleAsync(mocks, command);
+
+        resultado.IsSuccess.Should().BeTrue(resultado.Error?.Message);
+    }
+
+    [Fact(DisplayName = "Gate de fase: PontoResolucao do fato citado não pertence ao cronograma deste processo é recusado")]
+    public async Task Handle_GatilhoComPontoResolucaoForaDoCronograma_RetornaErroNomeado()
+    {
+        ProcessoSeletivo processo = ProcessoSeletivo.Criar("PS Handler", TipoProcesso.SiSU, OrigemCandidatos.ImportacaoExterna);
+        FaseCronograma inscricao = FaseComOrdemECodigo(1, "INSCRICAO");
+        processo.DefinirCronogramaFases([inscricao], [], PrecondicaoIfMatch.Ausente).IsSuccess.Should().BeTrue();
+
+        Mocks mocks = NovosMocks(processo, processo.Id);
+        Guid tipoDocumentoId = Guid.CreateVersion7();
+        mocks.TipoDocumentoReader.ObterPorIdAsync(tipoDocumentoId, Arg.Any<CancellationToken>())
+            .Returns(TipoDocumentoResultado(tipoDocumentoId));
+        // SEXO resolve numa fase ("HOMOLOGACAO") que não existe no cronograma deste processo.
+        mocks.FatoCandidatoReader.ListarAsync(Arg.Any<CancellationToken>())
+            .Returns((IReadOnlyList<FatoCandidatoView>)[FatoSexoComPontoResolucao("HOMOLOGACAO")]);
+
+        CondicaoGatilhoInput condicao = new(0, "SEXO", "IGUAL", "\"MASCULINO\"");
+        ItemDocumentoExigidoInput item = new(inscricao.Id, tipoDocumentoId, "CONDICIONAL", true, null, null, [condicao], [], null, null, null);
+        DefinirDocumentosExigidosCommand command = new(processo.Id, [item], PrecondicaoIfMatch.Ausente);
+
+        Result<MutacaoAceita> resultado = await HandleAsync(mocks, command);
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be("DocumentoExigido.PontoResolucaoForaDoCronograma");
     }
 }

--- a/tests/Unifesspa.UniPlus.Selecao.Domain.UnitTests/Entities/CondicaoGatilhoTests.cs
+++ b/tests/Unifesspa.UniPlus.Selecao.Domain.UnitTests/Entities/CondicaoGatilhoTests.cs
@@ -47,13 +47,12 @@ public sealed class CondicaoGatilhoTests
         resultado.Error!.Code.Should().Be("CondicaoDnf.FatoObrigatorio");
     }
 
-    [Fact(DisplayName = "Criar propaga a falha de forma de CondicaoDnf (EM com array vazio)")]
-    public void Criar_OperadorEmComArrayVazio_PropagaErroDeCondicaoDnf()
+    [Fact(DisplayName = "Story #916: Criar aceita EM com array vazio — a forma passou a admitir lista vazia (semântica de avaliação é de PredicadoDnf, não desta factory)")]
+    public void Criar_OperadorEmComArrayVazio_Aceita()
     {
         Result<CondicaoGatilho> resultado = CondicaoGatilho.Criar(0, "MODALIDADE", Operador.Em, Json("[]"));
 
-        resultado.IsFailure.Should().BeTrue();
-        resultado.Error!.Code.Should().Be("CondicaoDnf.FormaIncoerenteComOperador");
+        resultado.IsSuccess.Should().BeTrue();
     }
 
     [Fact(DisplayName = "DocumentoExigidoId nasce vazio antes da vinculação ao pai")]

--- a/tests/Unifesspa.UniPlus.Selecao.Domain.UnitTests/Entities/DocumentoExigidoTests.cs
+++ b/tests/Unifesspa.UniPlus.Selecao.Domain.UnitTests/Entities/DocumentoExigidoTests.cs
@@ -166,4 +166,74 @@ public sealed class DocumentoExigidoTests
 
         exigencia.BasesLegaisResolvidas().Should().BeEmpty();
     }
+
+    // ── Story #916 — AplicavelPara ternário ──
+
+    private static CondicaoGatilho CondicaoDe(string fato, Operador operador, string valorJson)
+    {
+        using JsonDocument documento = JsonDocument.Parse(valorJson);
+        return CondicaoGatilho.Criar(0, fato, operador, documento.RootElement.Clone()).Value!;
+    }
+
+    [Fact(DisplayName = "AplicavelPara: GERAL é sempre Verdadeiro, gatilho nunca avaliado")]
+    public void AplicavelPara_Geral_SempreVerdadeiro()
+    {
+        DocumentoExigido exigencia = Exigencia(Aplicabilidade.Geral).Value!;
+
+        exigencia.AplicavelPara(new Dictionary<string, JsonElement>()).Should().Be(Ternario.Verdadeiro);
+    }
+
+    [Fact(DisplayName = "AplicavelPara: CONDICIONAL sem condição viva (zero cláusulas) é Falso — estrutural, não ausência de dado")]
+    public void AplicavelPara_CondicionalSemCondicoes_Falso()
+    {
+        DocumentoExigido exigencia = Exigencia(Aplicabilidade.Condicional).Value!;
+
+        exigencia.AplicavelPara(new Dictionary<string, JsonElement>()).Should().Be(Ternario.Falso);
+    }
+
+    [Fact(DisplayName = "AplicavelPara: CONDICIONAL cujo fato não está resolvido é Indeterminado, nunca Falso")]
+    public void AplicavelPara_CondicionalComFatoAusente_Indeterminado()
+    {
+        DocumentoExigido exigencia = Exigencia(
+            Aplicabilidade.Condicional, condicoes: [CondicaoDe("SEXO", Operador.Igual, "\"MASCULINO\"")]).Value!;
+
+        exigencia.AplicavelPara(new Dictionary<string, JsonElement>()).Should().Be(Ternario.Indeterminado);
+    }
+
+    [Fact(DisplayName = "AplicavelPara: CONDICIONAL com fato resolvido avalia normalmente (Verdadeiro/Falso)")]
+    public void AplicavelPara_CondicionalComFatoResolvido_AvaliaNormalmente()
+    {
+        DocumentoExigido exigencia = Exigencia(
+            Aplicabilidade.Condicional, condicoes: [CondicaoDe("SEXO", Operador.Igual, "\"MASCULINO\"")]).Value!;
+
+        Dictionary<string, JsonElement> fatos = new() { ["SEXO"] = JsonSerializer.SerializeToElement("MASCULINO") };
+        exigencia.AplicavelPara(fatos).Should().Be(Ternario.Verdadeiro);
+
+        Dictionary<string, JsonElement> fatosDivergentes = new() { ["SEXO"] = JsonSerializer.SerializeToElement("FEMININO") };
+        exigencia.AplicavelPara(fatosDivergentes).Should().Be(Ternario.Falso);
+    }
+
+    // ── Story #916 — PodeAlcancarModalidade com DIFERENTE/NAO_EM ──
+
+    [Fact(DisplayName = "PodeAlcancarModalidade: MODALIDADE DIFERENTE X alcança qualquer modalidade que não seja X")]
+    public void PodeAlcancarModalidade_Diferente_AlcancaModalidadeDivergente()
+    {
+        DocumentoExigido exigencia = Exigencia(
+            Aplicabilidade.Condicional, condicoes: [CondicaoDe("MODALIDADE", Operador.Diferente, "\"LB_PPI\"")]).Value!;
+
+        exigencia.PodeAlcancarModalidade("AC").Should().BeTrue();
+        exigencia.PodeAlcancarModalidade("LB_PPI").Should().BeFalse();
+    }
+
+    [Fact(DisplayName = "PodeAlcancarModalidade: MODALIDADE NAO_EM [...] alcança qualquer modalidade fora da lista")]
+    public void PodeAlcancarModalidade_NaoEm_AlcancaModalidadeForaDaLista()
+    {
+        DocumentoExigido exigencia = Exigencia(
+            Aplicabilidade.Condicional,
+            condicoes: [CondicaoDe("MODALIDADE", Operador.NaoEm, "[\"LB_PPI\",\"LB_Q\"]")]).Value!;
+
+        exigencia.PodeAlcancarModalidade("AC").Should().BeTrue();
+        exigencia.PodeAlcancarModalidade("LB_PPI").Should().BeFalse();
+        exigencia.PodeAlcancarModalidade("LB_Q").Should().BeFalse();
+    }
 }

--- a/tests/Unifesspa.UniPlus.Selecao.Domain.UnitTests/Services/AvaliadorConformidadeLegalTests.cs
+++ b/tests/Unifesspa.UniPlus.Selecao.Domain.UnitTests/Services/AvaliadorConformidadeLegalTests.cs
@@ -406,6 +406,27 @@ public sealed class AvaliadorConformidadeLegalTests
             "e a obrigação legal (\"a modalidade X DEVE exigir o documento Y\") não admite exceção");
     }
 
+    [Fact(DisplayName = "Story #916: exigência CONDICIONAL cujo gatilho é Indeterminado (fato extra não resolvido pelo fato sintético) não conta como cobertura incondicional — Indeterminado reprova, igual a Falso")]
+    public void DocumentoObrigatorioParaModalidade_ExigenciaComGatilhoIndeterminado_Reprova()
+    {
+        ProcessoSeletivo processo = NovoProcesso();
+        Guid faseId = PrepararProcessoComModalidade(processo, "LB_PPI");
+        // AvaliadorConformidadeLegal avalia contra um fato sintético só com MODALIDADE — o
+        // fato FAIXA_ETARIA (fatoExtra) nunca está presente, e por isso o gatilho avalia
+        // Ternario.Indeterminado (Story #916, fail-closed), não mais Ternario.Falso — a
+        // conclusão de cobertura, porém, é a mesma: não prova incondicionalidade.
+        processo.DefinirDocumentosExigidos(
+            [ExigenciaCondicionalPorModalidade(faseId, "COMPROVANTE_RESIDENCIA", "LB_PPI", fatoExtra: "FAIXA_ETARIA")],
+            PrecondicaoIfMatch.Curinga).IsSuccess.Should().BeTrue();
+        ObrigatoriedadeLegal regra = NovaRegra(
+            "DOCUMENTO", new DocumentoObrigatorioParaModalidade("LB_PPI", "COMPROVANTE_RESIDENCIA"));
+
+        ResultadoConformidade resultado = AvaliadorConformidadeLegal.Avaliar(processo, TipoProcessoAvaliado, [regra]);
+
+        resultado.Regras.Single().Aprovada.Should().BeFalse(
+            "Indeterminado conta como \"não provado\", mesma conclusão que Falso já dava — nenhuma mudança de comportamento observável");
+    }
+
     [Fact(DisplayName = "CA-09: exigência do TIPO ERRADO não conta, mesmo cobrindo a modalidade corretamente")]
     public void DocumentoObrigatorioParaModalidade_ExigenciaDeOutroTipo_Reprova()
     {

--- a/tests/Unifesspa.UniPlus.Selecao.Domain.UnitTests/Services/PredicadoDnfValidadorTests.cs
+++ b/tests/Unifesspa.UniPlus.Selecao.Domain.UnitTests/Services/PredicadoDnfValidadorTests.cs
@@ -246,4 +246,47 @@ public sealed class PredicadoDnfValidadorTests
         resultado.IsFailure.Should().BeTrue();
         resultado.Error!.Code.Should().Be("PredicadoDnf.OperadorIncompativelComDominio");
     }
+
+    // ── Story #916 — operadores de exclusão (DIFERENTE/NAO_EM) ──
+
+    [Theory(DisplayName = "DIFERENTE é aceito em todo domínio onde IGUAL já vale (booleano, numérico, categórico)")]
+    [InlineData("PCD", "false")]
+    [InlineData("FAIXA_ETARIA", "18")]
+    [InlineData("COR_RACA", "\"PARDA\"")]
+    public void PredicadoDnfValidador_Aceita_Diferente_EmTodoDominioDeIgual(string fato, string valorJson)
+    {
+        CondicaoDnf condicao = CondicaoDnf.Criar(fato, Operador.Diferente, Json(valorJson)).Value!;
+
+        Validar(condicao).IsSuccess.Should().BeTrue();
+    }
+
+    [Fact(DisplayName = "NAO_EM é aceito em categórico (onde EM já vale)")]
+    public void PredicadoDnfValidador_Aceita_NaoEm_Categorico()
+    {
+        CondicaoDnf condicao = CondicaoDnf.Criar("COR_RACA", Operador.NaoEm, Json("[\"PRETA\",\"PARDA\"]")).Value!;
+
+        Validar(condicao).IsSuccess.Should().BeTrue();
+    }
+
+    [Theory(DisplayName = "NAO_EM é recusado em booleano/numérico — a matriz só admite NAO_EM onde EM vale")]
+    [InlineData("PCD", "[true]")]
+    [InlineData("FAIXA_ETARIA", "[18,19]")]
+    public void PredicadoDnfValidador_Rejeita_NaoEm_BooleanoOuNumerico(string fato, string valorJson)
+    {
+        CondicaoDnf condicao = CondicaoDnf.Criar(fato, Operador.NaoEm, Json(valorJson)).Value!;
+
+        Result resultado = Validar(condicao);
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be("PredicadoDnf.OperadorIncompativelComDominio");
+    }
+
+    [Fact(DisplayName = "NAO_EM categórico dinâmico é aceito (mesma matriz do estático)")]
+    public void Validar_CategoricoDinamico_NaoEm_Aceita()
+    {
+        Dictionary<string, IReadOnlySet<string>> dominios = new() { ["MODALIDADE"] = new HashSet<string> { "LB_PPI", "AC" } };
+        CondicaoDnf condicao = CondicaoDnf.Criar("MODALIDADE", Operador.NaoEm, Json("[\"LB_PPI\"]")).Value!;
+
+        ValidarComDominioDinamico(condicao, dominios).IsSuccess.Should().BeTrue();
+    }
 }

--- a/tests/Unifesspa.UniPlus.Selecao.Domain.UnitTests/Services/ResolvedorExigenciasDocumentaisTests.cs
+++ b/tests/Unifesspa.UniPlus.Selecao.Domain.UnitTests/Services/ResolvedorExigenciasDocumentaisTests.cs
@@ -232,26 +232,47 @@ public sealed class ResolvedorExigenciasDocumentaisTests
         resultado.Exigencias.Should().AllSatisfy(e => e.Status.Should().Be(StatusResolucaoExigencia.Pendente));
     }
 
-    [Fact(DisplayName = "Grupo de satisfação: membro NÃO aplicável (CONDICIONAL sem casar) não é satisfeito pelo grupo, e não contamina os demais")]
-    public void Resolver_GrupoSatisfacaoComMembroNaoAplicavel_NaoInterfereNosDemais()
+    [Fact(DisplayName = "Story #916: grupo de satisfação com membro cujo fato não está resolvido fica AplicabilidadeIndeterminada (não mais NaoAplicavel) e não é satisfeito pelo grupo, nem contamina os demais")]
+    public void Resolver_GrupoSatisfacaoComMembroDeFatoNaoResolvido_AplicabilidadeIndeterminada()
     {
         Guid grupo = Guid.CreateVersion7();
         DocumentoExigido geral = Geral(FaseA, grupo);
-        CondicaoGatilho condicaoQueNaoCasa = CondicaoGatilho.Criar(
+        // Antes da Story #916, um fato ausente (SemFatos, abaixo) avaliava falso — o gatilho
+        // "não casava" e a exigência resolvia NaoAplicavel. Fail-closed: fato ausente agora é
+        // Indeterminado, nunca Falso — a exigência fica AplicabilidadeIndeterminada.
+        CondicaoGatilho condicaoDeFatoNaoResolvido = CondicaoGatilho.Criar(
             0, "CONDICAO_ATENDIMENTO", Operador.Igual, JsonSerializer.SerializeToElement("PCD")).Value!;
-        DocumentoExigido condicionalSemCasar = DocumentoExigido.Criar(
+        DocumentoExigido condicionalIndeterminada = DocumentoExigido.Criar(
             FaseA, Guid.CreateVersion7(), "LAUDO", "Laudo médico", "SAUDE", Aplicabilidade.Condicional,
             obrigatorio: true, consequenciaIndeferimento: null, grupo,
-            condicoes: [condicaoQueNaoCasa], basesLegais: [], idadeMaximaEmissao: null,
+            condicoes: [condicaoDeFatoNaoResolvido], basesLegais: [], idadeMaximaEmissao: null,
             formatoPermitido: null, tamanhoMaximoBytes: null).Value!;
-        BlocoExigenciasCongelado bloco = BlocoExigenciasCongelado.DeGrafoReidratado([geral, condicionalSemCasar]);
+        BlocoExigenciasCongelado bloco = BlocoExigenciasCongelado.DeGrafoReidratado([geral, condicionalIndeterminada]);
         Dictionary<Guid, ApresentacaoDocumento> apresentacoes = ApresentacaoPara(geral.Id);
 
         ResultadoResolucaoExigencias resultado = ResolvedorExigenciasDocumentais.Resolver(
             bloco, SemFatos, apresentacoes).Value!;
 
         resultado.Exigencias.Should().ContainSingle(e => e.ExigenciaId == geral.Id && e.Status == StatusResolucaoExigencia.Satisfeita);
-        resultado.Exigencias.Should().ContainSingle(e => e.ExigenciaId == condicionalSemCasar.Id && e.Status == StatusResolucaoExigencia.NaoAplicavel);
+        resultado.Exigencias.Should().ContainSingle(e => e.ExigenciaId == condicionalIndeterminada.Id && e.Status == StatusResolucaoExigencia.AplicabilidadeIndeterminada);
+    }
+
+    // ── Story #916 — AplicabilidadeIndeterminada ──
+
+    [Fact(DisplayName = "CONDICIONAL cujo fato não está resolvido resolve AplicabilidadeIndeterminada, mesmo com apresentação")]
+    public void Resolver_CondicionalComFatoNaoResolvido_AplicabilidadeIndeterminada()
+    {
+        DocumentoExigido exigencia = Condicional("CONDICAO_ATENDIMENTO", "PCD");
+        BlocoExigenciasCongelado bloco = BlocoExigenciasCongelado.DeGrafoReidratado([exigencia]);
+        Dictionary<Guid, ApresentacaoDocumento> apresentacoes = ApresentacaoPara(exigencia.Id);
+
+        ResultadoResolucaoExigencias resultado = ResolvedorExigenciasDocumentais.Resolver(
+            bloco, SemFatos, apresentacoes).Value!;
+
+        ExigenciaResolvida veredicto = resultado.Exigencias.Single();
+        veredicto.Status.Should().Be(StatusResolucaoExigencia.AplicabilidadeIndeterminada);
+        veredicto.ApresentacaoId.Should().BeNull(
+            "uma exigência de aplicabilidade desconhecida nunca vira Satisfeita só porque o candidato enviou algo");
     }
 
     // ── Contraprova geral ──

--- a/tests/Unifesspa.UniPlus.Selecao.Domain.UnitTests/ValueObjects/ClausulaDnfTests.cs
+++ b/tests/Unifesspa.UniPlus.Selecao.Domain.UnitTests/ValueObjects/ClausulaDnfTests.cs
@@ -40,4 +40,37 @@ public sealed class ClausulaDnfTests
         resultado.IsSuccess.Should().BeTrue();
         resultado.Value!.Condicoes.Should().HaveCount(2);
     }
+
+    // ── Story #916 — avaliação ternária (E lógico) ──
+
+    [Fact(DisplayName = "Avaliar: todas verdadeiras resolve Verdadeiro")]
+    public void Avaliar_TodasVerdadeiras_Verdadeiro()
+    {
+        ClausulaDnf clausula = ClausulaDnf.Criar([Condicao("PCD"), Condicao("QUILOMBOLA")]).Value!;
+        Dictionary<string, JsonElement> fatos = new()
+        {
+            ["PCD"] = JsonSerializer.SerializeToElement(true),
+            ["QUILOMBOLA"] = JsonSerializer.SerializeToElement(true),
+        };
+
+        clausula.Avaliar(fatos).Should().Be(Ternario.Verdadeiro);
+    }
+
+    [Fact(DisplayName = "Avaliar: uma condição Falso faz a cláusula inteira ser Falso, mesmo com outra Indeterminada")]
+    public void Avaliar_UmaFalsoVenceSobreIndeterminado()
+    {
+        ClausulaDnf clausula = ClausulaDnf.Criar([Condicao("PCD"), Condicao("FATO_AUSENTE")]).Value!;
+        Dictionary<string, JsonElement> fatos = new() { ["PCD"] = JsonSerializer.SerializeToElement(false) };
+
+        clausula.Avaliar(fatos).Should().Be(Ternario.Falso);
+    }
+
+    [Fact(DisplayName = "Avaliar: sem nenhuma Falso, uma Indeterminada faz a cláusula ser Indeterminada")]
+    public void Avaliar_SemFalso_IndeterminadoVence()
+    {
+        ClausulaDnf clausula = ClausulaDnf.Criar([Condicao("PCD"), Condicao("FATO_AUSENTE")]).Value!;
+        Dictionary<string, JsonElement> fatos = new() { ["PCD"] = JsonSerializer.SerializeToElement(true) };
+
+        clausula.Avaliar(fatos).Should().Be(Ternario.Indeterminado);
+    }
 }

--- a/tests/Unifesspa.UniPlus.Selecao.Domain.UnitTests/ValueObjects/CondicaoDnfTests.cs
+++ b/tests/Unifesspa.UniPlus.Selecao.Domain.UnitTests/ValueObjects/CondicaoDnfTests.cs
@@ -35,11 +35,13 @@ public sealed class CondicaoDnfTests
         resultado.Error!.Code.Should().Be("CondicaoDnf.OperadorInvalido");
     }
 
-    [Theory(DisplayName = "CondicaoDnf aceita as quatro variantes válidas de operador com valor coerente")]
+    [Theory(DisplayName = "CondicaoDnf aceita as seis variantes válidas de operador com valor coerente")]
     [InlineData(Operador.Igual, "true")]
     [InlineData(Operador.Em, "[\"BRANCA\"]")]
     [InlineData(Operador.MaiorIgual, "18")]
     [InlineData(Operador.MenorIgual, "60")]
+    [InlineData(Operador.Diferente, "true")]
+    [InlineData(Operador.NaoEm, "[\"BRANCA\"]")]
     public void CondicaoDnf_Aceita_Operadores_Validos(Operador operador, string valorJson)
     {
         Result<CondicaoDnf> resultado = CondicaoDnf.Criar("FATO", operador, Json(valorJson));
@@ -56,10 +58,37 @@ public sealed class CondicaoDnfTests
         resultado.Error!.Code.Should().Be("CondicaoDnf.FormaIncoerenteComOperador");
     }
 
-    [Fact(DisplayName = "CondicaoDnf_Em_Rejeita_Lista_Vazia")]
-    public void CondicaoDnf_Em_Rejeita_Lista_Vazia()
+    [Theory(DisplayName = "Story #916: EM/NAO_EM aceitam array vazio na FORMA — a semântica de avaliação é de PredicadoDnf, não desta factory")]
+    [InlineData(Operador.Em)]
+    [InlineData(Operador.NaoEm)]
+    public void CondicaoDnf_EmOuNaoEm_Aceita_Lista_Vazia(Operador operador)
     {
-        Result<CondicaoDnf> resultado = CondicaoDnf.Criar("COR_RACA", Operador.Em, Json("[]"));
+        Result<CondicaoDnf> resultado = CondicaoDnf.Criar("COR_RACA", operador, Json("[]"));
+
+        resultado.IsSuccess.Should().BeTrue();
+    }
+
+    [Fact(DisplayName = "Story #916: DIFERENTE aceita a mesma forma escalar de IGUAL")]
+    public void CondicaoDnf_Diferente_AceitaEscalar()
+    {
+        Result<CondicaoDnf> resultado = CondicaoDnf.Criar("SEXO", Operador.Diferente, Json("\"FEMININO\""));
+
+        resultado.IsSuccess.Should().BeTrue();
+    }
+
+    [Fact(DisplayName = "Story #916: DIFERENTE rejeita array, mesma checagem de forma escalar")]
+    public void CondicaoDnf_Diferente_RejeitaArray()
+    {
+        Result<CondicaoDnf> resultado = CondicaoDnf.Criar("SEXO", Operador.Diferente, Json("[\"FEMININO\"]"));
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be("CondicaoDnf.FormaIncoerenteComOperador");
+    }
+
+    [Fact(DisplayName = "Story #916: NAO_EM rejeita valor não lista, mesma checagem de EM")]
+    public void CondicaoDnf_NaoEm_RejeitaValorNaoLista()
+    {
+        Result<CondicaoDnf> resultado = CondicaoDnf.Criar("COR_RACA", Operador.NaoEm, Json("\"BRANCA\""));
 
         resultado.IsFailure.Should().BeTrue();
         resultado.Error!.Code.Should().Be("CondicaoDnf.FormaIncoerenteComOperador");
@@ -69,6 +98,7 @@ public sealed class CondicaoDnfTests
     [InlineData(Operador.Igual)]
     [InlineData(Operador.MaiorIgual)]
     [InlineData(Operador.MenorIgual)]
+    [InlineData(Operador.Diferente)]
     public void CondicaoDnf_Escalar_Rejeita_Lista(Operador operador)
     {
         Result<CondicaoDnf> resultado = CondicaoDnf.Criar("FATO", operador, Json("[1,2]"));

--- a/tests/Unifesspa.UniPlus.Selecao.Domain.UnitTests/ValueObjects/PredicadoDnfTests.cs
+++ b/tests/Unifesspa.UniPlus.Selecao.Domain.UnitTests/ValueObjects/PredicadoDnfTests.cs
@@ -8,7 +8,7 @@ using Unifesspa.UniPlus.Kernel.Results;
 using Unifesspa.UniPlus.Selecao.Domain.Enums;
 using Unifesspa.UniPlus.Selecao.Domain.ValueObjects;
 
-/// <summary>Cobre CA-01, CA-03 e CA-11 da Story #847 (ADR-0111).</summary>
+/// <summary>Cobre CA-01, CA-03 e CA-11 da Story #847 (ADR-0111) e a avaliação ternária da Story #916.</summary>
 public sealed class PredicadoDnfTests
 {
     private static CondicaoDnf Booleana(string fato, bool valor) =>
@@ -21,7 +21,8 @@ public sealed class PredicadoDnfTests
 
         resultado.IsSuccess.Should().BeTrue("zero cláusulas é um estado estruturalmente válido");
         resultado.Value!.Clausulas.Should().BeEmpty();
-        resultado.Value.Avaliar(new Dictionary<string, JsonElement>()).Should().BeFalse();
+        resultado.Value.Avaliar(new Dictionary<string, JsonElement>()).Should().Be(
+            Ternario.Falso, "zero cláusulas é estado estrutural — nunca casa com ninguém, não se confunde com indeterminação");
     }
 
     [Fact(DisplayName = "PredicadoDnf_CriarDeCondicoesAgrupadas_Ignora_Ordinais_Ausentes")]
@@ -56,7 +57,7 @@ public sealed class PredicadoDnfTests
             ["QUILOMBOLA"] = JsonSerializer.SerializeToElement(false),
             ["EGRESSO_ESCOLA_PUBLICA"] = JsonSerializer.SerializeToElement(false),
         };
-        predicado.Avaliar(soPcd).Should().BeFalse("a primeira cláusula exige AMBAS as condições");
+        predicado.Avaliar(soPcd).Should().Be(Ternario.Falso, "a primeira cláusula exige AMBAS as condições");
 
         Dictionary<string, JsonElement> soEgresso = new()
         {
@@ -64,11 +65,11 @@ public sealed class PredicadoDnfTests
             ["QUILOMBOLA"] = JsonSerializer.SerializeToElement(false),
             ["EGRESSO_ESCOLA_PUBLICA"] = JsonSerializer.SerializeToElement(true),
         };
-        predicado.Avaliar(soEgresso).Should().BeTrue("a segunda cláusula sozinha já satisfaz o OU");
+        predicado.Avaliar(soEgresso).Should().Be(Ternario.Verdadeiro, "a segunda cláusula sozinha já satisfaz o OU");
     }
 
-    [Fact(DisplayName = "PredicadoDnf_Avaliar_Fato_Nao_Resolvivel_E_Falso_Conservador")]
-    public void PredicadoDnf_Avaliar_Fato_Nao_Resolvivel_E_Falso_Conservador()
+    [Fact(DisplayName = "Story #916: fato não resolvível é Indeterminado (fail-closed) — nunca Falso, nunca lança")]
+    public void PredicadoDnf_Avaliar_Fato_Nao_Resolvivel_E_Indeterminado()
     {
         Result<PredicadoDnf> resultado = PredicadoDnf.CriarDeCondicoesAgrupadas([(1, Booleana("SEXO_DESCONHECIDO", true))]);
         PredicadoDnf predicado = resultado.Value!;
@@ -76,7 +77,7 @@ public sealed class PredicadoDnfTests
         Action avaliar = () => predicado.Avaliar(new Dictionary<string, JsonElement>());
 
         avaliar.Should().NotThrow();
-        predicado.Avaliar(new Dictionary<string, JsonElement>()).Should().BeFalse();
+        predicado.Avaliar(new Dictionary<string, JsonElement>()).Should().Be(Ternario.Indeterminado);
     }
 
     // ── Story #554 (PR #896, issue #892) — extensão dinâmica/multivalorada ──
@@ -101,7 +102,7 @@ public sealed class PredicadoDnfTests
             ["MODALIDADE"] = ArrayJson("LB_PPI", "AC"),
         };
 
-        predicado.Avaliar(fatos).Should().BeTrue("LB_PPI pertence ao conjunto [LB_PPI, AC] do candidato");
+        predicado.Avaliar(fatos).Should().Be(Ternario.Verdadeiro, "LB_PPI pertence ao conjunto [LB_PPI, AC] do candidato");
     }
 
     [Fact(DisplayName = "IGUAL em fato multivalorado sem o valor no conjunto é falso (contraprova)")]
@@ -115,7 +116,7 @@ public sealed class PredicadoDnfTests
             ["MODALIDADE"] = ArrayJson("LB_PPI", "AC"),
         };
 
-        predicado.Avaliar(fatos).Should().BeFalse();
+        predicado.Avaliar(fatos).Should().Be(Ternario.Falso);
     }
 
     [Fact(DisplayName = "EM em fato multivalorado é interseção — vazia resolve falso")]
@@ -129,7 +130,7 @@ public sealed class PredicadoDnfTests
             ["MODALIDADE"] = ArrayJson("AC"),
         };
 
-        predicado.Avaliar(fatos).Should().BeFalse("[AC] intersecta [LB_PPI, LB_Q] em vazio");
+        predicado.Avaliar(fatos).Should().Be(Ternario.Falso, "[AC] intersecta [LB_PPI, LB_Q] em vazio");
     }
 
     [Fact(DisplayName = "EM em fato multivalorado é interseção — não vazia resolve verdadeiro")]
@@ -143,7 +144,7 @@ public sealed class PredicadoDnfTests
             ["MODALIDADE"] = ArrayJson("AC", "LB_PPI"),
         };
 
-        predicado.Avaliar(fatos).Should().BeTrue("[AC, LB_PPI] intersecta [LB_PPI, LB_Q] em [LB_PPI], não vazio");
+        predicado.Avaliar(fatos).Should().Be(Ternario.Verdadeiro, "[AC, LB_PPI] intersecta [LB_PPI, LB_Q] em [LB_PPI], não vazio");
     }
 
     [Fact(DisplayName = "Avaliação escalar não regride com a extensão multivalorada")]
@@ -154,6 +155,175 @@ public sealed class PredicadoDnfTests
 
         Dictionary<string, JsonElement> fatos = new() { ["SEXO"] = StringJson("MASCULINO") };
 
-        predicado.Avaliar(fatos).Should().BeTrue("fato escalar (não-array) segue o ramo original, sem mudança de comportamento");
+        predicado.Avaliar(fatos).Should().Be(Ternario.Verdadeiro, "fato escalar (não-array) segue o ramo original, sem mudança de comportamento");
+    }
+
+    // ── Story #916 — operadores de exclusão (DIFERENTE/NAO_EM) e tabela-verdade ternária ──
+
+    private static PredicadoDnf Predicado(params (int Clausula, CondicaoDnf Condicao)[] linhas) =>
+        PredicadoDnf.CriarDeCondicoesAgrupadas(linhas).Value!;
+
+    private static Dictionary<string, JsonElement> Fatos(string chave, JsonElement valor) =>
+        new() { [chave] = valor };
+
+    [Theory(DisplayName = "DIFERENTE escalar: nega IGUAL quando o fato está resolvido")]
+    [InlineData("FEMININO", Ternario.Verdadeiro)]
+    [InlineData("MASCULINO", Ternario.Falso)]
+    public void Diferente_Escalar_NegaIgualQuandoResolvido(string valorCandidato, Ternario esperado)
+    {
+        PredicadoDnf predicado = Predicado((1, Categorica("SEXO", Operador.Diferente, StringJson("MASCULINO"))));
+
+        predicado.Avaliar(Fatos("SEXO", StringJson(valorCandidato))).Should().Be(esperado);
+    }
+
+    [Fact(DisplayName = "DIFERENTE nunca inverte ausência para Verdadeiro — fato ausente é Indeterminado")]
+    public void Diferente_FatoAusente_Indeterminado()
+    {
+        PredicadoDnf predicado = Predicado((1, Categorica("SEXO", Operador.Diferente, StringJson("MASCULINO"))));
+
+        predicado.Avaliar(new Dictionary<string, JsonElement>()).Should().Be(Ternario.Indeterminado);
+    }
+
+    [Theory(DisplayName = "NAO_EM categórico: nega EM quando o fato está resolvido")]
+    [InlineData("PARDA", Ternario.Verdadeiro)]
+    [InlineData("PRETA", Ternario.Falso)]
+    public void NaoEm_Categorico_NegaEmQuandoResolvido(string valorCandidato, Ternario esperado)
+    {
+        PredicadoDnf predicado = Predicado(
+            (1, Categorica("COR_RACA", Operador.NaoEm, ArrayJson("PRETA"))));
+
+        predicado.Avaliar(Fatos("COR_RACA", StringJson(valorCandidato))).Should().Be(esperado);
+    }
+
+    [Fact(DisplayName = "NAO_EM nunca inverte ausência para Verdadeiro — fato ausente é Indeterminado")]
+    public void NaoEm_FatoAusente_Indeterminado()
+    {
+        PredicadoDnf predicado = Predicado((1, Categorica("COR_RACA", Operador.NaoEm, ArrayJson("PRETA"))));
+
+        predicado.Avaliar(new Dictionary<string, JsonElement>()).Should().Be(Ternario.Indeterminado);
+    }
+
+    [Fact(DisplayName = "EM [] com fato resolvido é Falso (interseção vazia)")]
+    public void Em_ListaVazia_ComFatoResolvido_Falso()
+    {
+        PredicadoDnf predicado = Predicado((1, Categorica("COR_RACA", Operador.Em, ArrayJson())));
+
+        predicado.Avaliar(Fatos("COR_RACA", StringJson("PARDA"))).Should().Be(Ternario.Falso);
+    }
+
+    [Fact(DisplayName = "NAO_EM [] com fato resolvido é Verdadeiro (não pertence ao vazio)")]
+    public void NaoEm_ListaVazia_ComFatoResolvido_Verdadeiro()
+    {
+        PredicadoDnf predicado = Predicado((1, Categorica("COR_RACA", Operador.NaoEm, ArrayJson())));
+
+        predicado.Avaliar(Fatos("COR_RACA", StringJson("PARDA"))).Should().Be(Ternario.Verdadeiro);
+    }
+
+    [Fact(DisplayName = "EM []/NAO_EM [] com fato ausente continuam Indeterminado — a ausência tem precedência sobre a semântica de lista vazia")]
+    public void EmOuNaoEmListaVazia_ComFatoAusente_Indeterminado()
+    {
+        PredicadoDnf emVazio = Predicado((1, Categorica("COR_RACA", Operador.Em, ArrayJson())));
+        PredicadoDnf naoEmVazio = Predicado((1, Categorica("COR_RACA", Operador.NaoEm, ArrayJson())));
+
+        emVazio.Avaliar(new Dictionary<string, JsonElement>()).Should().Be(Ternario.Indeterminado);
+        naoEmVazio.Avaliar(new Dictionary<string, JsonElement>()).Should().Be(Ternario.Indeterminado);
+    }
+
+    [Fact(DisplayName = "Fato presente porém null é Indeterminado, não Falso")]
+    public void Avaliar_FatoNulo_Indeterminado()
+    {
+        PredicadoDnf predicado = Predicado((1, Booleana("PCD", true)));
+        using JsonDocument nulo = JsonDocument.Parse("null");
+
+        predicado.Avaliar(Fatos("PCD", nulo.RootElement.Clone())).Should().Be(Ternario.Indeterminado);
+    }
+
+    [Fact(DisplayName = "Comparação numérica sobre valor de tipo incoerente é Indeterminado, nunca lança")]
+    public void Avaliar_ComparacaoNumericaComValorIncoerente_IndeterminadoSemLancar()
+    {
+        PredicadoDnf predicado = Predicado(
+            (1, Categorica("FAIXA_ETARIA", Operador.MaiorIgual, JsonSerializer.SerializeToElement(18))));
+
+        Action avaliar = () => predicado.Avaliar(Fatos("FAIXA_ETARIA", StringJson("NAO_NUMERICO")));
+
+        avaliar.Should().NotThrow();
+        predicado.Avaliar(Fatos("FAIXA_ETARIA", StringJson("NAO_NUMERICO"))).Should().Be(Ternario.Indeterminado);
+    }
+
+    [Fact(DisplayName = "IGUAL escalar com tipo de fato incoerente com o valor configurado é Indeterminado, não Falso")]
+    public void Avaliar_IgualComTipoIncoerente_Indeterminado()
+    {
+        PredicadoDnf predicado = Predicado((1, Booleana("PCD", true)));
+
+        predicado.Avaliar(Fatos("PCD", StringJson("SIM"))).Should().Be(Ternario.Indeterminado);
+    }
+
+    [Fact(DisplayName = "Propagação E: Falso vence sobre Indeterminado na mesma cláusula")]
+    public void ClausulaAvaliar_FalsoVenceSobreIndeterminado()
+    {
+        PredicadoDnf predicado = Predicado(
+            (1, Booleana("PCD", true)),
+            (1, Booleana("FATO_AUSENTE", true)));
+
+        // PCD=false (Falso) E FATO_AUSENTE (Indeterminado) -> Falso vence.
+        predicado.Avaliar(Fatos("PCD", JsonSerializer.SerializeToElement(false))).Should().Be(Ternario.Falso);
+    }
+
+    [Fact(DisplayName = "Propagação E: Indeterminado vence quando nenhuma condição é Falso")]
+    public void ClausulaAvaliar_IndeterminadoVenceSemFalso()
+    {
+        PredicadoDnf predicado = Predicado(
+            (1, Booleana("PCD", true)),
+            (1, Booleana("FATO_AUSENTE", true)));
+
+        Dictionary<string, JsonElement> fatos = new() { ["PCD"] = JsonSerializer.SerializeToElement(true) };
+
+        // PCD=true (Verdadeiro) E FATO_AUSENTE (Indeterminado) -> Indeterminado.
+        predicado.Avaliar(fatos).Should().Be(Ternario.Indeterminado);
+    }
+
+    [Fact(DisplayName = "Propagação OU: Verdadeiro vence sobre qualquer outra cláusula")]
+    public void PredicadoAvaliar_VerdadeiroVenceSobreIndeterminadoEFalso()
+    {
+        PredicadoDnf predicado = Predicado(
+            (1, Booleana("EGRESSO_ESCOLA_PUBLICA", true)),
+            (2, Booleana("FATO_AUSENTE", true)),
+            (3, Booleana("QUILOMBOLA", true)));
+
+        Dictionary<string, JsonElement> fatos = new()
+        {
+            ["EGRESSO_ESCOLA_PUBLICA"] = JsonSerializer.SerializeToElement(true),
+            ["QUILOMBOLA"] = JsonSerializer.SerializeToElement(false),
+        };
+
+        predicado.Avaliar(fatos).Should().Be(Ternario.Verdadeiro);
+    }
+
+    [Fact(DisplayName = "Propagação OU: Indeterminado vence sobre Falso quando nenhuma cláusula é Verdadeira")]
+    public void PredicadoAvaliar_IndeterminadoVenceSobreFalsoSemVerdadeiro()
+    {
+        PredicadoDnf predicado = Predicado(
+            (1, Booleana("QUILOMBOLA", true)),
+            (2, Booleana("FATO_AUSENTE", true)));
+
+        Dictionary<string, JsonElement> fatos = new() { ["QUILOMBOLA"] = JsonSerializer.SerializeToElement(false) };
+
+        predicado.Avaliar(fatos).Should().Be(Ternario.Indeterminado);
+    }
+
+    [Fact(DisplayName = "Propagação OU: Falso só quando TODAS as cláusulas são Falso (nenhuma indeterminada, nenhuma verdadeira)")]
+    public void PredicadoAvaliar_FalsoQuandoTodasAsClausulasSaoFalso()
+    {
+        PredicadoDnf predicado = Predicado(
+            (1, Booleana("QUILOMBOLA", true)),
+            (2, Booleana("PCD", true)));
+
+        Dictionary<string, JsonElement> fatos = new()
+        {
+            ["QUILOMBOLA"] = JsonSerializer.SerializeToElement(false),
+            ["PCD"] = JsonSerializer.SerializeToElement(false),
+        };
+
+        predicado.Avaliar(fatos).Should().Be(Ternario.Falso);
     }
 }


### PR DESCRIPTION
## Resumo

(Feature #914) — implementa a Story #916. Depende da PR (#917/#930, mergeada — introduziu `FatoCandidato.PontoResolucao`).

- **Operadores de exclusão**: `DIFERENTE`/`NAO_EM` somam-se ao vocabulário fechado de `Operador`. Matriz operador×domínio (`PredicadoDnfValidador`): `DIFERENTE` vale onde `IGUAL` já vale (booleano/numérico/categórico); `NAO_EM` vale onde `EM` já vale (só categórico — nunca valeu para booleano/numérico).
- **Avaliação ternária fail-closed**: `PredicadoDnf`/`ClausulaDnf`/`DocumentoExigido.AplicavelPara` passam de `bool` para `Ternario { Indeterminado = 0, Verdadeiro, Falso }`. Um fato ausente, `null` ou de tipo incoerente com o operador nunca vira `Falso` — fica `Indeterminado`, e a exigência correspondente ganha o novo status `AplicabilidadeIndeterminada` (nunca é descartada silenciosamente).
- **Gate de fase**: `DefinirDocumentosExigidosCommandHandler` recusa uma condição de gatilho cujo fato só é conhecido (`PontoResolucao`) numa fase posterior à fase da exigência — comparando a `Ordem` das duas fases no cronograma do próprio processo.
- `DocumentoExigido.PodeAlcancarModalidade` (gate estrutural CA-05) ganhou os mesmos 2 operadores em seu interpretador próprio — não compartilha código com o avaliador do predicado.
- `AvaliadorConformidadeLegal` preserva exatamente o comportamento já documentado (só `Verdadeiro` prova cobertura incondicional de uma modalidade), adaptado ao novo tipo sem mudança de resultado.

## Por quê

O modelo anterior tratava "fato ausente" como `false`, fazendo uma exigência condicional desaparecer silenciosamente quando o dado ainda não existia — fail-open. A Story #916 fecha essa lacuna com lógica de três valores: ausência de dado nunca é confundida com "não se aplica".

## Escopo fora desta PR

- `formatosPermitidos[]` — Story #918 (PR3).
- Congelamento RN08 / shape final de OpenAPI do contrato `documentos-exigidos` — Story #919 (PR4).
- Postman (task 1.7 da change) — não incluído nesta PR.
- Revalidação simétrica do gate de fase quando `DefinirCronogramaFases` reordena fases depois de documentos já cadastrados — limitação conhecida e documentada (nenhum cenário de aceite da Story cobre isso); o congelamento RN08 da Story #919 é o ponto natural que fixaria o estado final de qualquer forma.

## Decisões de design

- `Ternario.Indeterminado = 0` (não `Verdadeiro`) — o zero-default de um enum C# tem que ser o estado fail-closed, nunca o mais permissivo.
- `EM []`/`NAO_EM []` passam a ser aceitos na forma (antes `CondicaoDnf.Criar` rejeitava array vazio) — a spec desta change exige `EM []`→`Falso`/`NAO_EM []`→`Verdadeiro` como cenários válidos, o que refina a invariante "lista de EM nunca vazia" da ADR-0111 só para este par de operadores.
- `PontoResolucao` por fato **não** entra em `DescritorFatoCandidato` (VO mínimo compartilhado com `DefinirCriteriosDesempateCommandHandler`) — vive numa projeção própria do handler de documentos, para não obrigar o desempate a carregar um dado que não usa.
- Uma exigência `AplicabilidadeIndeterminada` nunca conta como cobertura de grupo de satisfação nem é resolvida por uma apresentação já enviada — é resolvida fato-a-fato, independentemente do grupo.

## Teste

- `dotnet build UniPlus.slnx` — 0 erros/0 warnings.
- `dotnet test UniPlus.slnx` — suíte completa (24 assemblies) verde.
- Tabela-verdade ternária completa testada (fato resolvido × cada operador, ausência/null/tipo incoerente, `EM []`/`NAO_EM []`, propagação E/OU).
- Regressão: `AvaliadorConformidadeLegalTests`/`ResolvedorExigenciasDocumentaisTests` (consumidores já existentes da migração bool→Ternario) sem nenhuma mudança de resultado nos testes pré-existentes.
- Gate de fase: condição sobre fato de `PontoResolucao` posterior à fase da exigência é recusada; sobre fato de fase igual/anterior é aceita; fato de `PontoResolucao` fora do cronograma do processo é recusado.

Refs #914
Closes #916