### PR TITLE
docs(adr): emenda o vocabulário de fatos com operadores de exclusão e a derivação de modalidade

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -237,6 +237,31 @@ dotnet ef migrations add <Nome> \
 - **NUNCA adicionar Co-Authored-By**
 - **NUNCA usar --no-verify**
 
+## Referências têm de se explicar sozinhas
+
+Vale para **comentário de código, descrição de PR, corpo de issue e mensagem de commit** — tudo que sobrevive ao contexto em que foi escrito.
+
+**Nunca usar rótulo interno solto.** Numeração de PR de um plano de trabalho, letra de achado de revisão, sigla de decisão, número de rodada — só existem dentro do documento que os definiu. Para quem lê o código ou o PR seis meses depois, são ruído que obriga a caçar o significado num arquivo que talvez nem esteja no repositório.
+
+A referência tem de carregar o **conteúdo**, não o ponteiro:
+
+| Não | Sim |
+|---|---|
+| `// gate conforme A5` | `// COR_RACA é categórico estático: os valores de domínio vivem em FatoValorDominio` |
+| "aplica S3 e S10" | "MODALIDADE resolve por candidato e processo; a restrição por oferta de curso é passo da classificação" |
+| "corrige o achado da rodada 10" | "trata o fato ausente como indeterminado em vez de falso" |
+| "depende do PR 3" | "depende do PR que generaliza a gramática de binding do fato derivado" |
+
+**Identificador rastreável é permitido quando a prosa já explica o assunto.** O token acrescenta rastreabilidade, não substitui o sentido. `ADR-0111`, `UNI-REQ-0078`, `Lei 12.711/2012`, `#927` e `arquivo:linha` são legítimos **desde que** a frase continue compreensível se o leitor ignorar o token:
+
+- ✅ `// Pares de elegibilidade e opt-in do formulário de cotas (UNI-REQ-0078)`
+- ✅ "a imutabilidade de código de fato fixada na ADR-0111"
+- ❌ `// conforme UNI-REQ-0078` — sem a prosa, o token é a única informação
+
+Vale também para **títulos de seção** em PR e issue: nomear pelo assunto, não pelo rótulo.
+
+A regra é a mesma que proíbe citar ferramenta de IA ou processo de revisão em código-fonte: o artefato registra o **porquê técnico ou de negócio**, nunca o caminho burocrático que levou até ele.
+
 ## Idioma
 
 - Documentação e strings user-facing em **português do Brasil**

--- a/docs/adrs/0111-vocabulario-fechado-de-fatos-do-candidato.md
+++ b/docs/adrs/0111-vocabulario-fechado-de-fatos-do-candidato.md
@@ -386,3 +386,116 @@ os protege.
 - RN08 (congelamento de parâmetros por processo).
 - Lei 12.711/2012 arts. 1º e 3º (red. Lei 14.723/2023), Lei 13.409/2016,
   Lei 13.146/2015, Lei 10.741/2003 art. 27, LGPD (Lei 13.709/2018) art. 5º, II.
+
+## Emenda 1 (2026-07-22) — operadores de exclusão, semântica sobre fato multivalorado e ordem canônica
+
+Esta emenda reconcilia a ADR com o código que a implementa. Os operadores de exclusão `DIFERENTE` e
+`NAO_EM` entraram no validador e no avaliador de predicado depois que esta ADR foi aceita, e a matriz
+acima ficou para trás. A emenda promove a texto de decisão o que hoje só existe em implementação e
+teste, e corrige quatro afirmações desta ADR que o código contradiz.
+
+**Trechos substituídos.** A tabela da seção "Matriz de compatibilidade operador × domínio" é
+substituída por 1.1. A frase "A lista de `EM` nunca é vazia", na seção "Cardinalidade e átomo canônico
+do predicado", é substituída por 1.3. A forma do valor booleano é corrigida em 1.1. A contagem de fatos
+é corrigida em 1.5. O restante da ADR permanece vigente sem alteração.
+
+### 1.1 — Matriz de compatibilidade operador × domínio
+
+| Domínio | Operadores aceitos | Forma do valor |
+|---|---|---|
+| `Booleano` | `IGUAL`, `DIFERENTE` | booleano JSON (`true`/`false`) |
+| `Numerico` | `IGUAL`, `DIFERENTE`, `MAIOR_IGUAL`, `MENOR_IGUAL` | número JSON **inteiro** — decimal é rejeitado |
+| `Categorico` (estático ou de escopo-processo) | `IGUAL`, `DIFERENTE`, `EM`, `NAO_EM` | `IGUAL`/`DIFERENTE`: um código do domínio; `EM`/`NAO_EM`: lista de códigos do domínio |
+
+A regra que gera a tabela: **`DIFERENTE` acompanha `IGUAL` em todo domínio onde `IGUAL` vale** —
+inclusive booleano e numérico —, e **`NAO_EM` acompanha `EM`**, valendo portanto só nos dois ramos
+categóricos, já que booleano e numérico nunca admitiram `EM`. A forma do valor de um operador negativo
+é a mesma do positivo que ele nega: escalar para `DIFERENTE`, lista para `NAO_EM`.
+
+A forma do valor booleano é o **booleano JSON**, não os tokens textuais `sim`/`não` que a tabela
+original registrava; `sim`/`não` é vocabulário de apresentação ao candidato, e não participa nem do
+predicado configurado nem da canonicalização — que também usam o booleano JSON. A restrição de que numérico é inteiro e rejeita decimal
+permanece, e passa a valer também para `DIFERENTE`.
+
+### 1.2 — Semântica dos operadores sobre fato multivalorado
+
+A seção "Cardinalidade e átomo canônico do predicado" define `IGUAL` e `EM` sobre fato multivalorado
+(`MODALIDADE`, `CONDICAO_ATENDIMENTO`). Os negativos completam a tabela e são a **negação lógica** do
+positivo correspondente, não operadores com regra própria:
+
+| Operador | Fato escalar | Fato multivalorado |
+|---|---|---|
+| `IGUAL X` | o valor é `X` | `X` pertence ao conjunto do candidato |
+| `DIFERENTE X` | o valor não é `X` | **nenhum** elemento do conjunto é `X` |
+| `EM [..]` | o valor está na lista | a interseção com a lista não é vazia |
+| `NAO_EM [..]` | o valor não está na lista | a interseção com a lista **é vazia** |
+
+A negação só se aplica quando o fato está **resolvido**. Fato ausente ou nulo avalia como
+*indeterminado*, e **indeterminado nunca inverte para verdadeiro** — a ausência tem precedência sobre a
+negação. Sem essa precedência, um predicado negativo passaria a ser satisfeito justamente pelos
+candidatos sobre os quais nada se sabe, que é o oposto do comportamento seguro.
+
+A incoerência de tipo entre o valor resolvido e o configurado tem tratamento **diferente** conforme a
+cardinalidade, e a diferença é deliberada:
+
+- No fato **escalar**, tipo incoerente é *indeterminado* — o predicado não sabe comparar aquilo, e
+  responder "falso" confundiria "resolvido e diferente" com "resolvido em forma que não sei comparar".
+- No fato **multivalorado**, a comparação é de pertinência elemento a elemento: um elemento de tipo
+  diferente simplesmente **não é igual**, e não contamina o conjunto. Um `DIFERENTE` sobre conjunto
+  cujos elementos são todos de outro tipo resolve *verdadeiro* — corretamente, porque de fato nenhum
+  elemento é igual ao valor configurado.
+
+### 1.3 — Lista vazia em `EM`/`NAO_EM` é aceita na forma e decidível na avaliação
+
+Esta ADR afirmava que "a lista de `EM` nunca é vazia". **Não é o caso**, e a emenda corrige: a factory
+do átomo aceita `EM []` e `NAO_EM []` como forma válida. A validação de forma não é o lugar de recusar
+a lista vazia, porque a lista pode chegar vazia legitimamente de uma projeção que não selecionou nada,
+e a avaliação é decidível sem ambiguidade.
+
+Sobre um fato **resolvido**, o resultado segue da definição de interseção:
+
+- `EM []` → **falso**: a interseção com o conjunto vazio é sempre vazia.
+- `NAO_EM []` → **verdadeiro**: nada pertence ao conjunto vazio. É verdade vácua, não caso especial.
+
+Sobre um fato **não resolvido**, ambos continuam *indeterminado*: a regra de precedência da ausência,
+fixada em 1.2, prevalece sobre a semântica de lista vazia.
+
+### 1.4 — Ordem canônica dos operadores
+
+A canonicalização do envelope de publicação ordena os átomos de uma cláusula, e essa ordem entra no
+hash congelado por RN08 — portanto precisa de **fonte única e declarada**. A ordem canônica dos
+operadores é a **ordinal do seu código textual**:
+
+```text
+DIFERENTE < EM < IGUAL < MAIOR_IGUAL < MENOR_IGUAL < NAO_EM
+```
+
+Ela não é uma regra própria de operador: **decorre** da regra geral da ADR-0109 de ordenar toda coleção
+sem chave de negócio natural pela própria serialização canônica do item. O átomo canônico é
+`{fato, operador, valor}` com chaves ordenadas, e a comparação é ordinal sobre o texto dessa
+serialização — de modo que recai primeiro sobre o fato e, no desempate, sobre o código textual do
+operador. Nenhuma tabela de precedência participa disso, e é assim que o canonicalizador se comporta
+hoje.
+
+Duas fontes rivais ficam explicitamente **descartadas** como critério de ordenação:
+
+- **A numeração do enum `Operador`** é identidade de persistência e reflete a cronologia em que os
+  operadores foram introduzidos, não precedência. Ordenar por valor numérico produziria outra ordem, e
+  renumerar o enum para alinhá-lo reescreveria valores já persistidos. A numeração **nunca** é peso de
+  ordenação.
+- **Uma ordem semântica** que agrupasse cada operador com a sua negação
+  (`IGUAL < DIFERENTE < EM < NAO_EM < MAIOR_IGUAL < MENOR_IGUAL`) seria mais legível para quem audita
+  um envelope, mas exigiria uma tabela de precedência específica de operador, criando exceção à regra
+  uniforme de canonicalização por conteúdo e um segundo lugar a manter em sincronia com o enum.
+
+A ordem só é observável quando dois átomos sobre o **mesmo fato** coexistem numa cláusula. Ela é
+critério de determinismo, não de semântica: o que o congelamento exige dela é que seja total e estável,
+não que exprima parentesco entre operadores.
+
+### 1.5 — Correção da contagem de fatos do vocabulário
+
+Esta ADR descreve "o vocabulário (nove fatos)". O catálogo semeado tem hoje **dezessete** fatos: os
+nove originais, os dois acrescentados ao refinar origem e binding (`NACIONALIDADE` e
+`TIPO_DEFICIENCIA`) e os seis da coleta de fatos de cota. A tabela dos nove permanece válida como
+registro do que esta decisão semeou; a contagem total vive no seed, que é a fonte única, e não deve ser
+repetida como número fixo em texto de ADR.

--- a/docs/adrs/0116-origem-ponto-resolucao-binding-fato-valor-dominio.md
+++ b/docs/adrs/0116-origem-ponto-resolucao-binding-fato-valor-dominio.md
@@ -167,3 +167,138 @@ mesmo mecanismo de `OfertaAtendimentoEspecializado`/`OfertaTipoDeficiencia`).
 - ADR-0061 (snapshot-copy cross-módulo).
 - Change OpenSpec `documentos-exigidos-cobertura-editais`, Story
   [#917](https://github.com/unifesspa-edu-br/uniplus-api/issues/917).
+
+## Emenda 1 (2026-07-22) — `MODALIDADE` passa a derivado e o binding admite mais de um prefixo por origem
+
+Esta emenda registra decisões **prospectivas**: o código ainda classifica `MODALIDADE` como `Declarado`
+com binding `CAMPO_INSCRICAO:MODALIDADE`, e a factory de `FatoCandidato` ainda aceita um único prefixo
+por origem. A emenda é pré-requisito das stories que implementam a derivação — decide antes, para que o
+código não nasça contradizendo a decisão registrada.
+
+**Trechos substituídos.** A tabela de origem dos fatos, na seção "Resultado da decisão", passa a
+classificar `MODALIDADE` como `Derivado` (1.1). A gramática de binding da mesma seção é substituída por
+1.2. Na ADR-0111, o parágrafo que atribui ao eixo de origem a sustentação da invariante "um fato
+derivado não é insumo de si mesmo nem de um gatilho avaliado antes da etapa que o produz" é substituído
+por 1.4. As demais decisões de ambas permanecem vigentes.
+
+### 1.1 — `MODALIDADE` passa de `Declarado` a `Derivado`, mantendo o código
+
+O desenho da coleta de fatos do candidato mostrou que `MODALIDADE` não é resposta do candidato: ele
+declara fatos (cor/raça, egresso de escola pública, deficiência, renda) e manifesta opt-ins de
+concorrência, e o **conjunto de modalidades resulta** da avaliação dessas declarações contra as regras
+congeladas do processo. Mantê-la como `Declarado` obrigaria a tela a perguntar "em qual modalidade você
+concorre?" — pergunta que a legislação de ações afirmativas não delega ao candidato, e que produziria
+inscrição inválida sempre que a resposta divergisse dos fatos declarados.
+
+`MODALIDADE` passa a `Derivado` mantendo o mesmo código — sem `MODALIDADE_V2` nem código novo. Isso
+exige reconciliar a regra de imutabilidade da ADR-0111, que declara `Codigo`, `Dominio`, `Origem` e
+`Cardinalidade` imutáveis **desde a semeadura**, exigindo código novo para mudança incompatível.
+
+**A emenda revoga esse marco e o substitui por outro:** os quatro eixos tornam-se imutáveis **a partir
+da primeira publicação de um processo seletivo que cite o fato**. Não é releitura da regra antiga — é
+troca deliberada, e vale a pena declarar por que.
+
+A regra existe para uma finalidade única e declarada na própria ADR-0111: proteger **predicado já
+publicado**, que carrega o código por valor e seria reinterpretado com outra semântica se o significado
+do código mudasse sob ele. Não existe predicado publicado — o sistema está em pré-produção e o
+congelamento só ocorre no ato de publicar, o que nunca ocorreu. Não há passado a preservar, e criar um
+código novo apenas para satisfazer a letra da regra deixaria `MODALIDADE` como lixo permanente no
+vocabulário, com um sucessor idêntico ao lado. Depois da primeira publicação, a regra da ADR-0111 volta
+a valer integralmente, incluindo a exigência de código novo para mudança incompatível.
+
+O marco **não exige mecanismo em runtime**, e não é omissão. A entidade `FatoCandidato` já é imutável
+nesses eixos por construção (propriedades sem mutador público), e ela continua assim: a reclassificação
+de um fato não acontece por chamada de domínio, mas por alteração do seed e migration — operação de
+desenvolvimento, sujeita a revisão de PR. O marco governa **o que um PR pode fazer**, e é aí que ele é
+verificável: enquanto não houver publicação, a reclassificação é legítima; depois, o PR que a tentasse
+estaria violando decisão registrada.
+
+A reclassificação não altera o avaliador — ver 1.4.
+
+### 1.2 — O mapa origem → prefixo de binding deixa de ser bijeção
+
+A gramática fixada por esta ADR associa **exatamente um** prefixo a cada origem
+(`Derivado`→`ATRIBUTO_CANDIDATO:`, `Declarado`→`CAMPO_INSCRICAO:`, `Integracao`→`INTEGRACAO:`), e a
+factory recusa qualquer outro. É estreito demais para `Derivado`, que passa a ter **dois mecanismos
+distintos** de produção de valor:
+
+| Origem | Prefixos aceitos | Referência |
+|---|---|---|
+| `Derivado` | `ATRIBUTO_CANDIDATO:` | atributo do candidato do qual o valor é computado — o mecanismo de `FAIXA_ETARIA` e `RENDA_PER_CAPITA` |
+| `Derivado` | `REGRA_DERIVACAO:` | código do próprio fato, cuja regra de derivação vive na configuração congelada do processo |
+| `Declarado` | `CAMPO_INSCRICAO:` | campo do formulário de inscrição |
+| `Integracao` | `INTEGRACAO:` | sistema externo de origem |
+
+`MODALIDADE` passa a `REGRA_DERIVACAO:MODALIDADE`.
+
+A divisão de responsabilidade que isso expressa: **o catálogo de fatos é global e diz o mecanismo; a
+configuração do processo diz o conteúdo.** A matriz de regras que decide quais modalidades um perfil
+alcança é parâmetro de edital, congelado por RN08 junto com o resto da configuração, não entrada de um
+catálogo compartilhado por todos os processos. Um binding que apontasse para a matriz tornaria o
+catálogo global dependente de configuração por edital; apontar para o **código do fato** mantém a
+referência estável e resolve a matriz onde ela de fato vive.
+
+A validação continua recusando prefixo incoerente com a origem — `REGRA_DERIVACAO:` em fato `Declarado`
+ou `Integracao` é recusado como sempre foi. O que muda é que a coerência passa a ser verificada contra
+um **conjunto** de prefixos aceitos por origem, e a mensagem de erro deixa de anunciar um prefixo único
+como o esperado.
+
+Não há restrição declarativa de banco a ajustar: os CHECKs de `rol_de_fatos_candidato` cobrem
+cardinalidade, domínio, origem e coerência de valores de domínio — o binding é validado no agregado.
+
+### 1.3 — `AC_PCD` é a identidade da modalidade de pessoa com deficiência fora da reserva federal
+
+A modalidade de pessoa com deficiência que concorre fora da reserva da Lei 12.711/2012 tem **`AC_PCD`**
+como código canônico. O termo `V`, usado nos editais, é rótulo de apresentação e vive na `Descricao` da
+modalidade cadastrada ("Ampla Concorrência – Pessoa com Deficiência (V)").
+
+**Não haverá alias.** O formato de `CodigoModalidade` aceita `V` como código sintaticamente válido, e
+continuará aceitando — a recusa não é sintática. Ela vem do **domínio congelado da configuração**: um
+código de modalidade que não pertença ao conjunto ofertado e congelado naquele processo é recusado com
+erro nomeado, nunca traduzido para o código canônico. É a mesma disciplina que o decodificador de wire
+aplica: recusar, jamais normalizar. Um tradutor de alias criaria duas grafias para a mesma identidade,
+e a que entrasse no envelope congelado dependeria de qual caminho de código a produziu.
+
+Isso vale para todo código de modalidade, e não introduz lista global fixa: o domínio de `MODALIDADE`
+continua sendo de escopo-processo, resolvido contra a oferta congelada, como a ADR-0111 fixa.
+
+### 1.4 — Quem faz cumprir a ordem de resolução é o ponto de resolução, não a origem
+
+A ADR-0111 atribui ao eixo de origem a sustentação da invariante de que um fato derivado não é insumo
+de si mesmo nem de um gatilho avaliado antes da etapa que o produz. Essa atribuição fica **superada**:
+quem faz cumprir a ordem temporal é o `PontoResolucao` introduzido por esta ADR, comparado contra a
+fase da exigência pela tabela de precedência entre fases — e é assim que o código a implementa.
+
+A origem passa a ser **puramente descritiva**: diz de onde o valor vem e qual binding é coerente, e
+**nunca** entra na avaliação de um predicado. É por isso que reclassificar `MODALIDADE` de `Declarado`
+para `Derivado` não muda nenhum resultado de avaliação — só muda o mecanismo pelo qual o valor passa a
+ser produzido.
+
+A invariante de que um fato derivado não é insumo de si mesmo continua valendo, mas por outro
+mecanismo: a lista **explícita** de dependências do fato derivado, validada como grafo acíclico no
+cadastro e congelada na publicação.
+
+### 1.5 — O que a regra de derivação precisa ser para que este binding signifique algo
+
+`REGRA_DERIVACAO:{codigoDoFato}` só é uma promessa cumprida se a regra apontada for **determinística e
+congelável**. Hoje a configuração de modalidade guarda critérios como lista de texto livre, que não
+serve: texto livre não é avaliável, não tem vocabulário fechado e não pode ser congelado com garantia
+de que a mesma entrada produz a mesma saída.
+
+Esta ADR fixa, portanto, o que a story de implementação deve entregar junto com o prefixo, sob pena de
+o binding ficar decorativo — exatamente o defeito que a ADR-0111 existe para impedir:
+
+1. **Regra tipada** sobre o vocabulário fechado de fatos, na forma `{quando, contribui}`, em que
+   `quando` é um predicado em forma normal disjuntiva de átomos completos, sem referência de uma regra
+   a outra. Regra incondicional é a disjunção **vazia**, não um literal textual.
+2. **Agregação declarada**: o valor do fato derivado é a **união** das contribuições de todas as regras
+   cujo `quando` é verdadeiro. A união é idempotente e comutativa, o que torna o resultado independente
+   da ordem de avaliação; nenhuma regra aplicável produz o conjunto vazio.
+3. **Dependências explícitas**, não inferidas do texto da regra — é o que alimenta o grafo acíclico
+   de 1.4.
+4. **Recorte pela oferta congelada** do processo como último passo, e não como propriedade da regra.
+5. **Congelamento**: a regra entra no snapshot da publicação junto com o vocabulário e a versão do
+   interpretador que a avalia, de modo que uma reavaliação futura produza o mesmo resultado (RN08).
+
+Sem esses cinco elementos, o binding não deve ser adotado — é preferível manter o fato como
+`Declarado` a registrar uma origem que o código não sustenta.

--- a/docs/adrs/README.md
+++ b/docs/adrs/README.md
@@ -139,12 +139,12 @@ npx markdownlint-cli2 'docs/adrs/**/*.md'
 | [0108](0108-registro-do-ato-por-mensagem-duravel.md) | O domínio registra o ato por mensagem durável, não por chamada síncrona (supersede a 0106 no mecanismo) | accepted | 2026-07-12 |
 | [0109](0109-envelope-canonico-v2-do-congelamento.md) | Contrato do envelope canônico do congelamento (v2) | accepted | 2026-07-13 |
 | [0110](0110-retificacao-como-sessao-editorial.md) | A retificação é uma sessão editorial sobre a configuração, não um estado do certame | accepted | 2026-07-13 |
-| [0111](0111-vocabulario-fechado-de-fatos-do-candidato.md) | Vocabulário fechado de fatos do candidato (catálogo seed-governado em Configuração, identidade imutável) | accepted | 2026-07-15 |
+| [0111](0111-vocabulario-fechado-de-fatos-do-candidato.md) | Vocabulário fechado de fatos do candidato (catálogo seed-governado em Configuração, identidade imutável) — emendada em 2026-07-22: operadores de exclusão, semântica sobre fato multivalorado e ordem canônica | accepted | 2026-07-15 |
 | [0112](0112-fronteira-append-only-do-catalogo-de-regras.md) | Fronteira do append-only na correção do catálogo de regras (substituível enquanto nada congelado referenciar) | accepted | 2026-07-14 |
 | [0113](0113-fase-x-etapa-eixo-temporal-e-eixo-de-pontuacao.md) | Fase × Etapa — eixo temporal (cronograma) e eixo de pontuação são agregados distintos, ligados por bicondicional; precedência entre fases é dado de cadastro | accepted | 2026-07-15 |
 | [0114](0114-ruleset-conformidade-legal-processo-seletivo.md) | Ruleset de conformidade legal do processo seletivo | accepted | 2026-07-15 |
 | [0115](0115-quadro-de-vagas-materializacao-derivada-congelamento-atomico.md) | O quadro de vagas é output derivado da configuração de distribuição, materializado e congelado na mesma operação que os insumos | accepted | 2026-07-16 |
-| [0116](0116-origem-ponto-resolucao-binding-fato-valor-dominio.md) | Fato multi-fonte: origem (renomeia/reclassifica `Natureza`), ponto de resolução, binding e `FatoValorDominio` — refina a ADR-0111 | accepted | 2026-07-19 |
+| [0116](0116-origem-ponto-resolucao-binding-fato-valor-dominio.md) | Fato multi-fonte: origem (renomeia/reclassifica `Natureza`), ponto de resolução, binding e `FatoValorDominio` — refina a ADR-0111; emendada em 2026-07-22: `MODALIDADE` passa a derivado e o binding admite mais de um prefixo por origem | accepted | 2026-07-19 |
 
 > **Nota de numeração:** a sequência de `0001` a `0116` está completa, sem lacunas. Ao adicionar uma ADR nova, use `0117+`.
 

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Domain/Enums/Operador.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Domain/Enums/Operador.cs
@@ -8,11 +8,19 @@ namespace Unifesspa.UniPlus.Selecao.Domain.Enums;
 /// design: os seis operadores espelham exatamente a matriz operador ×
 /// domínio da ADR-0111.
 /// </summary>
+/// <remarks>
+/// A numeração dos membros é identidade de persistência e reflete a ordem em que os
+/// operadores foram introduzidos — não é peso de ordenação. A ordem canônica que entra
+/// no hash de congelamento é a ordinal do código textual, e decorre de a canonicalização
+/// ordenar cada átomo pela sua própria serialização canônica; ordenar por valor numérico
+/// produziria outra ordem. O código textual de wire vive em
+/// <see cref="OperadorCodigo"/>, nunca em <c>enum.ToString()</c>.
+/// </remarks>
 public enum Operador
 {
     Nenhuma = 0,
 
-    /// <summary>Igualdade — único operador aceito para domínio booleano; um dos dois para categórico.</summary>
+    /// <summary>Igualdade — aceito nos três domínios.</summary>
     Igual = 1,
 
     /// <summary>Pertencimento a uma lista — só aceito para domínio categórico.</summary>
@@ -24,9 +32,16 @@ public enum Operador
     /// <summary>Menor ou igual — só aceito para domínio numérico.</summary>
     MenorIgual = 4,
 
-    /// <summary>Negação de <see cref="Igual"/> (Story #916) — aceito em todo domínio onde <see cref="Igual"/> vale.</summary>
+    /// <summary>
+    /// Negação de <see cref="Igual"/> (Story #916) — aceito em todo domínio onde
+    /// <see cref="Igual"/> vale. Sobre fato multivalorado significa que nenhum elemento do
+    /// conjunto é igual ao valor configurado.
+    /// </summary>
     Diferente = 5,
 
-    /// <summary>Negação de <see cref="Em"/> (Story #916) — só aceito onde <see cref="Em"/> vale.</summary>
+    /// <summary>
+    /// Negação de <see cref="Em"/> (Story #916) — só aceito onde <see cref="Em"/> vale.
+    /// Sobre fato multivalorado significa interseção vazia com a lista configurada.
+    /// </summary>
     NaoEm = 6,
 }


### PR DESCRIPTION
## Contexto

O grafo de pré-condições da coleta de fatos do candidato precisa expressar o gate do bloco quilombola como `COR_RACA DIFERENTE INDIGENA` — na forma negativa, porque a lista de cores que *não* são indígena mudaria a cada valor acrescentado ao domínio. Só que a matriz operador × domínio da ADR-0111 admite apenas `IGUAL` e `EM`.

Os operadores de exclusão **já estão implementados** desde a Story #916 (`PredicadoDnfValidador.ValidarOperador`, `ClausulaDnf.AvaliarCondicao`). A ADR é que ficou para trás. Implementar o grafo antes de emendá-la significaria escrever código conforme uma decisão que o próprio código já contradiz — por isso esta emenda precede toda a implementação da change.

Docs-only, mais um XML-doc. Nenhuma mudança de comportamento.

## O que muda

### Vocabulário de fatos — matriz, semântica e ordem canônica

Traz a matriz para o estado do código (`DIFERENTE` acompanha `IGUAL` em todo domínio onde ele vale; `NAO_EM` acompanha `EM` nos ramos categóricos) e promove a texto de decisão três semânticas que só existiam em implementação e teste:

- **negativos sobre fato multivalorado** — `DIFERENTE X` é "nenhum elemento é `X`"; `NAO_EM [..]` é interseção vazia;
- **precedência da ausência sobre a negação** — indeterminado nunca inverte para verdadeiro, senão um predicado negativo passaria a ser satisfeito justamente pelos candidatos sobre os quais nada se sabe;
- **lista vazia** — `EM []` é falso, `NAO_EM []` é verdade vácua; ambos seguem indeterminados sobre fato não resolvido.

**Ordem canônica.** Entra no hash congelado, então não pode ter duas fontes. A eleita é a **ordinal do código textual** (`DIFERENTE < EM < IGUAL < MAIOR_IGUAL < MENOR_IGUAL < NAO_EM`), que não é regra própria de operador: decorre da regra geral de ordenar coleção sem chave de negócio pela própria serialização canônica do item — exatamente o que `SnapshotPublicacaoCanonicalizer.OrdenarPorConteudo` já faz hoje. A numeração do enum fica declarada irrelevante para ordenação, e a alternativa semântica (cada operador ao lado da sua negação) fica descartada por exigir tabela de precedência própria, criando exceção à regra uniforme de canonicalização.

**Duas correções de fato**, apuradas contra o código durante a revisão: a forma do valor booleano é booleano JSON, não os tokens `sim`/`não`; e a lista de `EM` **pode** ser vazia — `CondicaoDnf.Criar` aceita, com teste explícito, e a ADR afirmava o contrário.

### Origem, binding e derivação de modalidade

Emenda **prospectiva** — o código ainda classifica `MODALIDADE` como declarado, com binding para campo de inscrição. Ela decide antes para que a implementação não nasça contradizendo decisão registrada.

- **`MODALIDADE` passa a derivado, mantendo o código.** A modalidade não é resposta do candidato: ele declara fatos e manifesta opt-ins, e o conjunto resulta da avaliação contra as regras congeladas. Mantê-la declarada obrigaria a tela a perguntar em qual modalidade o candidato concorre — pergunta que a legislação de ações afirmativas não lhe delega.
- **Marco de imutabilidade trocado**, de "desde a semeadura" para "a partir da primeira publicação que cite o fato". Troca deliberada, não releitura: a regra existe para proteger predicado congelado, não existe nenhum, e um código sucessor idêntico deixaria lixo permanente no vocabulário. O marco governa o que um PR pode fazer; a entidade segue imutável por construção.
- **Binding deixa de ser bijeção** — origem derivada passa a aceitar tanto `ATRIBUTO_CANDIDATO:` quanto `REGRA_DERIVACAO:`. O catálogo é global e diz o mecanismo; a configuração do edital diz o conteúdo.
- **O que a regra de derivação precisa ser** para o binding não ficar decorativo: regra tipada sobre o vocabulário fechado, agregação por união, dependências explícitas, recorte pela oferta e congelamento com a versão do interpretador. Sem isso, é preferível manter o fato como declarado.
- **Ordem de resolução é do ponto de resolução, não da origem** — que passa a ser puramente descritiva. É como o código já se comporta.
- **`AC_PCD` é a identidade** da modalidade de pessoa com deficiência fora da reserva federal; `V` é rótulo de apresentação. Sem alias: duas grafias para a mesma identidade tornariam o envelope congelado dependente do caminho de código que o produziu. A recusa não é sintática — `CodigoModalidade` aceita `V` — e sim do domínio congelado da configuração.

### Convenção de escrita

Rótulo de documento de trabalho não sobrevive ao contexto em que foi escrito. A convenção fixa que a referência carrega o **conteúdo**, não o ponteiro, em comentário de código, descrição de PR, corpo de issue e mensagem de commit — admitindo identificador rastreável desde que a frase siga compreensível sem ele. Vale para todo PR do projeto, por isso vive junto das regras de commit.

## Validação

```
tools/adr-lint/validate.sh          → 116 ADRs, 0 erros; markdownlint 0 erros
dotnet build UniPlus.slnx           → 0 erros, 0 avisos
dotnet test UniPlus.slnx            → 3.322 testes, 0 falhas (suíte completa)
dotnet format --verify-no-changes   → 0 diagnósticos (comando exato do CI)
```

## Fora de escopo

A implementação em si. O prefixo `REGRA_DERIVACAO:` na factory de `FatoCandidato`, o seed de modalidades, o motor de derivação e a materialização da tabela de pré-condições vêm nos PRs seguintes desta change.

Refs #926
Refs #927
