### PR TITLE
chore(smoke): adiciona fase INSCRICAO à coleção Postman de Seleção

### DIFF
--- a/src/selecao/Unifesspa.UniPlus.Selecao.API/postman/README.md
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.API/postman/README.md
@@ -82,11 +82,27 @@ aceitável para smoke, não para ambiente compartilhado sem rotina de limpeza.
 
 ## Achados de execução
 
-Executada de ponta a ponta contra o stack local (2026-07-17). **56/56 requests
-passam, 58/58 assertions** — todo o Setup, as 9 dimensões de `Definir*`
-(incluindo o cenário-alvo e2e da task 7.3), toda a Leitura e o ciclo completo de
-Publicação/Retificação/Sessão editorial. Reprodutível: rodada duas vezes
-seguidas contra o mesmo banco compartilhado, sem falhas em nenhuma.
+Executada de ponta a ponta contra o stack local (2026-07-19, pós-merge da
+change `documentos-exigidos-cobertura-editais`, Feature #914). **59/59
+requests passam, 61/61 assertions** — todo o Setup, as 9 dimensões de
+`Definir*` (incluindo o cenário-alvo e2e da task 7.3, os operadores de
+exclusão, `formatosPermitidos[]` e o congelamento RN08 de metadado de fato),
+toda a Leitura e o ciclo completo de Publicação/Retificação/Sessão editorial.
+Reprodutível: rodada duas vezes seguidas contra o mesmo banco compartilhado,
+sem falhas em nenhuma.
+
+### Achado real corrigido — gate de fase exige a fase INSCRICAO no cronograma (issue #934)
+
+O gate de fase introduzido na Story #916 (PR #931) recusava **todas** as
+condições de gatilho existentes com `DocumentoExigido.PontoResolucaoForaDoCronograma`.
+Causa: o cronograma de fases da coleção sempre teve só a fase `AVALIACAO`, mas
+todo fato do vocabulário (Story #917) tem `PontoResolucao = "INSCRICAO"` — sem
+uma fase `INSCRICAO` no cronograma, o gate (corretamente) recusa qualquer
+condição que os referencie. **Não é bug de produção** — o gate está
+funcionando como projetado (RN08/fail-closed); nenhum edital real teria
+cronograma sem fase de inscrição. Corrigido acrescentando uma `FaseCanonica`/
+`FaseCronograma` de código `INSCRICAO` (ordem 1, anterior à `AVALIACAO`) ao
+Setup e ao cronograma da coleção.
 
 ### Cenário-alvo e2e da task 7.3 — 4 sub-casos de gatilho DNF + bordas
 

--- a/src/selecao/Unifesspa.UniPlus.Selecao.API/postman/selecao.postman_collection.json
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.API/postman/selecao.postman_collection.json
@@ -1160,6 +1160,120 @@
               }
             }
           ]
+        },
+        {
+          "name": "Criar Fase Canônica (INSCRICAO)",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Idempotency-Key",
+                "value": "{{$guid}}",
+                "type": "text"
+              },
+              {
+                "key": "Content-Type",
+                "value": "application/json",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{base_url}}/api/configuracao/admin/fases-canonicas",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "configuracao",
+                "admin",
+                "fases-canonicas"
+              ]
+            },
+            "auth": {
+              "type": "bearer",
+              "bearer": [
+                {
+                  "key": "token",
+                  "value": "{{token}}",
+                  "type": "string"
+                }
+              ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"codigo\": \"INSCRICAO\",\n  \"nome\": \"Inscrição (smoke)\",\n  \"descricao\": null,\n  \"donoTipico\": \"CEPS\",\n  \"agrupaEtapas\": false,\n  \"permiteComplementacao\": false,\n  \"baseLegal\": null,\n  \"produzResultado\": false,\n  \"resultadoDefinitivo\": false,\n  \"coletaInscricao\": false,\n  \"origemData\": \"PROPRIA\"\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            }
+          },
+          "response": [],
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('201 Created ou 409 (código canônico único)', () => {",
+                  "  pm.expect([201, 409]).to.include(pm.response.code);",
+                  "  if (pm.response.code === 201) {",
+                  "    pm.environment.set('fase_canonica_inscricao_id', pm.response.json());",
+                  "  }",
+                  "});"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "Obter Fase Canônica por código (INSCRICAO, fallback se já existia)",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{base_url}}/api/configuracao/fases-canonicas",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "configuracao",
+                "fases-canonicas"
+              ]
+            },
+            "auth": {
+              "type": "bearer",
+              "bearer": [
+                {
+                  "key": "token",
+                  "value": "{{token}}",
+                  "type": "string"
+                }
+              ]
+            }
+          },
+          "response": [],
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('200 e resolve fase_canonica_inscricao_id se ainda vazio', () => {",
+                  "  pm.response.to.have.status(200);",
+                  "  if (!pm.environment.get('fase_canonica_inscricao_id')) {",
+                  "    const arr = pm.response.json();",
+                  "    const achada = (arr.items || arr).find(f => f.codigo === 'INSCRICAO');",
+                  "    pm.expect(achada, 'INSCRICAO deve existir').to.not.be.undefined;",
+                  "    pm.environment.set('fase_canonica_inscricao_id', achada.id);",
+                  "  }",
+                  "});"
+                ]
+              }
+            }
+          ]
         }
       ],
       "description": "Árvore mínima Campus→LocalOferta→Curso→OfertaCurso + Modalidade + TipoDocumento + FaseCanonica exigida pelas dimensões de ProcessoSeletivo. Nenhum destes recursos é pré-seedado (exceto o catálogo interno rol_de_regras, referenciado só por código)."
@@ -1524,7 +1638,7 @@
             },
             "body": {
               "mode": "raw",
-              "raw": "[\n  {\n    \"ordem\": 1,\n    \"faseCanonicaId\": \"{{fase_canonica_id}}\",\n    \"inicio\": \"2026-01-01T00:00:00Z\",\n    \"fim\": \"2026-01-31T00:00:00Z\",\n    \"atoProduzidoCodigo\": \"RESULTADO_FINAL\",\n    \"tiposBancaIds\": [],\n    \"regraRecurso\": null\n  }\n]",
+              "raw": "[\n  {\n    \"ordem\": 1,\n    \"faseCanonicaId\": \"{{fase_canonica_inscricao_id}}\",\n    \"inicio\": \"2025-12-01T00:00:00Z\",\n    \"fim\": \"2025-12-31T00:00:00Z\",\n    \"atoProduzidoCodigo\": null,\n    \"tiposBancaIds\": [],\n    \"regraRecurso\": null\n  },\n  {\n    \"ordem\": 2,\n    \"faseCanonicaId\": \"{{fase_canonica_id}}\",\n    \"inicio\": \"2026-01-01T00:00:00Z\",\n    \"fim\": \"2026-01-31T00:00:00Z\",\n    \"atoProduzidoCodigo\": \"RESULTADO_FINAL\",\n    \"tiposBancaIds\": [],\n    \"regraRecurso\": null\n  }\n]",
               "options": {
                 "raw": {
                   "language": "json"
@@ -1586,11 +1700,13 @@
               "script": {
                 "type": "text/javascript",
                 "exec": [
-                  "pm.test('200 com cronogramaFases[0].id', () => {",
+                  "pm.test('200 com cronogramaFases (INSCRICAO + AVALIACAO), captura a de AVALIACAO', () => {",
                   "  pm.response.to.have.status(200);",
                   "  const j = pm.response.json();",
-                  "  pm.expect(j.cronogramaFases).to.have.lengthOf(1);",
-                  "  pm.environment.set('fase_cronograma_id', j.cronogramaFases[0].id);",
+                  "  pm.expect(j.cronogramaFases).to.have.lengthOf(2);",
+                  "  const avaliacao = j.cronogramaFases.find(f => f.codigo === 'AVALIACAO');",
+                  "  pm.expect(avaliacao, 'fase AVALIACAO deve estar no cronograma').to.not.be.undefined;",
+                  "  pm.environment.set('fase_cronograma_id', avaliacao.id);",
                   "});"
                 ]
               }


### PR DESCRIPTION
## Resumo

Validação pós-merge da change `documentos-exigidos-cobertura-editais` (Feature #914): rodei a coleção Postman de Seleção de ponta a ponta contra o stack Docker (Newman) pela primeira vez desde as 4 PRs mergeadas.

Achado: o gate de fase (Story #916/#931) recusava **todas** as condições de gatilho existentes com `DocumentoExigido.PontoResolucaoForaDoCronograma` — o cronograma da coleção só tinha a fase `AVALIACAO`, mas todo fato do vocabulário (Story #917/#930) resolve em `INSCRICAO`. **Não é bug de produção** — o gate está funcionando como projetado (RN08/fail-closed); é lacuna da fixture (nenhum edital real teria cronograma sem fase de inscrição).

## O que muda

- Nova `FaseCanonica`/`FaseCronograma` `INSCRICAO` (ordem 1, anterior à `AVALIACAO`) no Setup e no cronograma da coleção.
- Teste de captura de `fase_cronograma_id` ajustado para 2 fases (busca por `codigo === 'AVALIACAO'`, não mais índice `[0]`).
- README documenta o achado, seguindo o padrão já usado para os demais "achados de execução"/"bugs reais corrigidos" do arquivo.

## Teste

Rodada 2x seguidas contra o stack Docker completo (Newman): **59/59 requests, 61/61 assertions**, 0 falhas em ambas.

Closes #934