### PR TITLE
ci: adiciona gate de formatação bloqueante

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,14 @@
+# Commits que só mexem em formatação e poluiriam o `git blame`.
+#
+# O GitHub respeita este arquivo automaticamente na visão de blame da web.
+# Localmente, configure uma vez por clone:
+#
+#   git config blame.ignoreRevsFile .git-blame-ignore-revs
+#
+# Só entram aqui commits comprovadamente sem mudança de comportamento —
+# espaçamento, ordenação de `using`, encoding. Nunca renomeações de símbolo
+# ou refatorações, que o blame precisa mostrar.
+
+# chore(formatacao): normaliza formatação do repositório (#955)
+# 205 arquivos: WHITESPACE + IMPORTS conforme .editorconfig.
+44b8412409f321a3920e6aff2244e4598ba9f122

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,6 +108,53 @@ jobs:
       - name: Verificar pacotes proibidos
         run: bash tools/forbidden-deps/check.sh
 
+  formatacao:
+    name: Formatação (dotnet format)
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: ${{ env.DOTNET_VERSION }}
+
+      - name: Cache NuGet packages
+        uses: actions/cache@v5
+        with:
+          path: ~/.nuget/packages
+          key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj', '**/Directory.Packages.props', '**/packages.lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-nuget-
+
+      # O dotnet format precisa dos pacotes restaurados: sem eles o compilador
+      # não resolve tipo nenhum e a ferramenta emite milhares de CS0246, em vez
+      # dos diagnósticos de formatação que interessam aqui.
+      - name: Restore dependencies
+        run: dotnet restore ${{ env.SOLUTION_PATH }} --locked-mode
+
+      # --exclude-diagnostics CA1515: o xunit.analyzers fornece um
+      # DiagnosticSuppressor para essa regra que o build respeita e o
+      # dotnet format não. Sem o filtro, a ferramenta trata as classes de teste
+      # públicas como violação — e, no modo que aplica correções, converte todas
+      # para internal, quebrando a descoberta de testes do xUnit (xUnit1000).
+      #
+      # --exclude **/Migrations/**: o dotnet ef gera migrations com UTF-8 BOM
+      # enquanto o .editorconfig exige utf-8 sem BOM. Sem a exclusão, todo PR que
+      # adicionasse uma migration nasceria vermelho neste gate.
+      - name: Verificar formatação
+        run: |
+          dotnet format ${{ env.SOLUTION_PATH }} \
+            --verify-no-changes \
+            --no-restore \
+            --exclude-diagnostics CA1515 \
+            --exclude "**/Migrations/**"
+
   # ─────────────────────────────────────────────────────────────────────────
   # Pipeline build → (test-unit ∥ test-integration) → coverage-summary
   #

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,7 +17,7 @@ dotnet restore UniPlus.slnx --locked-mode
 dotnet build UniPlus.slnx
 dotnet test UniPlus.slnx --filter "Category!=Integration"
 dotnet test UniPlus.slnx --filter "Category=Integration"
-dotnet format --exclude-diagnostics CA1515 --verify-no-changes
+dotnet format --verify-no-changes --exclude-diagnostics CA1515 --exclude "**/Migrations/**"
 bash tools/forbidden-deps/check.sh
 ```
 Never run `dotnet format` without `--exclude-diagnostics CA1515`: `xunit.analyzers` ships a

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -265,14 +265,13 @@ dotnet test --filter "Category!=Integration"
 # Testes de integração (requer Docker)
 dotnet test --filter "Category=Integration"
 
-# Formatação — a flag --exclude-diagnostics CA1515 é OBRIGATÓRIA (ver aviso abaixo)
-dotnet format --exclude-diagnostics CA1515 --verify-no-changes
+# Formatação — as duas flags são OBRIGATÓRIAS (ver aviso abaixo)
+dotnet format --verify-no-changes --exclude-diagnostics CA1515 --exclude "**/Migrations/**"
 ```
 
-Todos os comandos acima devem passar antes de abrir o PR — com uma ressalva temporária para o
-`dotnet format`: enquanto a formatação do repositório não estiver normalizada, ele ainda acusa
-diagnósticos preexistentes. O que se exige hoje é que **os arquivos que você tocou** não apareçam
-no relatório. Ver [§ Formatação e o filtro CA1515](#formatação-e-o-filtro-ca1515).
+Todos os comandos acima devem passar antes de abrir o PR. O de formatação é o mesmo que o job
+`Formatação (dotnet format)` roda no CI, e ele bloqueia o merge — ver
+[§ Formatação e o filtro CA1515](#formatação-e-o-filtro-ca1515).
 
 > ⚠️ **Nunca rode `dotnet format` sem `--exclude-diagnostics CA1515`.** Sem a flag, o comando
 > converte as classes de teste de `public` para `internal` e quebra o build inteiro — 688 erros,
@@ -382,8 +381,11 @@ Essas regras são aplicadas automaticamente via GitHub aos colaboradores sem per
 O comando de formatação deste repositório é sempre:
 
 ```bash
-dotnet format --exclude-diagnostics CA1515 --verify-no-changes
+dotnet format --verify-no-changes --exclude-diagnostics CA1515 --exclude "**/Migrations/**"
 ```
+
+É exatamente o que o job **`Formatação (dotnet format)`** executa no CI, e ele bloqueia o merge.
+Rode antes do push para não descobrir divergência só no PR.
 
 **A flag `--exclude-diagnostics CA1515` não é opcional — não a remova.**
 
@@ -401,9 +403,24 @@ métodos de teste (helpers e fixtures — daí os atributos `[SuppressMessage]` 
 `tests/*/Infrastructure/*ApiFactory.cs`). Por isso a regra é filtrada apenas no comando do
 `dotnet format`, e não silenciada no `.editorconfig`.
 
-> A formatação do repositório ainda não está normalizada — o `--verify-no-changes` acusa
-> diagnósticos preexistentes de `WHITESPACE`, `IMPORTS` e `CHARSET`. Isso é conhecido e está
-> sendo tratado em issue própria; não tente corrigi-los junto com a sua mudança.
+A exclusão de `**/Migrations/**` também é necessária: o `dotnet ef` gera migrations com UTF-8 BOM
+enquanto o `.editorconfig` exige `charset = utf-8` sem BOM. Sem ela, todo PR que adicionasse uma
+migration nasceria vermelho no gate por um arquivo que a ferramenta regenera assim.
+
+### `git blame` e commits de formatação
+
+O commit que normalizou a formatação do repositório tocou 205 arquivos, o que faria o `git blame`
+apontar para ele em vez de para o commit que realmente escreveu cada linha. O
+`.git-blame-ignore-revs` na raiz resolve isso — o GitHub o respeita automaticamente na web.
+Localmente, configure uma vez por clone:
+
+```bash
+git config blame.ignoreRevsFile .git-blame-ignore-revs
+```
+
+Ao adicionar um commit novo a esse arquivo, inclua apenas mudanças comprovadamente sem alteração
+de comportamento (espaçamento, ordenação de `using`, encoding) — nunca renomeações de símbolo,
+que o blame precisa mostrar.
 
 ### Validação
 
@@ -506,7 +523,7 @@ O PR será bloqueado se qualquer gate falhar:
 - [ ] Cobertura de código >= 80% nas camadas Domain e Application
 - [ ] SonarQube: zero issues críticos ou bloqueadores
 - [ ] Nenhuma vulnerabilidade crítica em dependências
-- [ ] Formatação correta (`dotnet format --exclude-diagnostics CA1515 --verify-no-changes`) — ver [§ Formatação e o filtro CA1515](#formatação-e-o-filtro-ca1515)
+- [ ] Formatação correta — job `Formatação (dotnet format)` no CI; ver [§ Formatação e o filtro CA1515](#formatação-e-o-filtro-ca1515)
 - [ ] Pacotes proibidos ausentes (`bash tools/forbidden-deps/check.sh`) — ver [§ Pacotes proibidos](#pacotes-proibidos)
 
 ### Pacotes proibidos

--- a/docs/guia-commits-e-integracao.md
+++ b/docs/guia-commits-e-integracao.md
@@ -164,7 +164,8 @@ dotnet test UniPlus.slnx --filter "Category=Integration"
 # A flag --exclude-diagnostics CA1515 é obrigatória: sem ela o comando
 # converte as classes de teste para `internal` e quebra o build.
 # Ver CONTRIBUTING.md.
-dotnet format --exclude-diagnostics CA1515 --verify-no-changes
+dotnet format --verify-no-changes --exclude-diagnostics CA1515 \
+  --exclude "**/Migrations/**"
 
 # Markdownlint (se mexeu em docs/**/*.md)
 npx markdownlint-cli2 'docs/**/*.md'
@@ -209,8 +210,8 @@ docs/0021-cache-distribuido
 - [ ] PR vinculado à issue com `Closes #N` na descrição (fora de blocos de código).
 - [ ] Build com `TreatWarningsAsErrors` passou — zero avisos, zero erros.
 - [ ] Testes unitários e de integração passando localmente.
-- [ ] `dotnet format --exclude-diagnostics CA1515 --verify-no-changes` sem
-  drift nos arquivos que você tocou.
+- [ ] Formatação sem drift — o job `Formatação (dotnet format)` do CI roda o
+  mesmo comando e bloqueia o merge.
 
 ## 9. Particularidades do `uniplus-api`
 


### PR DESCRIPTION
## Resumo

Fecha a frente de formatação: adiciona o job **`Formatação (dotnet format)`** ao CI e o `.git-blame-ignore-revs` que preserva o `git blame` após a normalização da #955.

## O comando do gate

```bash
dotnet format UniPlus.slnx \
  --verify-no-changes \
  --no-restore \
  --exclude-diagnostics CA1515 \
  --exclude "**/Migrations/**"
```

Cada parte foi verificada empiricamente, não escolhida por preferência:

| Decisão | Evidência |
|---|---|
| `--exclude-diagnostics CA1515` | O `xunit.analyzers` fornece um `DiagnosticSuppressor` para a regra (confirmei em 1.18.0: o assembly expõe `CA1515_Suppression`) que o build respeita e o format não. Sem o filtro: 339 falsos positivos, e no modo que aplica correções, 688 erros de build por converter classes de teste para `internal`. |
| `--exclude "**/Migrations/**"` com glob | Testei as duas formas: `--exclude "Migrations"` (nome simples) **não exclui nada** — permanecem os 84 diagnósticos. Só o glob funciona. E o glob é resiliente a módulos novos, ao contrário de caminhos literais. |
| `restore` antes de formatar | Sem restore o compilador não resolve tipo algum e o format emite **23.415 `CS0246`** no lugar dos diagnósticos de formatação. Aprendi isso ao criar um worktree limpo durante a #955. |

**Falsificação do filtro.** "0 diagnósticos" também seria o resultado se o glob excluísse o repositório inteiro. Desformatei propositalmente o `CorrelationIdAccessor.cs` (fora de migrations) e o comando **detectou**; restaurei e confirmei que o worktree voltou idêntico. O gate exclui só o que deve.

## Job separado, não step dentro do `Build`

Segue a convenção dos outros lints do pipeline (`ADR lint`, `Spectral lint`, `Forbidden dependencies`). Um check chamado `Formatação (dotnet format)` diz na hora o que falhou — relevante porque foi exatamente aqui que dois desenvolvedores tropeçaram esta semana. Custa um `restore` próprio (~1–2 min), mas roda em paralelo com os demais jobs.

> ⚠️ **Este job ainda não é obrigatório.** A branch protection lista hoje `PR author is org member`, `Build`, `Unit + arch tests`, `Integration tests`, `Coverage summary`. Para bloquear merge de fato, preciso adicionar `Formatação (dotnet format)` aos required status checks **depois** deste merge — o GitHub só reconhece o nome quando o check já executou. Isso afeta PRs abertos: os do Dependabot (#940, #941) ficarão pendentes até rebasearem sobre a `main` com o job.

## `.git-blame-ignore-revs`

O commit de normalização (`44b8412`, 205 arquivos) sequestrava a atribuição do blame. Conferido linha a linha:

| | `git blame` da linha 94 de `AvaliadorConformidadeLegal.cs` |
|---|---|
| **Sem** o ignore | `44b84124` — o commit de formatação |
| **Com** o ignore | `768f9cc4f` — o commit que de fato escreveu a linha, em 16/07 |

O GitHub respeita o arquivo automaticamente na web; localmente é `git config blame.ignoreRevsFile .git-blame-ignore-revs`, documentado no `CONTRIBUTING.md`.

## Documentação atualizada

`CONTRIBUTING.md`, `AGENTS.md` e `docs/guia-commits-e-integracao.md` passam a citar o comando exato do CI. Removida a ressalva "enquanto a formatação não estiver normalizada, ignore os diagnósticos preexistentes" — obsoleta desde a #955.

## Validação

```
dotnet format … --verify-no-changes    → 0 diagnósticos nesta branch (gate passa)
python3 -c "yaml.safe_load(ci.yml)"    → YAML válido, job e steps conforme esperado
markdownlint docs/guia-…               → 62 erros, idêntico ao baseline (todos MD013 preexistentes)
```

Closes #949
