### PR TITLE
feat(configuracao): semeia os opt-ins de cota e a autodeclaração de renda

### DIFF
--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Infrastructure/Persistence/Migrations/20260722031611_AddFatosDeclaradosCotas.Designer.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Infrastructure/Persistence/Migrations/20260722031611_AddFatosDeclaradosCotas.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Unifesspa.UniPlus.Configuracao.Infrastructure.Persistence;
@@ -11,9 +12,11 @@ using Unifesspa.UniPlus.Configuracao.Infrastructure.Persistence;
 namespace Unifesspa.UniPlus.Configuracao.Infrastructure.Persistence.Migrations
 {
     [DbContext(typeof(ConfiguracaoDbContext))]
-    partial class ConfiguracaoDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260722031611_AddFatosDeclaradosCotas")]
+    partial class AddFatosDeclaradosCotas
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Infrastructure/Persistence/Migrations/20260722031611_AddFatosDeclaradosCotas.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Infrastructure/Persistence/Migrations/20260722031611_AddFatosDeclaradosCotas.cs
@@ -1,0 +1,71 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+#pragma warning disable CA1814 // Prefer jagged arrays over multidimensional
+
+namespace Unifesspa.UniPlus.Configuracao.Infrastructure.Persistence.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddFatosDeclaradosCotas : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.InsertData(
+                schema: "configuracao",
+                table: "rol_de_fatos_candidato",
+                columns: new[] { "id", "binding", "cardinalidade", "codigo", "created_at", "descricao", "dominio", "nome", "origem", "ponto_resolucao", "updated_at", "valores_dominio" },
+                values: new object[,]
+                {
+                    { new Guid("fa700000-0000-7000-8000-000000000012"), "CAMPO_INSCRICAO:BAIXA_RENDA", "ESCALAR", "BAIXA_RENDA", new DateTimeOffset(new DateTime(2026, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified), new TimeSpan(0, 0, 0, 0, 0)), null, "BOOLEANO", "Renda familiar per capita igual ou inferior a um salário mínimo", "DECLARADO", "INSCRICAO", null, null },
+                    { new Guid("fa700000-0000-7000-8000-000000000013"), "CAMPO_INSCRICAO:CONCORRER_PCD", "ESCALAR", "CONCORRER_PCD", new DateTimeOffset(new DateTime(2026, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified), new TimeSpan(0, 0, 0, 0, 0)), null, "BOOLEANO", "Deseja concorrer às vagas reservadas a pessoas com deficiência", "DECLARADO", "INSCRICAO", null, null },
+                    { new Guid("fa700000-0000-7000-8000-000000000014"), "CAMPO_INSCRICAO:CONCORRER_EP", "ESCALAR", "CONCORRER_EP", new DateTimeOffset(new DateTime(2026, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified), new TimeSpan(0, 0, 0, 0, 0)), null, "BOOLEANO", "Deseja concorrer às vagas reservadas a egressos de escola pública", "DECLARADO", "INSCRICAO", null, null },
+                    { new Guid("fa700000-0000-7000-8000-000000000015"), "CAMPO_INSCRICAO:CONCORRER_PPI", "ESCALAR", "CONCORRER_PPI", new DateTimeOffset(new DateTime(2026, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified), new TimeSpan(0, 0, 0, 0, 0)), null, "BOOLEANO", "Deseja concorrer às vagas reservadas a pretos, pardos e indígenas", "DECLARADO", "INSCRICAO", null, null },
+                    { new Guid("fa700000-0000-7000-8000-000000000016"), "CAMPO_INSCRICAO:CONCORRER_Q", "ESCALAR", "CONCORRER_Q", new DateTimeOffset(new DateTime(2026, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified), new TimeSpan(0, 0, 0, 0, 0)), null, "BOOLEANO", "Deseja concorrer às vagas reservadas a quilombolas", "DECLARADO", "INSCRICAO", null, null },
+                    { new Guid("fa700000-0000-7000-8000-000000000017"), "CAMPO_INSCRICAO:CONCORRER_RENDA", "ESCALAR", "CONCORRER_RENDA", new DateTimeOffset(new DateTime(2026, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified), new TimeSpan(0, 0, 0, 0, 0)), null, "BOOLEANO", "Deseja concorrer às vagas reservadas por renda familiar per capita", "DECLARADO", "INSCRICAO", null, null }
+                });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DeleteData(
+                schema: "configuracao",
+                table: "rol_de_fatos_candidato",
+                keyColumn: "id",
+                keyValue: new Guid("fa700000-0000-7000-8000-000000000012"));
+
+            migrationBuilder.DeleteData(
+                schema: "configuracao",
+                table: "rol_de_fatos_candidato",
+                keyColumn: "id",
+                keyValue: new Guid("fa700000-0000-7000-8000-000000000013"));
+
+            migrationBuilder.DeleteData(
+                schema: "configuracao",
+                table: "rol_de_fatos_candidato",
+                keyColumn: "id",
+                keyValue: new Guid("fa700000-0000-7000-8000-000000000014"));
+
+            migrationBuilder.DeleteData(
+                schema: "configuracao",
+                table: "rol_de_fatos_candidato",
+                keyColumn: "id",
+                keyValue: new Guid("fa700000-0000-7000-8000-000000000015"));
+
+            migrationBuilder.DeleteData(
+                schema: "configuracao",
+                table: "rol_de_fatos_candidato",
+                keyColumn: "id",
+                keyValue: new Guid("fa700000-0000-7000-8000-000000000016"));
+
+            migrationBuilder.DeleteData(
+                schema: "configuracao",
+                table: "rol_de_fatos_candidato",
+                keyColumn: "id",
+                keyValue: new Guid("fa700000-0000-7000-8000-000000000017"));
+        }
+    }
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Infrastructure/Persistence/Seed/FatoCandidatoSeed.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Infrastructure/Persistence/Seed/FatoCandidatoSeed.cs
@@ -4,8 +4,8 @@ using Unifesspa.UniPlus.Configuracao.Domain.Enums;
 
 /// <summary>
 /// Fonte única do seed do catálogo <c>rol_de_fatos_candidato</c> (UNI-REQ-0077,
-/// ADR-0111, refinada pela ADR-0116): os onze fatos do vocabulário fechado do
-/// candidato. Consumida tanto pela configuração EF Core (que materializa as linhas
+/// ADR-0111, refinada pela ADR-0116; ampliada pela UNI-REQ-0078): os dezessete
+/// fatos do vocabulário fechado do candidato. Consumida tanto pela configuração EF Core (que materializa as linhas
 /// via <c>HasData</c> na migration) quanto pelos testes (que conferem o seed do
 /// banco contra esta lista), garantindo uma única definição por fato.
 /// </summary>
@@ -27,16 +27,22 @@ using Unifesspa.UniPlus.Configuracao.Domain.Enums;
 /// <see langword="null"/>.
 /// </para>
 /// <para>
-/// <see cref="OrigemFato"/> (ADR-0116) reclassifica os nove fatos originais:
-/// <c>FAIXA_ETARIA</c> e <c>RENDA_PER_CAPITA</c> são <see cref="OrigemFato.Derivado"/>
-/// (computados — o motor deriva o valor, o candidato não o responde diretamente); os
-/// demais sete + <c>NACIONALIDADE</c>/<c>TIPO_DEFICIENCIA</c> são
-/// <see cref="OrigemFato.Declarado"/> (resposta/seleção direta do candidato).
-/// <see cref="OrigemFato.Integracao"/> fica reservada, sem fato semeado (fonte
-/// externa futura, ex.: SIGAA #874).
+/// <see cref="OrigemFato"/> (ADR-0116): apenas <c>FAIXA_ETARIA</c> e
+/// <c>RENDA_PER_CAPITA</c> são <see cref="OrigemFato.Derivado"/> (computados — o motor
+/// deriva o valor, o candidato não o responde diretamente); todos os demais são
+/// <see cref="OrigemFato.Declarado"/> (resposta/seleção direta do candidato), inclusive
+/// os cinco opt-ins <c>CONCORRER_*</c> — que são seleção direta, ainda que expressem
+/// vontade e não afirmação de elegibilidade. <see cref="OrigemFato.Integracao"/> fica
+/// reservada, sem fato semeado (fonte externa futura, ex.: SIGAA #874).
 /// </para>
 /// <para>
-/// Todos os onze fatos resolvem em <c>PontoResolucao = "INSCRICAO"</c> — são
+/// <c>BAIXA_RENDA</c> <b>não</b> substitui <c>RENDA_PER_CAPITA</c>: são fatos distintos e
+/// coexistem. O primeiro é a autodeclaração booleana feita na inscrição (item 5.1 do
+/// formulário de cotas); o segundo é o valor numérico derivado, cuja comprovação ocorre em
+/// fase posterior.
+/// </para>
+/// <para>
+/// Todos os dezessete fatos resolvem em <c>PontoResolucao = "INSCRICAO"</c> — são
 /// respondidos/derivados no cadastro de inscrição do candidato, nenhum depende de
 /// fase posterior (o gate que recusaria isso é a Story #916/PR2).
 /// </para>
@@ -50,7 +56,7 @@ public static class FatoCandidatoSeed
     private static Guid SeedId(int n) =>
         Guid.Parse($"fa700000-0000-7000-8000-{n:D12}");
 
-    /// <summary>Os onze fatos do vocabulário, na ordem canônica da ADR-0111/ADR-0116.</summary>
+    /// <summary>Os dezessete fatos do vocabulário, na ordem canônica de semeadura.</summary>
     public static IReadOnlyList<FatoCandidatoSeedItem> Itens { get; } =
     [
         new(SeedId(1), "COR_RACA", "Cor ou raça", null,
@@ -96,6 +102,35 @@ public static class FatoCandidatoSeed
         new(SeedId(11), "TIPO_DEFICIENCIA", "Tipo de deficiência", null,
             DominioFato.Categorico, OrigemFato.Declarado, CardinalidadeFato.Escalar,
             null, PontoResolucaoInscricao, "CAMPO_INSCRICAO:TIPO_DEFICIENCIA"),
+
+        // ── Pares elegibilidade + opt-in do formulário de cotas (UNI-REQ-0078) ──
+        // A elegibilidade dos quatro blocos já está semeada acima e é REUTILIZADA:
+        // COR_RACA (PPI), QUILOMBOLA, PCD e EGRESSO_ESCOLA_PUBLICA. Falta a quinta
+        // elegibilidade — a autodeclaração de renda — e os cinco opt-ins.
+
+        new(SeedId(12), "BAIXA_RENDA", "Renda familiar per capita igual ou inferior a um salário mínimo", null,
+            DominioFato.Booleano, OrigemFato.Declarado, CardinalidadeFato.Escalar,
+            null, PontoResolucaoInscricao, "CAMPO_INSCRICAO:BAIXA_RENDA"),
+
+        new(SeedId(13), "CONCORRER_PCD", "Deseja concorrer às vagas reservadas a pessoas com deficiência", null,
+            DominioFato.Booleano, OrigemFato.Declarado, CardinalidadeFato.Escalar,
+            null, PontoResolucaoInscricao, "CAMPO_INSCRICAO:CONCORRER_PCD"),
+
+        new(SeedId(14), "CONCORRER_EP", "Deseja concorrer às vagas reservadas a egressos de escola pública", null,
+            DominioFato.Booleano, OrigemFato.Declarado, CardinalidadeFato.Escalar,
+            null, PontoResolucaoInscricao, "CAMPO_INSCRICAO:CONCORRER_EP"),
+
+        new(SeedId(15), "CONCORRER_PPI", "Deseja concorrer às vagas reservadas a pretos, pardos e indígenas", null,
+            DominioFato.Booleano, OrigemFato.Declarado, CardinalidadeFato.Escalar,
+            null, PontoResolucaoInscricao, "CAMPO_INSCRICAO:CONCORRER_PPI"),
+
+        new(SeedId(16), "CONCORRER_Q", "Deseja concorrer às vagas reservadas a quilombolas", null,
+            DominioFato.Booleano, OrigemFato.Declarado, CardinalidadeFato.Escalar,
+            null, PontoResolucaoInscricao, "CAMPO_INSCRICAO:CONCORRER_Q"),
+
+        new(SeedId(17), "CONCORRER_RENDA", "Deseja concorrer às vagas reservadas por renda familiar per capita", null,
+            DominioFato.Booleano, OrigemFato.Declarado, CardinalidadeFato.Escalar,
+            null, PontoResolucaoInscricao, "CAMPO_INSCRICAO:CONCORRER_RENDA"),
     ];
 }
 

--- a/tests/Unifesspa.UniPlus.Configuracao.IntegrationTests/FatosCandidato/FatoCandidatoEndpointTests.cs
+++ b/tests/Unifesspa.UniPlus.Configuracao.IntegrationTests/FatosCandidato/FatoCandidatoEndpointTests.cs
@@ -44,7 +44,7 @@ public sealed class FatoCandidatoEndpointTests
 
         List<FatoCandidatoView>? fatos = await response.Content.ReadFromJsonAsync<List<FatoCandidatoView>>();
         fatos.Should().NotBeNull();
-        fatos!.Should().HaveCount(11);
+        fatos!.Should().HaveCount(17);
         fatos.Select(f => f.Codigo).Should().BeInAscendingOrder(StringComparer.Ordinal);
         fatos.Should().Contain(f => f.Codigo == "MODALIDADE" && f.Cardinalidade == "MULTIVALORADO" && f.ValoresDominio == null);
     }

--- a/tests/Unifesspa.UniPlus.Configuracao.IntegrationTests/FatosCandidato/FatoCandidatoPersistenceTests.cs
+++ b/tests/Unifesspa.UniPlus.Configuracao.IntegrationTests/FatosCandidato/FatoCandidatoPersistenceTests.cs
@@ -13,10 +13,11 @@ using Unifesspa.UniPlus.Configuracao.Infrastructure.Persistence;
 using Unifesspa.UniPlus.Configuracao.Infrastructure.Persistence.Seed;
 using Unifesspa.UniPlus.Configuracao.Infrastructure.Readers;
 using Unifesspa.UniPlus.Configuracao.IntegrationTests.Infrastructure;
+using Unifesspa.UniPlus.Kernel.Results;
 
 /// <summary>
 /// Integração ponta-a-ponta do catálogo <c>rol_de_fatos_candidato</c> contra Postgres real
-/// (UNI-REQ-0077, ADR-0111, refinada pela ADR-0116): seed dos onze fatos, leitor
+/// (UNI-REQ-0077, ADR-0111, refinada pela ADR-0116; ampliada pela UNI-REQ-0078): seed dos dezessete fatos, leitor
 /// cross-módulo, ordenação, resolução por chave natural, sobrevivência do
 /// <c>valores_dominio</c> nulo ao round-trip, CHECKs de domínio/coerência, índice
 /// único total do código e o seed de <c>fato_valor_dominio</c>.
@@ -39,14 +40,127 @@ public sealed class FatoCandidatoPersistenceTests
         _fixture = fixture;
     }
 
-    [Fact(DisplayName = "Seed materializa exatamente os onze fatos da ADR-0111/ADR-0116, batendo com a fonte única")]
-    public async Task Seed_MaterializaOnzeFatos()
+    [Fact(DisplayName = "Todo item do seed passa pela factory de domínio — a linha materializada é construível")]
+    public void Seed_TodoItemEhAceitoPelaFactory()
+    {
+        // O seed materializa linhas direto pela migration, sem passar pela factory.
+        // Este teste fecha essa lacuna: garante que cada item semeado satisfaz as
+        // invariantes de FatoCandidato.Criar (formato de código, tamanho de nome,
+        // coerência binding × origem, ponto de resolução canônico).
+        foreach (FatoCandidatoSeedItem item in FatoCandidatoSeed.Itens)
+        {
+            Result<FatoCandidato> resultado = FatoCandidato.Criar(
+                item.Codigo,
+                item.Nome,
+                item.Descricao,
+                item.Dominio,
+                item.Origem,
+                item.Cardinalidade,
+                item.ValoresDominio,
+                item.PontoResolucao,
+                item.Binding);
+
+            resultado.IsSuccess.Should().BeTrue(
+                $"o item semeado {item.Codigo} deve satisfazer as invariantes de domínio; erro: {resultado.Error?.Code}");
+        }
+    }
+
+    [Fact(DisplayName = "Cada cota tem par elegibilidade + opt-in como fatos independentes (UNI-REQ-0078)")]
+    public async Task Seed_CadaCotaTemParElegibilidadeEOptIn()
     {
         await using ConfiguracaoDbContext ctx = _fixture.CreateDbContext(userId: null);
 
         List<FatoCandidato> fatos = await ctx.FatosCandidato.AsNoTracking().ToListAsync();
 
-        fatos.Should().HaveCount(FatoCandidatoSeed.Itens.Count).And.HaveCount(11);
+        // Os quatro blocos do formulário de cotas. A elegibilidade de PPI é COR_RACA
+        // (categórico); as demais são booleanas. O opt-in é sempre booleano.
+        (string Elegibilidade, string OptIn)[] pares =
+        [
+            ("PCD", "CONCORRER_PCD"),
+            ("EGRESSO_ESCOLA_PUBLICA", "CONCORRER_EP"),
+            ("COR_RACA", "CONCORRER_PPI"),
+            ("QUILOMBOLA", "CONCORRER_Q"),
+            ("BAIXA_RENDA", "CONCORRER_RENDA"),
+        ];
+
+        foreach ((string elegibilidade, string optIn) in pares)
+        {
+            FatoCandidato fatoElegibilidade = fatos.Single(f => f.Codigo == elegibilidade);
+            FatoCandidato fatoOptIn = fatos.Single(f => f.Codigo == optIn);
+
+            fatoElegibilidade.Id.Should().NotBe(fatoOptIn.Id,
+                $"{elegibilidade} e {optIn} são fatos independentes — a elegibilidade sozinha não coloca na cota");
+            fatoOptIn.Dominio.Should().Be(DominioFato.Booleano);
+            fatoOptIn.Origem.Should().Be(OrigemFato.Declarado,
+                "o opt-in é seleção direta do candidato, ainda que expresse vontade e não elegibilidade");
+            fatoOptIn.Cardinalidade.Should().Be(CardinalidadeFato.Escalar);
+        }
+    }
+
+    [Fact(DisplayName = "Fatos reutilizados mantêm a identidade semeada — o vocabulário não duplica código")]
+    public async Task Seed_FatosPreexistentesSaoReutilizadosSemDuplicar()
+    {
+        await using ConfiguracaoDbContext ctx = _fixture.CreateDbContext(userId: null);
+
+        List<FatoCandidato> fatos = await ctx.FatosCandidato.AsNoTracking().ToListAsync();
+
+        // Quatro fatos já existiam antes desta leva e são REUTILIZADOS, não recadastrados:
+        // renomeá-los violaria a imutabilidade de código da ADR-0111.
+        (string Codigo, string IdSufixo)[] reutilizados =
+        [
+            ("COR_RACA", "001"),
+            ("QUILOMBOLA", "002"),
+            ("PCD", "003"),
+            ("EGRESSO_ESCOLA_PUBLICA", "004"),
+        ];
+
+        foreach ((string codigo, string idSufixo) in reutilizados)
+        {
+            FatoCandidato fato = fatos.Single(f => f.Codigo == codigo);
+            fato.Id.Should().Be(Guid.Parse($"fa700000-0000-7000-8000-{idSufixo.PadLeft(12, '0')}"),
+                $"{codigo} preserva o Guid determinístico da semeadura original");
+        }
+
+        fatos.Select(f => f.Codigo).Should().OnlyHaveUniqueItems("o catálogo nunca tem dois fatos com o mesmo código");
+        fatos.Select(f => f.Id).Should().OnlyHaveUniqueItems();
+
+        // Nenhum código adjacente foi criado como sinônimo dos reutilizados.
+        fatos.Select(f => f.Codigo).Should().NotContain(["PCD_AUTODECLARADO", "ESCOLA_PUBLICA"]);
+
+        // BAIXA_RENDA não substitui RENDA_PER_CAPITA: coexistem com naturezas distintas.
+        fatos.Single(f => f.Codigo == "BAIXA_RENDA").Origem.Should().Be(OrigemFato.Declarado);
+        fatos.Single(f => f.Codigo == "RENDA_PER_CAPITA").Origem.Should().Be(OrigemFato.Derivado);
+    }
+
+    [Fact(DisplayName = "Fato booleano não recebe FatoValorDominio (ADR-0111/ADR-0116)")]
+    public async Task Seed_BooleanoNaoRecebeValorDominio()
+    {
+        await using ConfiguracaoDbContext ctx = _fixture.CreateDbContext(userId: null);
+
+        List<FatoCandidato> booleanos = await ctx.FatosCandidato.AsNoTracking()
+            .Where(f => f.Dominio == DominioFato.Booleano)
+            .Include(f => f.ValoresDominioDeclarados)
+            .ToListAsync();
+
+        // Prende a leva nova: sem os seis fatos desta story o conjunto não os contém.
+        booleanos.Select(f => f.Codigo).Should().Contain(
+            ["BAIXA_RENDA", "CONCORRER_PCD", "CONCORRER_EP", "CONCORRER_PPI", "CONCORRER_Q", "CONCORRER_RENDA"]);
+        foreach (FatoCandidato fato in booleanos)
+        {
+            fato.ValoresDominio.Should().BeNull($"{fato.Codigo} é booleano — domínio intrínseco SIM/NÃO");
+            fato.ValoresDominioDeclarados.Should().BeEmpty(
+                $"{fato.Codigo} é booleano; FatoValorDominio só vale para categórico estático");
+        }
+    }
+
+    [Fact(DisplayName = "Seed materializa exatamente os dezessete fatos do vocabulário, batendo com a fonte única")]
+    public async Task Seed_MaterializaTodosOsFatosDaFonteUnica()
+    {
+        await using ConfiguracaoDbContext ctx = _fixture.CreateDbContext(userId: null);
+
+        List<FatoCandidato> fatos = await ctx.FatosCandidato.AsNoTracking().ToListAsync();
+
+        fatos.Should().HaveCount(FatoCandidatoSeed.Itens.Count).And.HaveCount(17);
         fatos.Select(f => f.Codigo).Should().OnlyHaveUniqueItems();
 
         foreach (FatoCandidatoSeedItem item in FatoCandidatoSeed.Itens)
@@ -70,7 +184,7 @@ public sealed class FatoCandidatoPersistenceTests
         }
     }
 
-    [Fact(DisplayName = "Origem: FAIXA_ETARIA e RENDA_PER_CAPITA são Derivado; os demais nove são Declarado (ADR-0116)")]
+    [Fact(DisplayName = "Origem: só FAIXA_ETARIA e RENDA_PER_CAPITA são Derivado; todos os demais são Declarado (ADR-0116)")]
     public async Task Seed_OrigemReclassificadaConformeADR0116()
     {
         await using ConfiguracaoDbContext ctx = _fixture.CreateDbContext(userId: null);
@@ -87,7 +201,7 @@ public sealed class FatoCandidatoPersistenceTests
             .Should().OnlyContain(f => f.Origem == OrigemFato.Declarado);
     }
 
-    [Fact(DisplayName = "PontoResolucao: todos os onze fatos resolvem em INSCRICAO")]
+    [Fact(DisplayName = "PontoResolucao: todos os dezessete fatos resolvem em INSCRICAO")]
     public async Task Seed_PontoResolucaoInscricaoParaTodos()
     {
         await using ConfiguracaoDbContext ctx = _fixture.CreateDbContext(userId: null);
@@ -194,7 +308,7 @@ public sealed class FatoCandidatoPersistenceTests
 
         IReadOnlyList<FatoCandidatoView> views = await reader.ListarAsync();
 
-        views.Should().HaveCount(11);
+        views.Should().HaveCount(17);
         views.Select(v => v.Codigo).Should().BeInAscendingOrder(StringComparer.Ordinal);
 
         FatoCandidatoView corRaca = views.Single(v => v.Codigo == "COR_RACA");
@@ -392,6 +506,12 @@ public sealed class FatoCandidatoPersistenceTests
             ("CONDICAO_ATENDIMENTO", "009", DominioFato.Categorico, OrigemFato.Declarado, CardinalidadeFato.Multivalorado, "CAMPO_INSCRICAO:CONDICAO_ATENDIMENTO"),
             ("NACIONALIDADE", "010", DominioFato.Categorico, OrigemFato.Declarado, CardinalidadeFato.Escalar, "CAMPO_INSCRICAO:NACIONALIDADE"),
             ("TIPO_DEFICIENCIA", "011", DominioFato.Categorico, OrigemFato.Declarado, CardinalidadeFato.Escalar, "CAMPO_INSCRICAO:TIPO_DEFICIENCIA"),
+            ("BAIXA_RENDA", "012", DominioFato.Booleano, OrigemFato.Declarado, CardinalidadeFato.Escalar, "CAMPO_INSCRICAO:BAIXA_RENDA"),
+            ("CONCORRER_PCD", "013", DominioFato.Booleano, OrigemFato.Declarado, CardinalidadeFato.Escalar, "CAMPO_INSCRICAO:CONCORRER_PCD"),
+            ("CONCORRER_EP", "014", DominioFato.Booleano, OrigemFato.Declarado, CardinalidadeFato.Escalar, "CAMPO_INSCRICAO:CONCORRER_EP"),
+            ("CONCORRER_PPI", "015", DominioFato.Booleano, OrigemFato.Declarado, CardinalidadeFato.Escalar, "CAMPO_INSCRICAO:CONCORRER_PPI"),
+            ("CONCORRER_Q", "016", DominioFato.Booleano, OrigemFato.Declarado, CardinalidadeFato.Escalar, "CAMPO_INSCRICAO:CONCORRER_Q"),
+            ("CONCORRER_RENDA", "017", DominioFato.Booleano, OrigemFato.Declarado, CardinalidadeFato.Escalar, "CAMPO_INSCRICAO:CONCORRER_RENDA"),
         ];
 
         await using ConfiguracaoDbContext ctx = _fixture.CreateDbContext(userId: null);


### PR DESCRIPTION
## Contexto

O formulário de cotas do CEPS pergunta cada cota em **duas etapas**: primeiro a elegibilidade (*"você se autodeclara pessoa com deficiência?"*), depois o opt-in (*"você deseja concorrer às vagas reservadas?"*). A segunda pergunta não tinha fato correspondente no catálogo `rol_de_fatos_candidato` — logo a escolha de concorrer não era representável, e a elegibilidade sozinha colocaria o candidato na cota, o que contraria o formulário.

Este PR fecha essa lacuna no vocabulário. É a fatia §1 da change `coleta-de-fatos-e-derivacao`.

## O que muda

**Seis fatos novos** — a autodeclaração `BAIXA_RENDA` e os cinco opt-ins `CONCORRER_PCD`, `CONCORRER_EP`, `CONCORRER_PPI`, `CONCORRER_Q`, `CONCORRER_RENDA`. Todos booleanos, `DECLARADO`, escalares, com binding de campo de inscrição.

**Quatro fatos reutilizados, não recadastrados** — `COR_RACA`, `QUILOMBOLA`, `PCD` e `EGRESSO_ESCOLA_PUBLICA` já estavam semeados. A redação original da story pedia `PCD_AUTODECLARADO` e `ESCOLA_PUBLICA` como códigos novos; seriam sinônimos de fatos existentes, e código de fato é **imutável desde a semeadura** (ADR-0111). A novidade da change é a **pré-condição**, que é aresta do grafo por processo — não propriedade do catálogo. Quem se adapta é o texto da spec.

**`BAIXA_RENDA` não substitui `RENDA_PER_CAPITA`** — são fatos distintos e coexistem. O primeiro é booleano declarado na inscrição (item 5.1 do formulário); o segundo é numérico derivado, cuja comprovação ocorre em fase posterior.

**Nenhum `FatoValorDominio` novo** — a ADR-0111 fixa que booleano e numérico têm valores de domínio sempre nulos, e a ADR-0116 restringe a entidade aos categóricos estáticos. Nove dos dez fatos do par são booleanos; o único categórico (`COR_RACA`) já tem os seus seis valores.

## Critérios de aceite

- [x] Cada cota produz dois fatos independentes (elegibilidade + opt-in), cada um com binding de campo
- [x] Os quatro fatos preexistentes são reutilizados; o seed não cria identidade duplicada
- [x] Os seis fatos novos existem no catálogo com origem, domínio e cardinalidade corretos
- [x] Nenhum `FatoValorDominio` é criado; os seis valores de `COR_RACA` seguem intactos
- [x] Todos os fatos congelam na publicação (RN08) — mecanismo já existente, sem mudança

## Testes

Quatro testes novos em `FatoCandidatoPersistenceTests`:

| Teste | Prova |
|---|---|
| `Seed_CadaCotaTemParElegibilidadeEOptIn` | os cinco pares existem como identidades distintas |
| `Seed_FatosPreexistentesSaoReutilizadosSemDuplicar` | Guids originais preservados; sem código duplicado nem sinônimo |
| `Seed_BooleanoNaoRecebeValorDominio` | booleano não tem valores de domínio, e a leva nova está no conjunto |
| `Seed_TodoItemEhAceitoPelaFactory` | todo item do seed satisfaz `FatoCandidato.Criar` |

O último fecha uma lacuna que o próprio comentário do seed alegava cobrir: o seed materializa linhas direto pela migration, sem passar pela factory, e nada verificava essa paridade.

**Suíte completa: 3322 testes, zero falhas.** Gate de formatação (`dotnet format --verify-no-changes --exclude-diagnostics CA1515 --exclude "**/Migrations/**"`) verde.

## Fora de escopo

**Não** se afirma a qual modalidade o candidato concorre. Concorrência é resultado da derivação de `MODALIDADE`, entregue na #927. O aceite original da story afirmava isso, o que criava acoplamento impossível com a ordem de PRs — corrigido na issue.

## Nota sobre o ambiente

`dotnet restore --locked-mode` falha localmente com `NU1004` mesmo em `origin/main` limpa (SDK 10.0.109), enquanto o CI da main está verde com a mesma flag. Este PR **não toca nenhum `csproj` nem `packages.lock.json`** — os lock files estão idênticos a `origin/main`. Se o CI acusar `NU1004`, a causa é anterior a esta branch.

Closes #925
Refs #924