### PR TITLE
docs(contributing): alerta que dotnet format sem filtro quebra o build

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,9 +17,13 @@ dotnet restore UniPlus.slnx --locked-mode
 dotnet build UniPlus.slnx
 dotnet test UniPlus.slnx --filter "Category!=Integration"
 dotnet test UniPlus.slnx --filter "Category=Integration"
-dotnet format --verify-no-changes
+dotnet format --exclude-diagnostics CA1515 --verify-no-changes
 bash tools/forbidden-deps/check.sh
 ```
+Never run `dotnet format` without `--exclude-diagnostics CA1515`: `xunit.analyzers` ships a
+`DiagnosticSuppressor` for CA1515 that the build honors but `dotnet format` does not, so the
+command rewrites every public test class to `internal` and breaks the build with
+`xUnit1000: Test classes must be public`. See `CONTRIBUTING.md`.
 Use Docker for PostgreSQL, Redis, Kafka, MinIO, and Keycloak. Use
 `dotnet restore UniPlus.slnx --force-evaluate` only when intentionally updating
 NuGet versions or lockfiles. Regenerate OpenAPI baselines with

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -265,11 +265,19 @@ dotnet test --filter "Category!=Integration"
 # Testes de integração (requer Docker)
 dotnet test --filter "Category=Integration"
 
-# Formatação
-dotnet format --verify-no-changes
+# Formatação — a flag --exclude-diagnostics CA1515 é OBRIGATÓRIA (ver aviso abaixo)
+dotnet format --exclude-diagnostics CA1515 --verify-no-changes
 ```
 
-Todos os comandos acima devem passar antes de abrir o PR.
+Todos os comandos acima devem passar antes de abrir o PR — com uma ressalva temporária para o
+`dotnet format`: enquanto a formatação do repositório não estiver normalizada, ele ainda acusa
+diagnósticos preexistentes. O que se exige hoje é que **os arquivos que você tocou** não apareçam
+no relatório. Ver [§ Formatação e o filtro CA1515](#formatação-e-o-filtro-ca1515).
+
+> ⚠️ **Nunca rode `dotnet format` sem `--exclude-diagnostics CA1515`.** Sem a flag, o comando
+> converte as classes de teste de `public` para `internal` e quebra o build inteiro — 688 erros,
+> entre eles `xUnit1000: Test classes must be public`. Detalhes em
+> [§ Formatação e o filtro CA1515](#formatação-e-o-filtro-ca1515).
 
 ### 4. Commit
 
@@ -368,6 +376,34 @@ Essas regras são aplicadas automaticamente via GitHub aos colaboradores sem per
 | Tabelas (EF Core) | PascalCase plural | `Candidatos`, `Inscricoes` |
 | Strings user-facing | pt-BR | `"Inscrição realizada com sucesso"` |
 | Mensagens de erro da API | pt-BR | `"CPF já cadastrado neste processo"` |
+
+### Formatação e o filtro CA1515
+
+O comando de formatação deste repositório é sempre:
+
+```bash
+dotnet format --exclude-diagnostics CA1515 --verify-no-changes
+```
+
+**A flag `--exclude-diagnostics CA1515` não é opcional — não a remova.**
+
+O `CA1515` ("Consider making public types internal") comporta-se de forma diferente nas duas
+ferramentas. O pacote `xunit.analyzers` fornece um `DiagnosticSuppressor` para o `CA1515`, que o
+`dotnet build` respeita — por isso as classes `public sealed class XTests` não são sinalizadas na
+compilação. O `dotnet format` não aplica esse suppressor: enxerga os 339 tipos públicos dos
+projetos de teste como violações e, quando executado sem `--verify-no-changes`, **aplica a
+"correção"** — converte todos para `internal`. O xUnit exige classes públicas para descobrir os
+testes, então o resultado é o build inteiro quebrado com `xUnit1000: Test classes must be public`.
+
+Manter o `CA1515` ativo no build é desejável: ele pega tipos públicos legítimos que deveriam ser
+`internal`, inclusive dentro de projetos de teste que o suppressor não cobre por não conterem
+métodos de teste (helpers e fixtures — daí os atributos `[SuppressMessage]` em
+`tests/*/Infrastructure/*ApiFactory.cs`). Por isso a regra é filtrada apenas no comando do
+`dotnet format`, e não silenciada no `.editorconfig`.
+
+> A formatação do repositório ainda não está normalizada — o `--verify-no-changes` acusa
+> diagnósticos preexistentes de `WHITESPACE`, `IMPORTS` e `CHARSET`. Isso é conhecido e está
+> sendo tratado em issue própria; não tente corrigi-los junto com a sua mudança.
 
 ### Validação
 
@@ -470,7 +506,7 @@ O PR será bloqueado se qualquer gate falhar:
 - [ ] Cobertura de código >= 80% nas camadas Domain e Application
 - [ ] SonarQube: zero issues críticos ou bloqueadores
 - [ ] Nenhuma vulnerabilidade crítica em dependências
-- [ ] Formatação correta (`dotnet format`)
+- [ ] Formatação correta (`dotnet format --exclude-diagnostics CA1515 --verify-no-changes`) — ver [§ Formatação e o filtro CA1515](#formatação-e-o-filtro-ca1515)
 - [ ] Pacotes proibidos ausentes (`bash tools/forbidden-deps/check.sh`) — ver [§ Pacotes proibidos](#pacotes-proibidos)
 
 ### Pacotes proibidos

--- a/docs/guia-commits-e-integracao.md
+++ b/docs/guia-commits-e-integracao.md
@@ -160,8 +160,11 @@ dotnet test UniPlus.slnx --filter "Category!=Integration"
 # Testes de integração (Testcontainers — requer Docker rodando)
 dotnet test UniPlus.slnx --filter "Category=Integration"
 
-# Formatação (verifica sem aplicar — falha se houver drift)
-dotnet format --verify-no-changes
+# Formatação (verifica sem aplicar — falha se houver drift).
+# A flag --exclude-diagnostics CA1515 é obrigatória: sem ela o comando
+# converte as classes de teste para `internal` e quebra o build.
+# Ver CONTRIBUTING.md.
+dotnet format --exclude-diagnostics CA1515 --verify-no-changes
 
 # Markdownlint (se mexeu em docs/**/*.md)
 npx markdownlint-cli2 'docs/**/*.md'
@@ -206,7 +209,8 @@ docs/0021-cache-distribuido
 - [ ] PR vinculado à issue com `Closes #N` na descrição (fora de blocos de código).
 - [ ] Build com `TreatWarningsAsErrors` passou — zero avisos, zero erros.
 - [ ] Testes unitários e de integração passando localmente.
-- [ ] `dotnet format --verify-no-changes` sem drift.
+- [ ] `dotnet format --exclude-diagnostics CA1515 --verify-no-changes` sem
+  drift nos arquivos que você tocou.
 
 ## 9. Particularidades do `uniplus-api`
 


### PR DESCRIPTION
## Resumo

A documentação deste repositório instruía, em quatro pontos, a rodar um comando que **quebra o build inteiro**. Este PR corrige a instrução e registra a causa.

Somente documentação — nenhuma mudança de código, configuração ou CI.

## O problema

```
$ dotnet format
$ dotnet build UniPlus.slnx
fail dotnet build: 56 projects, 688 errors, 0 warnings
xUnit1000: Test classes must be public
```

O pacote `xunit.analyzers` fornece um `DiagnosticSuppressor` para o `CA1515` (confirmei em `xunit.analyzers` 1.18.0: o assembly expõe `CA1515_Suppression`). O `dotnet build` respeita esse suppressor — por isso as classes de teste públicas nunca aparecem como violação na compilação. O `dotnet format` **não** o aplica: enxerga os 339 tipos públicos dos projetos de teste como violações e, sem `--verify-no-changes`, aplica a "correção" convertendo todos para `internal`. O xUnit exige classes públicas para descobrir os testes.

## Onde a instrução perigosa estava

| Arquivo | Local |
|---|---|
| `CONTRIBUTING.md` | seção "3. Testar" (comando) |
| `CONTRIBUTING.md` | "Quality gates" (checklist de PR) |
| `AGENTS.md` | bloco "Build, Test, and Development Commands" |
| `docs/guia-commits-e-integracao.md` | comando de validação + checklist pré-PR |

Os dois últimos não estavam no escopo original da issue — encontrei-os na revisão, com `grep` em todo o repositório. Sem eles, o alerta ficaria pela metade.

## O que muda

- Todos os comandos passam a exigir `--exclude-diagnostics CA1515`.
- Nova seção `CONTRIBUTING.md § Formatação e o filtro CA1515` explicando **por que** a flag é obrigatória — para que ninguém a remova por parecer supérflua.
- `AGENTS.md` ganha o mesmo aviso em inglês (o arquivo é todo em inglês).
- Resolvida uma contradição que a primeira versão deste PR introduzia: a seção "3. Testar" exigia que todos os comandos passassem, enquanto a nota nova dizia que o `--verify-no-changes` ainda falha por diagnósticos preexistentes. Agora o texto pede explicitamente que **os arquivos que você tocou** não apareçam no relatório.

## Por que não silenciar o `CA1515` no `.editorconfig`

Seria mais simples, mas custaria cobertura real. O suppressor do xUnit cobre apenas classes que **contêm métodos de teste**; tipos públicos auxiliares em projetos de teste (helpers, fixtures) continuam sendo pegos — e devem continuar. É o caso dos `[SuppressMessage]` que já existem em `tests/*/Infrastructure/*ApiFactory.cs`. Filtrar a regra apenas no comando do `format` preserva o build como está.

## Validação

```
grep -rn "dotnet format" --include="*.md" .    → todo comando prescritivo tem a flag
                                                 (as ocorrências restantes são prosa)
npx markdownlint-cli2 docs/guia-commits-e-integracao.md
   → 62 erros, idênticos ao baseline da main (todos MD013 preexistentes);
     duas violações que eu havia introduzido foram corrigidas antes do commit
```

Âncora `#formatação-e-o-filtro-ca1515` conferida contra a regra de geração do GitHub (preserva acentuação).

O CI roda `markdownlint` apenas em `docs/adrs/**`, então nenhum dos arquivos deste PR passa por esse gate — rodei localmente mesmo assim.

## Relacionadas

- #949 — investigação completa, sondas e dados; ligar o gate de formatação no CI
- #955 — normalizar a formatação do repositório (os `WHITESPACE`/`IMPORTS`/`CHARSET` que a nota menciona)

Closes #954
