### PR TITLE
fix(selecao): resolve 500 ao substituir árvore de exigência com grupo E/OU

### DIFF
--- a/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/Persistence/Configurations/NoExigenciaConfiguration.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/Persistence/Configurations/NoExigenciaConfiguration.cs
@@ -114,17 +114,19 @@ public sealed class NoExigenciaConfiguration : IEntityTypeConfiguration<NoExigen
             .HasDatabaseName("ux_nos_exigencia_documento_exigido_id");
 
         // Sem colisão de posição entre irmãos (NoPaiId IS NOT NULL) nem entre raízes do
-        // mesmo processo (NoPaiId IS NULL) — dois índices filtrados porque NULL do Postgres
-        // já é distinto por padrão (a 2ª condição não precisa de AreNullsDistinct).
-        builder.HasIndex(n => new { n.NoPaiId, n.Ordem })
-            .IsUnique()
-            .HasFilter("no_pai_id IS NOT NULL")
-            .HasDatabaseName("ux_nos_exigencia_irmaos_ordem");
-
-        builder.HasIndex(n => new { n.ProcessoSeletivoId, n.Ordem })
-            .IsUnique()
-            .HasFilter("no_pai_id IS NULL")
-            .HasDatabaseName("ux_nos_exigencia_raiz_ordem");
+        // mesmo processo (NoPaiId IS NULL) — de propósito AUSENTES daqui como
+        // HasIndex().IsUnique(): são EXCLUDE constraints GiST DEFERRABLE INITIALLY DEFERRED
+        // (ex_nos_exigencia_irmaos_ordem/ex_nos_exigencia_raiz_ordem), criadas via SQL cru na
+        // migration — mesmo padrão de ex_tipo_ato_publicado_codigo_vigencia
+        // (TipoAtoPublicadoConfiguration.cs), que o Fluent API do EF Core não modela. Um
+        // índice único comum é verificado por-statement; como nos_exigencia é
+        // auto-referenciada (NoPaiId → Id, Restrict), substituir uma árvore com grupo E/OU
+        // faz o EF Core apagar bottom-up (netos → raiz) mas inserir a raiz NOVA antes da
+        // antiga sair do banco — a ordem Added-antes-Deleted do SaveChangesAsync não conhece
+        // este índice alternativo, e um índice não-deferível recusaria a raiz nova com a
+        // MESMA ordem da antiga, mesmo a transação terminando num estado válido (issue #943).
+        // Deferir a checagem para o COMMIT resolve sem separar a exclusão do outbox
+        // transacional (ADR-0004/0005) em duas chamadas a SaveChangesAsync.
 
         // Base legal 1:N PRÓPRIA de grupo OU/N-de com consequência (Story #920) — substituível
         // por inteiro junto com o próprio nó, mesmo padrão de DocumentoExigido.BasesLegais.

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/Persistence/Migrations/20260720143930_DeferConstraintsOrdemArvoreExigencia.Designer.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/Persistence/Migrations/20260720143930_DeferConstraintsOrdemArvoreExigencia.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Unifesspa.UniPlus.Selecao.Infrastructure.Persistence;
@@ -11,9 +12,11 @@ using Unifesspa.UniPlus.Selecao.Infrastructure.Persistence;
 namespace Unifesspa.UniPlus.Selecao.Infrastructure.Persistence.Migrations
 {
     [DbContext(typeof(SelecaoDbContext))]
-    partial class SelecaoDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260720143930_DeferConstraintsOrdemArvoreExigencia")]
+    partial class DeferConstraintsOrdemArvoreExigencia
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/Persistence/Migrations/20260720143930_DeferConstraintsOrdemArvoreExigencia.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/Persistence/Migrations/20260720143930_DeferConstraintsOrdemArvoreExigencia.cs
@@ -1,0 +1,116 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Unifesspa.UniPlus.Selecao.Infrastructure.Persistence.Migrations
+{
+    /// <inheritdoc />
+    public partial class DeferConstraintsOrdemArvoreExigencia : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "ux_nos_exigencia_irmaos_ordem",
+                schema: "selecao",
+                table: "nos_exigencia");
+
+            migrationBuilder.DropIndex(
+                name: "ux_nos_exigencia_raiz_ordem",
+                schema: "selecao",
+                table: "nos_exigencia");
+
+            migrationBuilder.CreateIndex(
+                name: "ix_nos_exigencia_no_pai_id",
+                schema: "selecao",
+                table: "nos_exigencia",
+                column: "no_pai_id");
+
+            migrationBuilder.CreateIndex(
+                name: "ix_nos_exigencia_processo_seletivo_id",
+                schema: "selecao",
+                table: "nos_exigencia",
+                column: "processo_seletivo_id");
+
+            // Pré-requisito das exclusion constraints abaixo: sem btree_gist o operador `=`
+            // de uuid/int não tem classe GIST. `nos_exigencia` já compartilha o mesmo banco
+            // físico do schema `publicacoes` (só schemas isolam os módulos, não bancos —
+            // ver 20260710021244_AddTipoAtoPublicado, que já criou a extensão), mas
+            // `IF NOT EXISTS` mantém esta migration autossuficiente mesmo rodando isolada
+            // (ex.: containers efêmeros de teste de integração que só aplicam o DbContext
+            // de Selecao).
+            migrationBuilder.Sql("CREATE EXTENSION IF NOT EXISTS btree_gist;");
+
+            // Substituem os dois índices únicos filtrados dropados acima (issue #943): um
+            // índice único comum é verificado por-statement, e nos_exigencia é
+            // auto-referenciada (no_pai_id → id, Restrict) — substituir uma árvore com grupo
+            // E/OU faz o EF Core apagar bottom-up (netos → raiz) mas inserir a raiz NOVA
+            // antes da antiga sair do banco, dentro do mesmo SaveChangesAsync. A ordem
+            // Added-antes-Deleted do EF Core não conhece este índice alternativo, e a
+            // checagem imediata do índice comum recusava a raiz nova com a MESMA ordem da
+            // antiga — mesmo a transação terminando num estado final válido. DEFERRABLE
+            // INITIALLY DEFERRED adia a checagem para o COMMIT, quando a exclusão já se
+            // efetivou. Mesmo padrão de ex_tipo_ato_publicado_codigo_vigencia
+            // (TipoAtoPublicadoConfiguration.cs) — EXCLUDE com predicado parcial não é
+            // modelável pelo Fluent API do EF Core, então vive só aqui e no
+            // ModelSnapshot (não em NoExigenciaConfiguration.cs).
+            migrationBuilder.Sql(
+                """
+                ALTER TABLE selecao.nos_exigencia
+                ADD CONSTRAINT ex_nos_exigencia_irmaos_ordem
+                EXCLUDE USING gist (
+                    no_pai_id WITH =,
+                    ordem WITH =
+                ) WHERE (no_pai_id IS NOT NULL)
+                DEFERRABLE INITIALLY DEFERRED;
+                """);
+
+            migrationBuilder.Sql(
+                """
+                ALTER TABLE selecao.nos_exigencia
+                ADD CONSTRAINT ex_nos_exigencia_raiz_ordem
+                EXCLUDE USING gist (
+                    processo_seletivo_id WITH =,
+                    ordem WITH =
+                ) WHERE (no_pai_id IS NULL)
+                DEFERRABLE INITIALLY DEFERRED;
+                """);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.Sql(
+                "ALTER TABLE selecao.nos_exigencia DROP CONSTRAINT ex_nos_exigencia_irmaos_ordem;");
+
+            migrationBuilder.Sql(
+                "ALTER TABLE selecao.nos_exigencia DROP CONSTRAINT ex_nos_exigencia_raiz_ordem;");
+
+            migrationBuilder.DropIndex(
+                name: "ix_nos_exigencia_no_pai_id",
+                schema: "selecao",
+                table: "nos_exigencia");
+
+            migrationBuilder.DropIndex(
+                name: "ix_nos_exigencia_processo_seletivo_id",
+                schema: "selecao",
+                table: "nos_exigencia");
+
+            migrationBuilder.CreateIndex(
+                name: "ux_nos_exigencia_irmaos_ordem",
+                schema: "selecao",
+                table: "nos_exigencia",
+                columns: new[] { "no_pai_id", "ordem" },
+                unique: true,
+                filter: "no_pai_id IS NOT NULL");
+
+            migrationBuilder.CreateIndex(
+                name: "ux_nos_exigencia_raiz_ordem",
+                schema: "selecao",
+                table: "nos_exigencia",
+                columns: new[] { "processo_seletivo_id", "ordem" },
+                unique: true,
+                filter: "no_pai_id IS NULL");
+        }
+    }
+}

--- a/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/ProcessosSeletivos/NoExigenciaPersistenciaTests.cs
+++ b/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/ProcessosSeletivos/NoExigenciaPersistenciaTests.cs
@@ -2,6 +2,10 @@ namespace Unifesspa.UniPlus.Selecao.IntegrationTests.ProcessosSeletivos;
 
 using AwesomeAssertions;
 
+using Microsoft.EntityFrameworkCore;
+
+using Npgsql;
+
 using Unifesspa.UniPlus.Kernel.Results;
 using Unifesspa.UniPlus.Selecao.Domain.Entities;
 using Unifesspa.UniPlus.Selecao.Domain.Enums;
@@ -97,5 +101,96 @@ public sealed class NoExigenciaPersistenciaTests : IClassFixture<ProcessoSeletiv
         // incoerente, sem exigência CONDICIONAL vazia, sem gatilho por FAIXA_ETARIA).
         DomainError? pendencia = recarregado.PendenciaPreCanonicalizacao();
         pendencia.Should().BeNull(pendencia?.Message);
+    }
+
+    /// <summary>
+    /// Issue #943: <c>nos_exigencia</c> é auto-referenciada (<c>no_pai_id → id</c>, Restrict) —
+    /// substituir uma árvore que já tem um grupo E/OU por outra (ou pela mesma, de novo) faz o
+    /// EF Core apagar bottom-up (netos → raiz) mas inserir a raiz NOVA antes da antiga sair do
+    /// banco, dentro do mesmo <c>SaveChangesAsync</c>. Um índice único comum era verificado
+    /// por-statement e recusava a raiz nova com a MESMA ordem da antiga — mesmo a transação
+    /// terminando num estado final válido. A correção troca os dois índices únicos filtrados
+    /// (<c>ux_nos_exigencia_raiz_ordem</c>/<c>ux_nos_exigencia_irmaos_ordem</c>) por exclusion
+    /// constraints GiST <c>DEFERRABLE INITIALLY DEFERRED</c> (mesmo padrão de
+    /// <c>ex_tipo_ato_publicado_codigo_vigencia</c>), que só checam no <c>COMMIT</c>.
+    /// </summary>
+    [Fact(DisplayName = "Issue #943: substituir uma árvore com grupo E/OU por outra, várias vezes seguidas na mesma sessão, não falha com 500")]
+    public async Task SubstituiArvoreComGrupo_PorOutrasArvores_MultiplasVezesSeguidas()
+    {
+        ProcessoSeletivo processo = ProcessoSeletivo.Criar("PS Substituição de árvore", TipoProcesso.SiSU, OrigemCandidatos.ImportacaoExterna);
+        FaseCronograma fase = FaseCronograma.Criar(
+            1, Guid.CreateVersion7(), "INSCRICAO", "CEPS", OrigemDataFase.Delegada,
+            agrupaEtapas: false, permiteComplementacao: false, produzResultado: false,
+            resultadoDefinitivo: false, coletaInscricao: false, inicio: null, fim: null,
+            atoProduzidoCodigo: null, atoProduzidoEfeitoIrreversivel: false,
+            bancasRequeridas: [], regraRecurso: null).Value!;
+        processo.DefinirCronogramaFases([fase], [], PrecondicaoIfMatch.Ausente).IsSuccess.Should().BeTrue();
+
+        await using SelecaoDbContext context = _fixture.CreateDbContext();
+        ProcessoSeletivoRepository repository = new(context, TimeProvider.System);
+        await repository.AdicionarAsync(processo, CancellationToken.None);
+        await context.SaveChangesAsync(CancellationToken.None);
+
+        // Três substituições seguidas na MESMA sessão de DbContext — a raiz de cada árvore usa
+        // Ordem 0, a mesma da raiz anterior, exatamente o cenário que colide com o índice
+        // não-deferível. A 1ª chamada não tem nada para colidir (árvore vazia -> com grupo);
+        // são a 2ª e a 3ª que exercitam a substituição de uma árvore-com-grupo por outra.
+        for (int tentativa = 1; tentativa <= 3; tentativa++)
+        {
+            NoExigencia grupoE = NoExigencia.CriarGrupo(
+                TipoNo.GrupoE, 0, null, null, [],
+                [NoExigencia.CriarFolha(Documento(fase.Id), 0).Value!, NoExigencia.CriarFolha(Documento(fase.Id), 1).Value!]).Value!;
+
+            Result definirResult = processo.DefinirDocumentosExigidos([grupoE], PrecondicaoIfMatch.Curinga);
+            definirResult.IsSuccess.Should().BeTrue(definirResult.Error?.Message);
+
+            Func<Task> salvar = async () => await context.SaveChangesAsync(CancellationToken.None);
+            await salvar.Should().NotThrowAsync(
+                $"tentativa {tentativa}: substituir uma árvore com grupo E/OU por outra não pode falhar com " +
+                "violação de índice único transitória (issue #943)");
+        }
+
+        processo.RaizesDeExigencia.Should().ContainSingle().Which.Tipo.Should().Be(TipoNo.GrupoE);
+    }
+
+    /// <summary>
+    /// As duas exclusion constraints vivem em SQL cru, fora do <c>ModelSnapshot</c> (mesmo
+    /// padrão de <c>ex_tipo_ato_publicado_codigo_vigencia</c>,
+    /// <c>TipoAtoPublicadoPersistenceTests.ExclusionConstraint_ExisteNoCatalogo</c>): um
+    /// squash de migrations as descartaria em silêncio, e o teste de substituição acima
+    /// continuaria passando contra um Testcontainer criado do zero — só voltaria a falhar em
+    /// produção, contra um banco com histórico de migrations real. Esta asserção olha o
+    /// catálogo do Postgres diretamente: <c>contype = 'x'</c> (EXCLUDE) e
+    /// <c>condeferrable AND condeferred</c> (a checagem só no COMMIT é o que resolve a
+    /// issue #943 — sem isso, seria só um EXCLUDE normal, tão imediato quanto o índice
+    /// único que substituiu).
+    /// </summary>
+    [Theory(DisplayName = "As exclusion constraints de ordem existem no catálogo, como EXCLUDE deferível")]
+    [InlineData("ex_nos_exigencia_raiz_ordem")]
+    [InlineData("ex_nos_exigencia_irmaos_ordem")]
+    public async Task ExclusionConstraintsDeOrdem_ExistemNoCatalogo_ComoDeferiveis(string nomeDaConstraint)
+    {
+        await using SelecaoDbContext context = _fixture.CreateDbContext();
+        await context.Database.OpenConnectionAsync();
+
+        await using NpgsqlCommand command = new(
+            """
+            SELECT contype::text, condeferrable, condeferred
+            FROM pg_constraint c
+            JOIN pg_class t ON t.oid = c.conrelid
+            JOIN pg_namespace n ON n.oid = t.relnamespace
+            WHERE n.nspname = 'selecao'
+              AND t.relname = 'nos_exigencia'
+              AND c.conname = @nome
+            """,
+            (NpgsqlConnection)context.Database.GetDbConnection());
+        command.Parameters.AddWithValue("nome", nomeDaConstraint);
+
+        await using NpgsqlDataReader reader = await command.ExecuteReaderAsync();
+        (await reader.ReadAsync()).Should().BeTrue($"a constraint '{nomeDaConstraint}' deveria existir no catálogo");
+
+        reader.GetString(0).Should().Be("x", "'x' é o contype de EXCLUDE no pg_constraint");
+        reader.GetBoolean(1).Should().BeTrue("a checagem deferível é o que evita a colisão transitória da issue #943");
+        reader.GetBoolean(2).Should().BeTrue("INITIALLY DEFERRED — checada só no COMMIT, não a cada statement");
     }
 }


### PR DESCRIPTION
## Contexto

`PUT /api/selecao/processos-seletivos/{id}/documentos-exigidos` respondia **500** (`ux_nos_exigencia_raiz_ordem` duplicate key) ao substituir uma árvore de satisfação que já continha um grupo `E`/`OU` por qualquer outra — reproduzido de forma consistente durante a Task #942 (matriz Postman dos padrões estruturais, PR #944), bloqueador para a edição de qualquer configuração não-trivial via retificação.

Closes #943

## Causa raiz

`nos_exigencia` é auto-referenciada (`no_pai_id → id`, `OnDelete(DeleteBehavior.Restrict)`). Substituir uma árvore com grupo faz o EF Core apagar bottom-up (netos → raiz) mas inserir a raiz NOVA antes da antiga sair do banco, dentro do mesmo `SaveChangesAsync` — a ordem Added-antes-Deleted do EF Core não conhece o índice único alternativo `(processo_seletivo_id, ordem)`, e a checagem imediata desse índice recusava a raiz nova com a mesma ordem da antiga, mesmo a transação terminando num estado final válido.

## Correção

Substitui os dois índices únicos filtrados (`ux_nos_exigencia_raiz_ordem`/`ux_nos_exigencia_irmaos_ordem`) por **exclusion constraints GiST `DEFERRABLE INITIALLY DEFERRED`**, que só checam no `COMMIT` — mesmo padrão já usado em `ex_tipo_ato_publicado_codigo_vigencia` (módulo Publicações) para o mesmo problema de constraint parcial não modelável pelo Fluent API do EF Core.

**Plano de correção revisado com o Codex CLI antes da implementação** (comparando 3 alternativas: constraint deferível / duas chamadas a `SaveChangesAsync` com detach-reattach / reordenação manual do `ChangeTracker`) — confirmou a causa raiz, recomendou a constraint deferível citando o precedente de Publicações, e apontou que `RestaurarConfiguracaoCongelada` usa o mesmo padrão de persistência e também se beneficia da correção.

## Validação

- Teste de integração (`SubstituiArvoreComGrupo_PorOutrasArvores_MultiplasVezesSeguidas`) reproduzindo 3 substituições seguidas de uma árvore com grupo — confirmado que falha na 2ª tentativa **sem** a correção (revertida manualmente, reproduzido o erro original) e passa **com** a correção.
- Teste de catálogo (`ExclusionConstraintsDeOrdem_ExistemNoCatalogo_ComoDeferiveis`) confirmando que as duas exclusion constraints existem no `pg_constraint` como deferíveis — sem isso, um squash de migrations as descartaria em silêncio.
- Suíte completa (`dotnet test UniPlus.slnx`) verde, incluindo ArchTests.
- Reproduzido o cenário exato do bug contra o stack docker local (3 PUTs seguidos com grupo E/OU, todos 204) e rodada completa da coleção Postman (104/104 requests verdes).

## Test plan

- [x] `dotnet build UniPlus.slnx` limpo
- [x] `dotnet test UniPlus.slnx` verde (todos os módulos)
- [x] Teste de integração reproduz e prova a correção do bug original
- [x] Teste de catálogo confirma a constraint deferível sobrevive a squash de migrations
- [x] Migration `Up`/`Down` testadas (aplicada contra o stack docker local, container rebuildado)
- [x] Newman contra o stack local, 104/104 requests verdes