### PR TITLE
refactor(observability): alinha campo static readonly do CorrelationIdAccessor à convenção PascalCase

### DIFF
--- a/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Middleware/CorrelationIdAccessor.cs
+++ b/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Middleware/CorrelationIdAccessor.cs
@@ -6,13 +6,13 @@ public sealed class CorrelationIdAccessor : ICorrelationIdWriter
     // não da instância do accessor. Permite registro Singleton no DI sem risco
     // de cross-talk entre requests — cada request roda em seu próprio fluxo
     // lógico e o AsyncLocal.Value é copiado/restaurado automaticamente.
-    private static readonly AsyncLocal<string?> _current = new();
+    private static readonly AsyncLocal<string?> Current = new();
 
-    public string? CorrelationId => _current.Value;
+    public string? CorrelationId => Current.Value;
 
     public void SetCorrelationId(string correlationId)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(correlationId);
-        _current.Value = correlationId;
+        Current.Value = correlationId;
     }
 }


### PR DESCRIPTION
## Resumo

Rename mecânico de 1 campo `private static readonly` para PascalCase em `CorrelationIdAccessor.cs`, alinhando ao `.editorconfig` (regra `IDE1006` / `static_readonly_should_be_pascal_case`).

Nenhuma mudança de comportamento. Nenhuma assinatura pública alterada.

## Contexto

É o caso **inverso** e último remanescente do que a issue #948 mapeou: lá, campos de instância usavam `_camelCase` faltando o prefixo; aqui, um campo `static readonly` usa `_camelCase` quando deveria ser PascalCase sem prefixo. Ficou fora do escopo da #948 por pertencer a um arquivo diferente (`Middleware/`, não `Messaging/SchemaRegistry/`) e ser a regra oposta.

Busquei `private static readonly.*_[a-zA-Z]` em todo `src/` e `tests/` — era a **única** ocorrência do repositório.

## Mudança

```diff
-    private static readonly AsyncLocal<string?> _current = new();
+    private static readonly AsyncLocal<string?> Current = new();

-    public string? CorrelationId => _current.Value;
+    public string? CorrelationId => Current.Value;

         ArgumentException.ThrowIfNullOrWhiteSpace(correlationId);
-        _current.Value = correlationId;
+        Current.Value = correlationId;
```

Sem colisão com a propriedade `CorrelationId` (símbolo distinto) nem com outro membro do arquivo.

## Validação executada

```
dotnet build UniPlus.slnx                                    → 56 projetos, 0 erros, 0 avisos
dotnet restore UniPlus.slnx --locked-mode                    → OK (mesmo modo do CI)
dotnet test tests/Unifesspa.UniPlus.Infrastructure.Core.UnitTests → 604 testes verdes
dotnet test UniPlus.slnx --filter "Category!=Integration"    → todos os projetos verdes
dotnet format --verify-no-changes | grep -c IDE1006           → 0 (era 2 — zera o repositório inteiro)
```

## Nota sobre `packages.lock.json`

Mesmo drift local já documentado no PR #950 — `dotnet build`/`test` sem `--locked-mode` regenera os lock files com entradas transitivas adicionais, sem nenhum `PackageReference` novo. Descartado antes de commitar; `--locked-mode` (modo do CI) passa limpo.

## Impacto na #949

Com este PR, `IDE1006` zera no repositório inteiro — pré-requisito que a #949 (ligar `dotnet format` como gate de CI) precisava para o relatório poder ficar limpo. Resta só o item dos 339 `CA1515` em projetos de teste.

## Critérios de aceite

- [x] Campo renomeado para `Current`, ambos os usos atualizados
- [x] `dotnet build UniPlus.slnx` sem avisos
- [x] Testes de `Infrastructure.Core.UnitTests` verdes
- [x] `IDE1006` zerado (repositório inteiro)
- [x] Nenhum pragma ou `[SuppressMessage]` introduzido
- [x] Commit único em conventional commits pt-BR

Closes #952
