### PR TITLE
ci: refina o gate de formatação (migrations e versão do SDK)

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -94,7 +94,14 @@ dotnet_diagnostic.CA1861.severity = none
 # - CA1062: tool não emite ArgumentNullException no migrationBuilder
 # - CA1861: tool emite arrays inline (`new[] { ... }`) em CreateIndex
 # - IDE0161: tool emite namespace-block clássico, não file-scoped
+#
+# Pelo mesmo motivo, duas regras de formatação seguem o que o `dotnet ef`
+# emite, em vez de exigir retrabalho manual a cada migration gerada:
+# - charset: o tool grava com BOM
+# - separate_import_directive_groups: o tool não separa grupos de using
 [src/**/Migrations/**.cs]
+charset = utf-8-bom
+dotnet_separate_import_directive_groups = false
 dotnet_diagnostic.CA1062.severity = none
 dotnet_diagnostic.CA1861.severity = none
 dotnet_diagnostic.IDE0161.severity = none

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,6 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 env:
-  DOTNET_VERSION: 10.0.x
   BUILD_CONFIG: Release
   SOLUTION_PATH: UniPlus.slnx
   COVERAGE_DIR: coverage
@@ -122,7 +121,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v5
         with:
-          dotnet-version: ${{ env.DOTNET_VERSION }}
+          global-json-file: global.json
 
       - name: Cache NuGet packages
         uses: actions/cache@v5
@@ -144,16 +143,17 @@ jobs:
       # públicas como violação — e, no modo que aplica correções, converte todas
       # para internal, quebrando a descoberta de testes do xUnit (xUnit1000).
       #
-      # --exclude **/Migrations/**: o dotnet ef gera migrations com UTF-8 BOM
-      # enquanto o .editorconfig exige utf-8 sem BOM. Sem a exclusão, todo PR que
-      # adicionasse uma migration nasceria vermelho neste gate.
+      # Migrations NÃO são excluídas: o que o `dotnet ef` gera fora da política
+      # (BOM e usings sem separação de grupo) está declarado na seção
+      # [src/**/Migrations/**.cs] do .editorconfig, então elas passam pelo gate
+      # como qualquer outro arquivo — indentação, trailing whitespace e demais
+      # regras seguem valendo nelas.
       - name: Verificar formatação
         run: |
           dotnet format ${{ env.SOLUTION_PATH }} \
             --verify-no-changes \
             --no-restore \
-            --exclude-diagnostics CA1515 \
-            --exclude "**/Migrations/**"
+            --exclude-diagnostics CA1515
 
   # ─────────────────────────────────────────────────────────────────────────
   # Pipeline build → (test-unit ∥ test-integration) → coverage-summary
@@ -182,7 +182,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v5
         with:
-          dotnet-version: ${{ env.DOTNET_VERSION }}
+          global-json-file: global.json
 
       - name: Cache NuGet packages
         uses: actions/cache@v5
@@ -238,7 +238,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v5
         with:
-          dotnet-version: ${{ env.DOTNET_VERSION }}
+          global-json-file: global.json
 
       - name: Cache NuGet packages
         uses: actions/cache@v5
@@ -309,7 +309,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v5
         with:
-          dotnet-version: ${{ env.DOTNET_VERSION }}
+          global-json-file: global.json
 
       - name: Cache NuGet packages
         uses: actions/cache@v5
@@ -448,7 +448,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v5
         with:
-          dotnet-version: ${{ env.DOTNET_VERSION }}
+          global-json-file: global.json
 
       - name: Restore .NET tools (reportgenerator)
         run: dotnet tool restore

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -38,7 +38,6 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 env:
-  DOTNET_VERSION: 10.0.x
   SOLUTION_PATH: UniPlus.slnx
 
 jobs:
@@ -65,7 +64,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v5
         with:
-          dotnet-version: ${{ env.DOTNET_VERSION }}
+          global-json-file: global.json
           # Cache de packages NuGet chaveado por hash dos .csproj. Reduz
           # restore frio (~30-60s na árvore atual de ~30 projetos) para
           # ~5s em cache hit, economizando runner minutes em PRs em rajada.

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Para atualizar as dependências localmente:
 
 ## Pré-requisitos
 
-- .NET 10 SDK (10.0.100+)
+- .NET 10 SDK 10.0.300 ou um patch da mesma feature band (`10.0.3xx`) — `global.json` usa `rollForward: latestPatch`, então bands anteriores não satisfazem
 - Docker e Docker Compose v2
 
 ## Como executar

--- a/docker/Dockerfile.host
+++ b/docker/Dockerfile.host
@@ -4,7 +4,7 @@
 # seguem deploy separado e NÃO entram na imagem.
 
 # ---- Restore + Build ----
-FROM mcr.microsoft.com/dotnet/sdk:10.0.100 AS build
+FROM mcr.microsoft.com/dotnet/sdk:10.0.300 AS build
 WORKDIR /src
 
 # Configuração da solution. .editorconfig é necessário porque políticas por glob

--- a/docker/Dockerfile.portal
+++ b/docker/Dockerfile.portal
@@ -1,5 +1,5 @@
 # ---- Restore + Build ----
-FROM mcr.microsoft.com/dotnet/sdk:10.0.100 AS build
+FROM mcr.microsoft.com/dotnet/sdk:10.0.300 AS build
 WORKDIR /src
 
 # Copiar arquivos de configuração da solution

--- a/docs/setup-ambiente-local.md
+++ b/docs/setup-ambiente-local.md
@@ -8,7 +8,7 @@ Guia para configurar e executar o ambiente de desenvolvimento da Uni+ API.
 |---|---|---|
 | Docker | 24+ | `docker --version` |
 | Docker Compose | 2.20+ | `docker compose version` |
-| .NET SDK | 10.0.100 | `dotnet --version` |
+| .NET SDK | 10.0.300 (qualquer patch `10.0.3xx`) | `dotnet --version` |
 | Git | 2.40+ | `git --version` |
 
 ## Setup rápido
@@ -154,10 +154,10 @@ docker exec docker-keycloak-1 bash -c "exec 3<>/dev/tcp/localhost/9000 && echo -
 
 ### Build Docker das APIs falha
 
-Se a imagem `sdk:10.0` não contiver o SDK GA, o build falhará. Os Dockerfiles usam a tag pinada `sdk:10.0.100` para evitar isso. Se precisar atualizar:
+Se a imagem `sdk:10.0` não contiver o SDK GA, o build falhará. Os Dockerfiles usam a tag pinada `sdk:10.0.300` para evitar isso — a mesma versão declarada em `global.json`, que restringe a resolução à feature band `10.0.3xx` (`rollForward: latestPatch`). Uma tag de outra band faz o `dotnet restore` falhar dentro da imagem antes do build. Se precisar atualizar:
 
 1. Verifique a versão local: `dotnet --version`
-2. Atualize a tag nos Dockerfiles: `FROM mcr.microsoft.com/dotnet/sdk:<versão>`
+2. Atualize `global.json` e a tag nos Dockerfiles juntos: `FROM mcr.microsoft.com/dotnet/sdk:<versão>` — as duas referências precisam ficar na mesma feature band
 
 ### Connection string inválida
 

--- a/global.json
+++ b/global.json
@@ -1,7 +1,7 @@
 {
   "sdk": {
-    "version": "10.0.100",
-    "rollForward": "latestFeature",
+    "version": "10.0.300",
+    "rollForward": "latestPatch",
     "allowPrerelease": false
   }
 }

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Infrastructure/Persistence/Migrations/20260719134416_AddOrigemPontoResolucaoBindingEFatoValorDominio.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Infrastructure/Persistence/Migrations/20260719134416_AddOrigemPontoResolucaoBindingEFatoValorDominio.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 
 using Microsoft.EntityFrameworkCore.Migrations;
 

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/Persistence/Migrations/20260708120000_AddIndiceRetificacaoUnica.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/Persistence/Migrations/20260708120000_AddIndiceRetificacaoUnica.cs
@@ -1,4 +1,4 @@
-using Microsoft.EntityFrameworkCore.Migrations;
+﻿using Microsoft.EntityFrameworkCore.Migrations;
 
 #nullable disable
 

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/Persistence/Migrations/20260716030741_RenomeiaTipoEditalCodigoParaTipoProcessoCodigo.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/Persistence/Migrations/20260716030741_RenomeiaTipoEditalCodigoParaTipoProcessoCodigo.cs
@@ -1,4 +1,4 @@
-using Microsoft.EntityFrameworkCore.Migrations;
+﻿using Microsoft.EntityFrameworkCore.Migrations;
 
 #nullable disable
 

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/Persistence/Migrations/20260719162733_AddFormatosPermitidos.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/Persistence/Migrations/20260719162733_AddFormatosPermitidos.cs
@@ -1,4 +1,4 @@
-using Microsoft.EntityFrameworkCore.Migrations;
+﻿using Microsoft.EntityFrameworkCore.Migrations;
 
 #nullable disable
 


### PR DESCRIPTION
## Resumo

Dois pontos levantados na revisão do #958, mais o alinhamento das imagens Docker que o bump de SDK exigiu. Três commits atômicos.

## 1. Migrations passam a ser cobertas pelo gate (#959)

O gate excluía `**/Migrations/**` por inteiro — silenciando *todas* as regras nesses arquivos quando o conflito real era com duas.

A correção segue a lógica que a seção `[src/**/Migrations/**.cs]` do `.editorconfig` **já usava** para `CA1062`/`CA1861`/`IDE0161` — *"o tool emite assim, a regra não se aplica"*:

```ini
charset = utf-8-bom                              # o dotnet ef grava com BOM
dotnet_separate_import_directive_groups = false  # o dotnet ef não separa grupos de using
```

Mais os 4 arquivos legados sem BOM normalizados (de 95 migrations, 91 já estavam conformes). O `--exclude` sai do `ci.yml`.

**A cobertura é real, não exclusão disfarçada.** Verifiquei introduzindo indentação errada numa migration (`    protected override` → `          protected override`): o gate **detecta**. Só as duas regras declaradas seguem o gerador; indentação, trailing whitespace, final newline e ordenação de usings continuam valendo.

### Por que não normalizar as migrations

A alternativa era normalizar as 40 migrations e remover o `--exclude`. Testei: os erros de `CHARSET` somem, mas sobram **43 `WHITESPACE`** — e ao investigar a natureza deles, todos eram a linha em branco entre grupos de `using` que o `dotnet ef` não emite. Ou seja, aquela abordagem resolveria hoje e **toda migration nova nasceria divergente**, exigindo `dotnet format` manual após cada `dotnet ef migrations add`.

Configurar as duas regras elimina o atrito recorrente em vez de institucionalizá-lo.

> Sobre o separador de `using` remanescente em `20260719134416_AddOrigemPontoResolucaoBindingEFatoValorDominio.cs`: `dotnet_separate_import_directive_groups = false` significa *"não force a separação"*, não *"remova a existente"*. O gate roda verde sobre esse arquivo — confirmado localmente com o comando exato do CI e pelo check `Formatação (dotnet format)` deste PR.

## 2. Versão do SDK reprodutível (#960)

O `dotnet format` vem no SDK, e havia três referências divergentes:

| Origem | Antes | Depois |
|---|---|---|
| `global.json` | `10.0.100` + `latestFeature` | `10.0.300` + **`latestPatch`** |
| workflows | `DOTNET_VERSION: 10.0.x` | **`global-json-file: global.json`** |
| imagens Docker | `sdk:10.0.100` | **`sdk:10.0.300`** |

Com `latestFeature`, uma feature band nova no runner seria adotada automaticamente e poderia mudar os diagnósticos, bloqueando PRs sem mudança no repositório. `latestPatch` restringe à band `10.0.3xx`.

O `global-json-file` elimina a duplicação nos workflows: uma fonte única, CI e ambiente local não podem mais divergir em silêncio. Aplicado também ao `codeql.yml`, que tinha a mesma duplicação.

**Requer atualizar o SDK local para a band `10.0.3xx`** — uma instalação `10.0.1xx` deixa de satisfazer o `global.json`. As referências no `README.md` e em `docs/setup-ambiente-local.md` foram atualizadas junto; seguir o guia antigo deixaria a máquina sem SDK compatível.

## 3. Imagens Docker na mesma feature band

Consequência direta do item 2, e a causa das falhas em `Trivy image (host)` e `Trivy image (portal)`: os Dockerfiles copiam `global.json` **antes** do `dotnet restore`, então uma imagem `sdk:10.0.100` falha na resolução do SDK antes de compilar qualquer coisa.

As duas tags passam a espelhar a `version` do `global.json`. Enquanto as duas referências ficarem na mesma band, a resolução é idêntica dentro e fora do container.

## Validação

```
docker build -f docker/Dockerfile.portal            → exit 0 (imagem construída)
dotnet build UniPlus.slnx                           → 0 erros, 0 avisos
dotnet format … --exclude-diagnostics CA1515        → 0 diagnósticos (sem --exclude de Migrations)
dotnet test UniPlus.slnx                            → 3.322 testes, 0 falhas (suíte completa)
yaml.safe_load(ci.yml / codeql.yml)                 → válidos, sem referência órfã a DOTNET_VERSION
falsificação: indentação errada em migration        → detectada
```

Closes #959
Closes #960
