### PR TITLE
refactor(selecao): registra aviso de bootstrap via LoggerMessage

### DIFF
--- a/src/selecao/Unifesspa.UniPlus.Selecao.API/SelecaoMessagingRegistration.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.API/SelecaoMessagingRegistration.cs
@@ -19,6 +19,7 @@ using Wolverine.Kafka;
 using Wolverine.Kafka.Serialization;
 using Wolverine.Postgresql;
 
+using ILogger = Microsoft.Extensions.Logging.ILogger;
 using ProcessoPublicadoAvro = unifesspa.uniplus.selecao.events.ProcessoPublicado;
 
 /// <summary>
@@ -37,7 +38,7 @@ using ProcessoPublicadoAvro = unifesspa.uniplus.selecao.events.ProcessoPublicado
     "Design",
     "CA1515:Consider making public types internal",
     Justification = "Referenciado pelo composition root (host do monólito modular) fora deste assembly.")]
-public static class SelecaoMessagingRegistration
+public static partial class SelecaoMessagingRegistration
 {
     /// <summary>
     /// Registra o Schema Registry do módulo (cliente + schema Avro
@@ -146,14 +147,7 @@ public static class SelecaoMessagingRegistration
             using ILoggerFactory missingSrLoggerFactory = LoggerFactory.Create(static b => b.AddSerilog());
             Microsoft.Extensions.Logging.ILogger missingSrLogger =
                 missingSrLoggerFactory.CreateLogger("Selecao.Messaging.Bootstrap");
-#pragma warning disable CA1848 // Bootstrap logging — fora do hot path; LoggerMessage source generator overkill aqui.
-#pragma warning disable CA2254 // Mensagem fixa após format de string interpolada — sem placeholders dinâmicos.
-            missingSrLogger.LogWarning(
-                "Kafka habilitado sem Schema Registry em ambiente {Env} — publishing Avro cross-módulo desligado. "
-                + "Esperado em test factory que isola cascading puro; sinal de bug em ambiente produtivo (ADR-0051).",
-                environment.EnvironmentName);
-#pragma warning restore CA2254
-#pragma warning restore CA1848
+            LogKafkaSemSchemaRegistry(missingSrLogger, environment.EnvironmentName);
         }
 
         if (string.IsNullOrWhiteSpace(srSettings.Url))
@@ -169,4 +163,9 @@ public static class SelecaoMessagingRegistration
         services.AddSingleton(srClient);
         return srClient;
     }
+
+    [LoggerMessage(
+        Level = LogLevel.Warning,
+        Message = "Kafka habilitado sem Schema Registry em ambiente {Env} — publishing Avro cross-módulo desligado. Esperado em test factory que isola cascading puro; sinal de bug em ambiente produtivo (ADR-0051).")]
+    private static partial void LogKafkaSemSchemaRegistry(ILogger logger, string env);
 }


### PR DESCRIPTION
## Resumo

* Refatora o registro de logging de bootstrap em `SelecaoMessagingRegistration` para utilizar o padrão `[LoggerMessage]`.
* Remove supressões de analisadores (`CA1848` e `CA2254`), alinhando a implementação às diretrizes do projeto.
* Resolve a ambiguidade entre `Microsoft.Extensions.Logging.ILogger` e `Serilog.ILogger` por meio de alias, preservando a compatibilidade com `AddSerilog()`.

## Mudanças

### Novos arquivos

* Nenhum.

### Modificados

* `src/selecao/Unifesspa.UniPlus.Selecao.API/SelecaoMessagingRegistration.cs`

  * Tornada a classe `static partial` para suportar a geração de código via `[LoggerMessage]`.
  * Substituída a chamada direta a `LogWarning(...)` por um método parcial gerado em tempo de compilação utilizando `[LoggerMessage]`.
  * Adicionado o método `LogKafkaSemSchemaRegistry`, preservando o nível `Warning`, a mensagem e o placeholder estruturado `{Env}`.
  * Removidos os quatro `#pragma warning disable/restore` referentes aos diagnósticos `CA1848` e `CA2254`.
  * Adicionado alias para `Microsoft.Extensions.Logging.ILogger`, eliminando a ambiguidade com `Serilog.ILogger`.
 
## Testes

- [x] Testes unitários passando
- [x] Testes de integração passando (se aplicável)
- [x] Testes E2E passando (se aplicável)

## Checklist

- [x] Build sem erros e sem warnings
- [x] Código segue Clean Architecture e SOLID
- [x] Sem exposição de PII (CPF, renda, dados sensíveis)
- [x] Strings user-facing em pt-BR
- [x] Soft delete utilizado (sem DELETE físico)
- [x] Documentação atualizada (se aplicável)