### PR TITLE
feat(selecao): distingue fato não-aplicável de fato indeterminado na avaliação de predicado

### DIFF
--- a/src/selecao/Unifesspa.UniPlus.Selecao.Domain/Entities/DocumentoExigido.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Domain/Entities/DocumentoExigido.cs
@@ -321,7 +321,7 @@ public sealed class DocumentoExigido : EntityBase
     /// — por um fato sintético fixo, ex. só <c>MODALIDADE</c>, para provar cobertura
     /// incondicional de uma modalidade inteira).
     /// </summary>
-    public Ternario AplicavelPara(IReadOnlyDictionary<string, JsonElement> fatosResolvidos)
+    public Ternario AplicavelPara(IReadOnlyDictionary<string, FatoResolvido> fatosResolvidos)
     {
         ArgumentNullException.ThrowIfNull(fatosResolvidos);
 

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Domain/Enums/EstadoAtomo.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Domain/Enums/EstadoAtomo.cs
@@ -1,0 +1,47 @@
+namespace Unifesspa.UniPlus.Selecao.Domain.Enums;
+
+/// <summary>
+/// Resultado da avaliação de um <b>átomo</b> — uma <see cref="ValueObjects.CondicaoDnf"/>
+/// isolada — contra os fatos de um candidato (Story #926). Tem quatro estados,
+/// um a mais que <see cref="Ternario"/>, porque o átomo é o único ponto onde a
+/// inaplicabilidade do fato ainda é distinguível.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Os quatro estados existem <b>apenas no átomo</b>. Numa cláusula <c>E</c>,
+/// <see cref="NaoAplicavel"/> colapsa como <see cref="Ternario.Falso"/> resolvido, e a
+/// cláusula continua ternária; o predicado em forma normal disjuntiva também.
+/// Não há motor duplo — só o átomo enxerga o quarto estado.
+/// </para>
+/// <para>
+/// O colapso não perde informação onde ela importa: quem consome o veredicto
+/// distingue "não exigido em definitivo" de "pendente" pelo resultado do
+/// predicado inteiro — <see cref="Ternario.Falso"/> versus
+/// <see cref="Ternario.Indeterminado"/> —, e é o átomo
+/// <see cref="NaoAplicavel"/> que garante que o primeiro seja alcançado em vez do
+/// segundo.
+/// </para>
+/// <para>
+/// <see cref="Indeterminado"/> é <c>0</c> pelo mesmo motivo de
+/// <see cref="Ternario"/>: o zero-default tem de ser o estado fail-closed.
+/// </para>
+/// </remarks>
+public enum EstadoAtomo
+{
+    /// <summary>O fato citado se aplica, mas não se sabe o seu valor — o átomo fica pendente.</summary>
+    Indeterminado = 0,
+
+    /// <summary>O fato está resolvido e satisfaz o operador.</summary>
+    Verdadeiro = 1,
+
+    /// <summary>O fato está resolvido e não satisfaz o operador.</summary>
+    Falso = 2,
+
+    /// <summary>
+    /// O fato citado não se aplica ao candidato. Vale para <b>todo</b> operador,
+    /// inclusive os de exclusão: a negação inverte um valor, nunca a
+    /// inaplicabilidade. Um átomo <c>CONCORRER_PCD DIFERENTE SIM</c> sobre um fato
+    /// inaplicável é inaplicável — não verdadeiro.
+    /// </summary>
+    NaoAplicavel = 3,
+}

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Domain/Enums/EstadoFato.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Domain/Enums/EstadoFato.cs
@@ -1,0 +1,37 @@
+namespace Unifesspa.UniPlus.Selecao.Domain.Enums;
+
+/// <summary>
+/// Estado de resolução de um fato do candidato (Story #926, ADR-0111). É o
+/// discriminador que distingue "não se aplica a este candidato" de "ainda não se
+/// sabe" — distinção que o valor sozinho nunca carrega, porque ambos os casos
+/// chegariam como ausência de valor.
+/// </summary>
+/// <remarks>
+/// <para>
+/// A distinção é material: <see cref="NaoAplicavel"/> é uma resposta
+/// <b>definitiva</b> — a pré-condição do campo é falsa, o campo nem foi
+/// apresentado ao candidato, e uma exigência que dependa dele fica dispensada.
+/// <see cref="Indeterminado"/> é <b>pendência</b> — o campo se aplica, o
+/// candidato ainda não respondeu, e a exigência permanece em aberto. Colapsar os
+/// dois dispensaria exigência sobre a qual nada se sabe.
+/// </para>
+/// <para>
+/// <see cref="Indeterminado"/> é <c>0</c> pelo mesmo motivo de
+/// <see cref="Ternario"/>: o zero-default de C# tem de ser o estado fail-closed.
+/// Um campo esquecido nunca é lido como resolvido nem como inaplicável.
+/// </para>
+/// </remarks>
+public enum EstadoFato
+{
+    /// <summary>O fato se aplica, mas o seu valor ainda não é conhecido — pendência.</summary>
+    Indeterminado = 0,
+
+    /// <summary>
+    /// O fato não se aplica a este candidato porque a sua pré-condição é falsa.
+    /// É estado <b>resolvido</b>, não pendência: não há valor a esperar.
+    /// </summary>
+    NaoAplicavel = 1,
+
+    /// <summary>O fato se aplica e tem valor conhecido.</summary>
+    Resolvido = 2,
+}

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Domain/Services/AvaliadorConformidadeLegal.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Domain/Services/AvaliadorConformidadeLegal.cs
@@ -168,9 +168,13 @@ public static class AvaliadorConformidadeLegal
             return (true, null, null);
         }
 
-        Dictionary<string, JsonElement> fatoDaModalidade = new()
+        // Só MODALIDADE entra: na publicação não há candidato, e todo outro fato é
+        // legitimamente desconhecido. Ausência resolve INDETERMINADO, que aqui significa
+        // "cobertura não provada" — o que se quer. Materializá-los como NÃO_APLICÁVEL faria a
+        // cláusula colapsar em FALSO e afirmaria algo que não se sabe.
+        Dictionary<string, FatoResolvido> fatoDaModalidade = new(StringComparer.Ordinal)
         {
-            ["MODALIDADE"] = JsonSerializer.SerializeToElement(predicado.Modalidade),
+            ["MODALIDADE"] = FatoResolvido.Resolvido(JsonSerializer.SerializeToElement(predicado.Modalidade)),
         };
 
         // Achado de revisão (Story #554, PR #903): uma exigência que casa por tipo e cobre a

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Domain/Services/ResolvedorArvoreSatisfacao.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Domain/Services/ResolvedorArvoreSatisfacao.cs
@@ -47,7 +47,7 @@ public static class ResolvedorArvoreSatisfacao
 {
     public static Result<ResultadoResolucaoArvore> Resolver(
         ArvoreExigenciasCongelada? arvore,
-        IReadOnlyDictionary<string, JsonElement> fatosResolvidos,
+        IReadOnlyDictionary<string, FatoResolvido> fatosResolvidos,
         IReadOnlyDictionary<Guid, IReadOnlyList<ApresentacaoDocumento>> apresentacoesPorExigenciaId,
         IReadOnlyDictionary<TipoEntidade, IReadOnlyList<InstanciaEntidade>>? instanciasPorTipoEntidade = null)
     {
@@ -160,7 +160,7 @@ public static class ResolvedorArvoreSatisfacao
 
     private static EstadoSatisfacao ResolverNo(
         NoExigencia no,
-        IReadOnlyDictionary<string, JsonElement> fatos,
+        IReadOnlyDictionary<string, FatoResolvido> fatos,
         IReadOnlyDictionary<Guid, IReadOnlyList<ApresentacaoDocumento>> apresentacoes,
         IReadOnlyDictionary<TipoEntidade, IReadOnlyList<InstanciaEntidade>> instanciasPorTipoEntidade,
         Dictionary<Guid, EstadoSatisfacao> estados,
@@ -185,7 +185,7 @@ public static class ResolvedorArvoreSatisfacao
     private static EstadoSatisfacao ResolverNoRepetido(
         NoExigencia no,
         TipoEntidade tipoEntidade,
-        IReadOnlyDictionary<string, JsonElement> fatosCandidato,
+        IReadOnlyDictionary<string, FatoResolvido> fatosCandidato,
         IReadOnlyDictionary<Guid, IReadOnlyList<ApresentacaoDocumento>> apresentacoes,
         IReadOnlyDictionary<TipoEntidade, IReadOnlyList<InstanciaEntidade>> instanciasPorTipoEntidade,
         Dictionary<Guid, List<InstanciaResolvida>> instanciasResolvidasPorNo)
@@ -202,7 +202,7 @@ public static class ResolvedorArvoreSatisfacao
         List<InstanciaResolvida> resolvidas = [];
         foreach (InstanciaEntidade instancia in instancias)
         {
-            Dictionary<string, JsonElement> fatosDaInstancia = MesclarFatosDeEntidade(fatosCandidato, instancia.Atributos);
+            Dictionary<string, FatoResolvido> fatosDaInstancia = MesclarFatosDeEntidade(fatosCandidato, instancia.Atributos);
             IReadOnlyDictionary<Guid, IReadOnlyList<ApresentacaoDocumento>> apresentacoesDaInstancia =
                 FiltrarApresentacoesPorEntidade(apresentacoes, instancia.EntidadeId);
 
@@ -230,11 +230,11 @@ public static class ResolvedorArvoreSatisfacao
         return ResolverE([.. resolvidas.Select(static r => r.Estado)]);
     }
 
-    private static Dictionary<string, JsonElement> MesclarFatosDeEntidade(
-        IReadOnlyDictionary<string, JsonElement> fatosCandidato, IReadOnlyDictionary<string, JsonElement> atributosDaInstancia)
+    private static Dictionary<string, FatoResolvido> MesclarFatosDeEntidade(
+        IReadOnlyDictionary<string, FatoResolvido> fatosCandidato, IReadOnlyDictionary<string, FatoResolvido> atributosDaInstancia)
     {
-        Dictionary<string, JsonElement> mesclado = new(fatosCandidato, StringComparer.Ordinal);
-        foreach (KeyValuePair<string, JsonElement> atributo in atributosDaInstancia)
+        Dictionary<string, FatoResolvido> mesclado = new(fatosCandidato, StringComparer.Ordinal);
+        foreach (KeyValuePair<string, FatoResolvido> atributo in atributosDaInstancia)
         {
             mesclado[atributo.Key] = atributo.Value;
         }
@@ -260,7 +260,7 @@ public static class ResolvedorArvoreSatisfacao
 
     private static EstadoSatisfacao ResolverFolha(
         NoExigencia no,
-        IReadOnlyDictionary<string, JsonElement> fatos,
+        IReadOnlyDictionary<string, FatoResolvido> fatos,
         IReadOnlyDictionary<Guid, IReadOnlyList<ApresentacaoDocumento>> apresentacoes,
         Dictionary<Guid, StatusResolucaoExigencia> statusPorExigencia)
     {
@@ -318,7 +318,7 @@ public static class ResolvedorArvoreSatisfacao
 
     private static EstadoSatisfacao ResolverGrupo(
         NoExigencia no,
-        IReadOnlyDictionary<string, JsonElement> fatos,
+        IReadOnlyDictionary<string, FatoResolvido> fatos,
         IReadOnlyDictionary<Guid, IReadOnlyList<ApresentacaoDocumento>> apresentacoes,
         IReadOnlyDictionary<TipoEntidade, IReadOnlyList<InstanciaEntidade>> instanciasPorTipoEntidade,
         Dictionary<Guid, EstadoSatisfacao> estados,

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Domain/ValueObjects/ClausulaDnf.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Domain/ValueObjects/ClausulaDnf.cs
@@ -38,20 +38,27 @@ public sealed record ClausulaDnf
     /// <see cref="Ternario.Indeterminado"/> se qualquer uma avaliar indeterminada; senão
     /// <see cref="Ternario.Verdadeiro"/>.
     /// </summary>
-    public Ternario Avaliar(IReadOnlyDictionary<string, JsonElement> fatosResolvidos)
+    /// <remarks>
+    /// O átomo tem quatro estados, mas a cláusula continua ternária (Story #926):
+    /// <see cref="EstadoAtomo.NaoAplicavel"/> <b>colapsa como <see cref="Ternario.Falso"/>
+    /// resolvido</b> aqui. É o colapso que dá a resposta correta ao consumidor: um gatilho
+    /// que cita um fato inaplicável resolve falso — a exigência não se aplica, em definitivo —
+    /// em vez de ficar pendente esperando um valor que nunca virá.
+    /// </remarks>
+    public Ternario Avaliar(IReadOnlyDictionary<string, FatoResolvido> fatosResolvidos)
     {
         ArgumentNullException.ThrowIfNull(fatosResolvidos);
 
         bool algumaIndeterminada = false;
         foreach (CondicaoDnf condicao in Condicoes)
         {
-            Ternario resultado = AvaliarCondicao(condicao, fatosResolvidos);
-            if (resultado == Ternario.Falso)
+            EstadoAtomo resultado = AvaliarCondicao(condicao, fatosResolvidos);
+            if (resultado is EstadoAtomo.Falso or EstadoAtomo.NaoAplicavel)
             {
                 return Ternario.Falso;
             }
 
-            if (resultado == Ternario.Indeterminado)
+            if (resultado == EstadoAtomo.Indeterminado)
             {
                 algumaIndeterminada = true;
             }
@@ -61,23 +68,44 @@ public sealed record ClausulaDnf
     }
 
     /// <summary>
-    /// Avalia uma condição isolada. Um fato citado que não está resolvido — chave ausente de
-    /// <paramref name="fatosResolvidos"/>, ou presente com <see cref="JsonValueKind.Null"/>/
-    /// <see cref="JsonValueKind.Undefined"/> — nunca vira <see cref="Ternario.Falso"/>: é
-    /// sempre <see cref="Ternario.Indeterminado"/> (Story #916, fail-closed). O mesmo vale
-    /// para um valor resolvido de tipo incoerente com o operador (ex.: comparação numérica
-    /// sobre um valor que não é número) — nunca lança, sempre <see cref="Ternario.Indeterminado"/>.
-    /// <see cref="Operador.Diferente"/>/<see cref="Operador.NaoEm"/> são a negação lógica de
-    /// <see cref="Operador.Igual"/>/<see cref="Operador.Em"/> — a negação só se aplica quando o
-    /// fato está efetivamente resolvido e coerente; nunca inverte ausência/indeterminação para
-    /// <see cref="Ternario.Verdadeiro"/>.
+    /// Avalia um átomo isolado, propagando o estado do fato para <b>qualquer</b> operador.
     /// </summary>
-    private static Ternario AvaliarCondicao(CondicaoDnf condicao, IReadOnlyDictionary<string, JsonElement> fatosResolvidos)
+    /// <remarks>
+    /// <para>
+    /// Fato <see cref="EstadoFato.NaoAplicavel"/> dá átomo <see cref="EstadoAtomo.NaoAplicavel"/>,
+    /// e fato ausente do dicionário ou <see cref="EstadoFato.Indeterminado"/> dá átomo
+    /// <see cref="EstadoAtomo.Indeterminado"/> — em ambos os casos para todo operador, inclusive
+    /// <see cref="Operador.Diferente"/>/<see cref="Operador.NaoEm"/>. A negação inverte um
+    /// <b>valor</b>; sobre a inaplicabilidade ou sobre a ausência de informação não há o que
+    /// inverter, e inverter mesmo assim faria o predicado ser satisfeito justamente pelos
+    /// candidatos sobre os quais nada se sabe.
+    /// </para>
+    /// <para>
+    /// Um valor resolvido de tipo incoerente com o operador (ex.: comparação numérica sobre um
+    /// valor que não é número) também é <see cref="EstadoAtomo.Indeterminado"/> — nunca lança, e
+    /// nunca vira falso silencioso, que confundiria "resolvido diferente" com "resolvido em
+    /// forma que este predicado não sabe comparar".
+    /// </para>
+    /// </remarks>
+    private static EstadoAtomo AvaliarCondicao(CondicaoDnf condicao, IReadOnlyDictionary<string, FatoResolvido> fatosResolvidos)
     {
-        if (!fatosResolvidos.TryGetValue(condicao.Fato, out JsonElement valorCandidato)
-            || valorCandidato.ValueKind is JsonValueKind.Null or JsonValueKind.Undefined)
+        // O nulo é tratado como ausência em vez de estourar: um dicionário montado por um
+        // adaptador descuidado não deve derrubar a avaliação inteira, e "não sei" é a leitura
+        // conservadora de uma entrada sem conteúdo — nunca "não se aplica", que dispensaria a
+        // exigência por um defeito de montagem.
+        if (!fatosResolvidos.TryGetValue(condicao.Fato, out FatoResolvido? fato) || fato is null)
         {
-            return Ternario.Indeterminado;
+            return EstadoAtomo.Indeterminado;
+        }
+
+        if (fato.Estado == EstadoFato.NaoAplicavel)
+        {
+            return EstadoAtomo.NaoAplicavel;
+        }
+
+        if (fato.Estado != EstadoFato.Resolvido || fato.Valor is not { } valorCandidato)
+        {
+            return EstadoAtomo.Indeterminado;
         }
 
         // Diferente/NaoEm são avaliados como a negação de Igual/Em: o resultado base é
@@ -100,11 +128,24 @@ public sealed record ClausulaDnf
         bool negar = condicao.Operador is Operador.Diferente or Operador.NaoEm;
         if (!negar || resultadoBase == Ternario.Indeterminado)
         {
-            return resultadoBase;
+            return TernarioParaAtomo(resultadoBase);
         }
 
-        return resultadoBase == Ternario.Verdadeiro ? Ternario.Falso : Ternario.Verdadeiro;
+        return resultadoBase == Ternario.Verdadeiro ? EstadoAtomo.Falso : EstadoAtomo.Verdadeiro;
     }
+
+    /// <summary>
+    /// Converte o resultado da comparação de valores — que é ternária, porque
+    /// <see cref="EstadoAtomo.NaoAplicavel"/> já foi decidido antes de comparar valor algum —
+    /// para o estado do átomo.
+    /// </summary>
+    private static EstadoAtomo TernarioParaAtomo(Ternario resultado) => resultado switch
+    {
+        Ternario.Verdadeiro => EstadoAtomo.Verdadeiro,
+        Ternario.Falso => EstadoAtomo.Falso,
+        Ternario.Indeterminado => EstadoAtomo.Indeterminado,
+        _ => throw new ArgumentOutOfRangeException(nameof(resultado), resultado, "Resultado ternário desconhecido."),
+    };
 
     /// <summary>
     /// Avalia os operadores positivos (<see cref="Operador.Igual"/>/<see cref="Operador.Em"/>/

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Domain/ValueObjects/FatoResolvido.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Domain/ValueObjects/FatoResolvido.cs
@@ -1,0 +1,83 @@
+namespace Unifesspa.UniPlus.Selecao.Domain.ValueObjects;
+
+using System.Text.Json;
+
+using Unifesspa.UniPlus.Selecao.Domain.Enums;
+
+/// <summary>
+/// O estado de um fato do candidato no instante da avaliação (Story #926): o
+/// discriminador <see cref="Estado"/> mais o valor, quando há um.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Existe para que <c>valor = null</c> deixe de ser ambíguo. Um fato sem valor
+/// pode ser <see cref="EstadoFato.NaoAplicavel"/> — o campo nem foi apresentado —
+/// ou <see cref="EstadoFato.Indeterminado"/> — o campo se aplica e ainda não foi
+/// respondido. Os dois casos levam a decisões opostas sobre a exigência que
+/// depende do fato, então o estado é declarado, nunca inferido da ausência.
+/// </para>
+/// <para>
+/// As três factories são o único caminho de construção, e cada uma fixa a
+/// combinação válida: só <see cref="Resolvido"/> carrega valor, e ele nunca é
+/// <see cref="JsonValueKind.Null"/> nem <see cref="JsonValueKind.Undefined"/> —
+/// aceitar um desses reintroduziria pela porta dos fundos a ambiguidade que este
+/// tipo fecha.
+/// </para>
+/// </remarks>
+public sealed record FatoResolvido
+{
+    private static readonly FatoResolvido NaoAplicavelInstancia = new(EstadoFato.NaoAplicavel, valor: null);
+    private static readonly FatoResolvido IndeterminadoInstancia = new(EstadoFato.Indeterminado, valor: null);
+
+    private FatoResolvido(EstadoFato estado, JsonElement? valor)
+    {
+        Estado = estado;
+        Valor = valor;
+    }
+
+    public EstadoFato Estado { get; }
+
+    /// <summary>
+    /// O valor do fato — preenchido se, e somente se, <see cref="Estado"/> é
+    /// <see cref="EstadoFato.Resolvido"/>.
+    /// </summary>
+    public JsonElement? Valor { get; }
+
+    /// <summary>
+    /// O fato não se aplica ao candidato (pré-condição falsa). Estado resolvido e
+    /// definitivo: quem depende dele é dispensado, não fica pendente.
+    /// </summary>
+    public static FatoResolvido NaoAplicavel() => NaoAplicavelInstancia;
+
+    /// <summary>
+    /// O fato se aplica, mas o valor ainda não é conhecido. Quem depende dele fica
+    /// pendente (fail-closed).
+    /// </summary>
+    public static FatoResolvido Indeterminado() => IndeterminadoInstancia;
+
+    /// <summary>
+    /// O fato se aplica e tem valor. Um <paramref name="valor"/> nulo ou indefinido
+    /// é recusado: essa forma significa "sem valor", e sem valor o fato é
+    /// <see cref="NaoAplicavel"/> ou <see cref="Indeterminado"/> — quem chama tem de
+    /// dizer qual.
+    /// </summary>
+    /// <exception cref="ArgumentException">
+    /// Quando <paramref name="valor"/> é <see cref="JsonValueKind.Null"/> ou
+    /// <see cref="JsonValueKind.Undefined"/>.
+    /// </exception>
+    public static FatoResolvido Resolvido(JsonElement valor)
+    {
+        if (valor.ValueKind is JsonValueKind.Null or JsonValueKind.Undefined)
+        {
+            throw new ArgumentException(
+                "Um fato resolvido exige valor. Para a ausência de valor, use NaoAplicavel() ou Indeterminado() — "
+                + "o estado é declarado, nunca inferido do nulo.",
+                nameof(valor));
+        }
+
+        // Clone desacopla o valor do JsonDocument de origem: sem isso, um fato
+        // sobreviveria ao descarte do documento que o produziu e a leitura posterior
+        // lançaria ObjectDisposedException no meio da avaliação.
+        return new FatoResolvido(EstadoFato.Resolvido, valor.Clone());
+    }
+}

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Domain/ValueObjects/InstanciaEntidade.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Domain/ValueObjects/InstanciaEntidade.cs
@@ -17,4 +17,4 @@ using System.Text.Json;
 /// irmã). Vazio para <see cref="Enums.TipoEntidade.PessoaJuridicaVinculada"/> (repetição pura,
 /// sem atributos). O vocabulário fechado por tipo é validado fora do domínio (Application).
 /// </param>
-public sealed record InstanciaEntidade(string EntidadeId, IReadOnlyDictionary<string, JsonElement> Atributos);
+public sealed record InstanciaEntidade(string EntidadeId, IReadOnlyDictionary<string, FatoResolvido> Atributos);

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Domain/ValueObjects/PredicadoDnf.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Domain/ValueObjects/PredicadoDnf.cs
@@ -71,7 +71,7 @@ public sealed record PredicadoDnf
     /// <see cref="Ternario.Indeterminado"/>, fail-closed — nunca lança, e o restante do
     /// predicado continua avaliável normalmente.
     /// </summary>
-    public Ternario Avaliar(IReadOnlyDictionary<string, JsonElement> fatosResolvidos)
+    public Ternario Avaliar(IReadOnlyDictionary<string, FatoResolvido> fatosResolvidos)
     {
         ArgumentNullException.ThrowIfNull(fatosResolvidos);
 

--- a/tests/Unifesspa.UniPlus.Selecao.Domain.UnitTests/Entities/DocumentoExigidoTests.cs
+++ b/tests/Unifesspa.UniPlus.Selecao.Domain.UnitTests/Entities/DocumentoExigidoTests.cs
@@ -179,7 +179,7 @@ public sealed class DocumentoExigidoTests
     {
         DocumentoExigido exigencia = Exigencia(Aplicabilidade.Geral).Value!;
 
-        exigencia.AplicavelPara(new Dictionary<string, JsonElement>()).Should().Be(Ternario.Verdadeiro);
+        exigencia.AplicavelPara(new Dictionary<string, FatoResolvido>()).Should().Be(Ternario.Verdadeiro);
     }
 
     [Fact(DisplayName = "AplicavelPara: CONDICIONAL sem condição viva (zero cláusulas) é Falso — estrutural, não ausência de dado")]
@@ -187,7 +187,7 @@ public sealed class DocumentoExigidoTests
     {
         DocumentoExigido exigencia = Exigencia(Aplicabilidade.Condicional).Value!;
 
-        exigencia.AplicavelPara(new Dictionary<string, JsonElement>()).Should().Be(Ternario.Falso);
+        exigencia.AplicavelPara(new Dictionary<string, FatoResolvido>()).Should().Be(Ternario.Falso);
     }
 
     [Fact(DisplayName = "AplicavelPara: CONDICIONAL cujo fato não está resolvido é Indeterminado, nunca Falso")]
@@ -196,7 +196,7 @@ public sealed class DocumentoExigidoTests
         DocumentoExigido exigencia = Exigencia(
             Aplicabilidade.Condicional, condicoes: [CondicaoDe("SEXO", Operador.Igual, "\"MASCULINO\"")]).Value!;
 
-        exigencia.AplicavelPara(new Dictionary<string, JsonElement>()).Should().Be(Ternario.Indeterminado);
+        exigencia.AplicavelPara(new Dictionary<string, FatoResolvido>()).Should().Be(Ternario.Indeterminado);
     }
 
     [Fact(DisplayName = "AplicavelPara: CONDICIONAL com fato resolvido avalia normalmente (Verdadeiro/Falso)")]
@@ -205,10 +205,10 @@ public sealed class DocumentoExigidoTests
         DocumentoExigido exigencia = Exigencia(
             Aplicabilidade.Condicional, condicoes: [CondicaoDe("SEXO", Operador.Igual, "\"MASCULINO\"")]).Value!;
 
-        Dictionary<string, JsonElement> fatos = new() { ["SEXO"] = JsonSerializer.SerializeToElement("MASCULINO") };
+        Dictionary<string, FatoResolvido> fatos = new() { ["SEXO"] = FatoResolvido.Resolvido(JsonSerializer.SerializeToElement("MASCULINO")) };
         exigencia.AplicavelPara(fatos).Should().Be(Ternario.Verdadeiro);
 
-        Dictionary<string, JsonElement> fatosDivergentes = new() { ["SEXO"] = JsonSerializer.SerializeToElement("FEMININO") };
+        Dictionary<string, FatoResolvido> fatosDivergentes = new() { ["SEXO"] = FatoResolvido.Resolvido(JsonSerializer.SerializeToElement("FEMININO")) };
         exigencia.AplicavelPara(fatosDivergentes).Should().Be(Ternario.Falso);
     }
 
@@ -256,7 +256,7 @@ public sealed class DocumentoExigidoTests
         DocumentoExigido comIdadeExigidaNaoEmPermanentes =
             ExigenciaSemIdadeGatilhadaPorTipoDeficiencia(Operador.NaoEm, listaPermanentes);
 
-        Dictionary<string, JsonElement> fatos = new() { ["TIPO_DEFICIENCIA"] = JsonSerializer.SerializeToElement("TEA") };
+        Dictionary<string, FatoResolvido> fatos = new() { ["TIPO_DEFICIENCIA"] = FatoResolvido.Resolvido(JsonSerializer.SerializeToElement("TEA")) };
 
         semIdadeExigidaEmPermanentes.AplicavelPara(fatos).Should().Be(Ternario.Verdadeiro,
             "TEA é permanente — a exigência SEM idade máxima (gatilhada por EM permanentes) se aplica");
@@ -273,7 +273,7 @@ public sealed class DocumentoExigidoTests
         DocumentoExigido comIdadeExigidaNaoEmPermanentes =
             ExigenciaSemIdadeGatilhadaPorTipoDeficiencia(Operador.NaoEm, listaPermanentes);
 
-        Dictionary<string, JsonElement> fatos = new() { ["TIPO_DEFICIENCIA"] = JsonSerializer.SerializeToElement("DEPRESSAO") };
+        Dictionary<string, FatoResolvido> fatos = new() { ["TIPO_DEFICIENCIA"] = FatoResolvido.Resolvido(JsonSerializer.SerializeToElement("DEPRESSAO")) };
 
         semIdadeExigidaEmPermanentes.AplicavelPara(fatos).Should().Be(Ternario.Falso,
             "DEPRESSAO não é permanente — a exigência SEM idade máxima (gatilhada por EM permanentes) NÃO se aplica");
@@ -290,7 +290,7 @@ public sealed class DocumentoExigidoTests
         DocumentoExigido comIdadeExigidaNaoEmPermanentes =
             ExigenciaSemIdadeGatilhadaPorTipoDeficiencia(Operador.NaoEm, listaPermanentes);
 
-        Dictionary<string, JsonElement> semFatos = [];
+        Dictionary<string, FatoResolvido> semFatos = [];
 
         semIdadeExigidaEmPermanentes.AplicavelPara(semFatos).Should().Be(Ternario.Indeterminado);
         comIdadeExigidaNaoEmPermanentes.AplicavelPara(semFatos).Should().Be(Ternario.Indeterminado);

--- a/tests/Unifesspa.UniPlus.Selecao.Domain.UnitTests/Services/ResolvedorArvoreSatisfacaoTests.cs
+++ b/tests/Unifesspa.UniPlus.Selecao.Domain.UnitTests/Services/ResolvedorArvoreSatisfacaoTests.cs
@@ -21,7 +21,7 @@ public sealed class ResolvedorArvoreSatisfacaoTests
 {
     private static readonly Guid FaseId = Guid.CreateVersion7();
     private static readonly FormatosPermitidos Qualquer = FormatosPermitidos.Criar(true, null).Value!;
-    private static readonly IReadOnlyDictionary<string, JsonElement> SemFatos = new Dictionary<string, JsonElement>(StringComparer.Ordinal);
+    private static readonly IReadOnlyDictionary<string, FatoResolvido> SemFatos = new Dictionary<string, FatoResolvido>(StringComparer.Ordinal);
 
     private static DocumentoExigido DocumentoGeral(string? consequencia = null) =>
         DocumentoExigido.Criar(
@@ -35,8 +35,8 @@ public sealed class ResolvedorArvoreSatisfacaoTests
             [CondicaoGatilho.Criar(0, fato, Operador.Igual, JsonSerializer.SerializeToElement(true)).Value!],
             [], null, Qualquer, null).Value!;
 
-    private static Dictionary<string, JsonElement> Fatos(string fato, bool valor) =>
-        new(StringComparer.Ordinal) { [fato] = JsonSerializer.SerializeToElement(valor) };
+    private static Dictionary<string, FatoResolvido> Fatos(string fato, bool valor) =>
+        new(StringComparer.Ordinal) { [fato] = FatoResolvido.Resolvido(JsonSerializer.SerializeToElement(valor)) };
 
     private static Dictionary<Guid, IReadOnlyList<ApresentacaoDocumento>> Apresenta(params DocumentoExigido[] documentos) =>
         documentos.ToDictionary(
@@ -58,7 +58,7 @@ public sealed class ResolvedorArvoreSatisfacaoTests
 
     private static Result<ResultadoResolucaoArvore> Resolver(
         ArvoreExigenciasCongelada arvore,
-        IReadOnlyDictionary<string, JsonElement>? fatos = null,
+        IReadOnlyDictionary<string, FatoResolvido>? fatos = null,
         IReadOnlyDictionary<Guid, IReadOnlyList<ApresentacaoDocumento>>? apresentacoes = null,
         IReadOnlyDictionary<TipoEntidade, IReadOnlyList<InstanciaEntidade>>? instancias = null) =>
         ResolvedorArvoreSatisfacao.Resolver(arvore, fatos ?? SemFatos, apresentacoes ?? SemApresentacoes, instancias);
@@ -66,7 +66,7 @@ public sealed class ResolvedorArvoreSatisfacaoTests
     private static InstanciaEntidade Instancia(string entidadeId, params (string Fato, bool Valor)[] atributos) =>
         new(entidadeId, atributos.ToDictionary(
             static a => a.Fato,
-            static a => JsonSerializer.SerializeToElement(a.Valor),
+            static a => FatoResolvido.Resolvido(JsonSerializer.SerializeToElement(a.Valor)),
             StringComparer.Ordinal));
 
     private static Dictionary<TipoEntidade, IReadOnlyList<InstanciaEntidade>> InstanciasDe(
@@ -230,6 +230,30 @@ public sealed class ResolvedorArvoreSatisfacaoTests
         Result<ResultadoResolucaoArvore> resultado = Resolver(Arvore(raiz));
 
         resultado.Value!.EstadosPorNo[raiz.Id].Should().Be(EstadoSatisfacao.Indeterminado);
+    }
+
+    [Fact(DisplayName = "Story #926: fato ausente e fato NÃO_APLICÁVEL levam a estados opostos na fronteira do resolvedor")]
+    public void Folha_FatoAusenteVersusNaoAplicavel_EstadosOpostos()
+    {
+        DocumentoExigido condicional = DocumentoCondicional("CONCORRER_PCD");
+        NoExigencia raiz = NoExigencia.CriarGrupo(
+            TipoNo.GrupoOu, 0, null, null, [], [NoExigencia.CriarFolha(condicional, 0).Value!]).Value!;
+
+        // Ausente do dicionário: nada se sabe sobre o fato, a exigência segue pendente.
+        Result<ResultadoResolucaoArvore> comFatoAusente = Resolver(Arvore(raiz));
+
+        // Declarado não-aplicável: a pré-condição do campo é falsa, a exigência está resolvida
+        // como não-exigida — e o candidato não é cobrado por um documento que não lhe cabe.
+        Dictionary<string, FatoResolvido> naoAplicavel = new(StringComparer.Ordinal)
+        {
+            ["CONCORRER_PCD"] = FatoResolvido.NaoAplicavel(),
+        };
+        Result<ResultadoResolucaoArvore> comFatoNaoAplicavel = Resolver(Arvore(raiz), naoAplicavel);
+
+        comFatoAusente.Value!.EstadosPorNo[raiz.Id].Should().Be(EstadoSatisfacao.Indeterminado);
+        comFatoNaoAplicavel.Value!.EstadosPorNo[raiz.Id].Should().Be(
+            EstadoSatisfacao.NaoAplicavel,
+            "a ausência do fato é pendência; a inaplicabilidade declarada é resposta definitiva");
     }
 
     [Fact(DisplayName = "E ignora alternativa não-aplicável")]
@@ -510,6 +534,36 @@ public sealed class ResolvedorArvoreSatisfacaoTests
     }
 
     // ── Repetição por entidade (Story #922) ──────────────────────────────────────────────
+
+    [Fact(DisplayName = "Story #926: atributo NÃO_APLICÁVEL da instância sobrescreve o mesmo fato resolvido do candidato")]
+    public void RepeticaoPorEntidade_AtributoNaoAplicavelSobrescreveFatoDoCandidato()
+    {
+        DocumentoExigido condicional = DocumentoCondicional("SEM_RENDA");
+        NoExigencia raiz = NoExigencia.CriarFolha(
+            condicional, 0, repetePorEntidade: TipoEntidade.MembroNucleoFamiliar).Value!;
+
+        // O candidato declarou o fato, mas para ESTE membro do núcleo familiar ele não se
+        // aplica — o sujeito do gatilho é a instância, não o candidato.
+        Dictionary<string, FatoResolvido> fatosDoCandidato = new(StringComparer.Ordinal)
+        {
+            ["SEM_RENDA"] = FatoResolvido.Resolvido(JsonSerializer.SerializeToElement(true)),
+        };
+        InstanciaEntidade membro = new("membro_1", new Dictionary<string, FatoResolvido>(StringComparer.Ordinal)
+        {
+            ["SEM_RENDA"] = FatoResolvido.NaoAplicavel(),
+        });
+
+        Result<ResultadoResolucaoArvore> resultado = Resolver(
+            Arvore(raiz),
+            fatos: fatosDoCandidato,
+            instancias: InstanciasDe(TipoEntidade.MembroNucleoFamiliar, membro));
+
+        resultado.Value!.StatusPorEntidade.Should().Contain(
+            s => s.DocumentoExigidoId == condicional.Id
+                && s.EntidadeId == "membro_1"
+                && s.Status == StatusResolucaoExigencia.NaoAplicavel,
+            "o atributo da instância tem precedência — sem isso, o fato do candidato exigiria o documento de um membro a quem ele não cabe");
+    }
 
     [Fact(DisplayName = "Documento correlacionado à instância certa: RG do membro 2 satisfaz só (RG, MEMBRO_NUCLEO_FAMILIAR, membro_2)")]
     public void RepeticaoPorEntidade_DocumentoCorrelacionadoAInstanciaCerta()

--- a/tests/Unifesspa.UniPlus.Selecao.Domain.UnitTests/ValueObjects/ClausulaDnfTests.cs
+++ b/tests/Unifesspa.UniPlus.Selecao.Domain.UnitTests/ValueObjects/ClausulaDnfTests.cs
@@ -47,10 +47,10 @@ public sealed class ClausulaDnfTests
     public void Avaliar_TodasVerdadeiras_Verdadeiro()
     {
         ClausulaDnf clausula = ClausulaDnf.Criar([Condicao("PCD"), Condicao("QUILOMBOLA")]).Value!;
-        Dictionary<string, JsonElement> fatos = new()
+        Dictionary<string, FatoResolvido> fatos = new()
         {
-            ["PCD"] = JsonSerializer.SerializeToElement(true),
-            ["QUILOMBOLA"] = JsonSerializer.SerializeToElement(true),
+            ["PCD"] = FatoResolvido.Resolvido(JsonSerializer.SerializeToElement(true)),
+            ["QUILOMBOLA"] = FatoResolvido.Resolvido(JsonSerializer.SerializeToElement(true)),
         };
 
         clausula.Avaliar(fatos).Should().Be(Ternario.Verdadeiro);
@@ -60,7 +60,7 @@ public sealed class ClausulaDnfTests
     public void Avaliar_UmaFalsoVenceSobreIndeterminado()
     {
         ClausulaDnf clausula = ClausulaDnf.Criar([Condicao("PCD"), Condicao("FATO_AUSENTE")]).Value!;
-        Dictionary<string, JsonElement> fatos = new() { ["PCD"] = JsonSerializer.SerializeToElement(false) };
+        Dictionary<string, FatoResolvido> fatos = new() { ["PCD"] = FatoResolvido.Resolvido(JsonSerializer.SerializeToElement(false)) };
 
         clausula.Avaliar(fatos).Should().Be(Ternario.Falso);
     }
@@ -69,7 +69,7 @@ public sealed class ClausulaDnfTests
     public void Avaliar_SemFalso_IndeterminadoVence()
     {
         ClausulaDnf clausula = ClausulaDnf.Criar([Condicao("PCD"), Condicao("FATO_AUSENTE")]).Value!;
-        Dictionary<string, JsonElement> fatos = new() { ["PCD"] = JsonSerializer.SerializeToElement(true) };
+        Dictionary<string, FatoResolvido> fatos = new() { ["PCD"] = FatoResolvido.Resolvido(JsonSerializer.SerializeToElement(true)) };
 
         clausula.Avaliar(fatos).Should().Be(Ternario.Indeterminado);
     }

--- a/tests/Unifesspa.UniPlus.Selecao.Domain.UnitTests/ValueObjects/PredicadoDnfTests.cs
+++ b/tests/Unifesspa.UniPlus.Selecao.Domain.UnitTests/ValueObjects/PredicadoDnfTests.cs
@@ -21,7 +21,7 @@ public sealed class PredicadoDnfTests
 
         resultado.IsSuccess.Should().BeTrue("zero cláusulas é um estado estruturalmente válido");
         resultado.Value!.Clausulas.Should().BeEmpty();
-        resultado.Value.Avaliar(new Dictionary<string, JsonElement>()).Should().Be(
+        resultado.Value.Avaliar(new Dictionary<string, FatoResolvido>()).Should().Be(
             Ternario.Falso, "zero cláusulas é estado estrutural — nunca casa com ninguém, não se confunde com indeterminação");
     }
 
@@ -51,19 +51,19 @@ public sealed class PredicadoDnfTests
         ]);
         PredicadoDnf predicado = resultado.Value!;
 
-        Dictionary<string, JsonElement> soPcd = new()
+        Dictionary<string, FatoResolvido> soPcd = new()
         {
-            ["PCD"] = JsonSerializer.SerializeToElement(true),
-            ["QUILOMBOLA"] = JsonSerializer.SerializeToElement(false),
-            ["EGRESSO_ESCOLA_PUBLICA"] = JsonSerializer.SerializeToElement(false),
+            ["PCD"] = FatoResolvido.Resolvido(JsonSerializer.SerializeToElement(true)),
+            ["QUILOMBOLA"] = FatoResolvido.Resolvido(JsonSerializer.SerializeToElement(false)),
+            ["EGRESSO_ESCOLA_PUBLICA"] = FatoResolvido.Resolvido(JsonSerializer.SerializeToElement(false)),
         };
         predicado.Avaliar(soPcd).Should().Be(Ternario.Falso, "a primeira cláusula exige AMBAS as condições");
 
-        Dictionary<string, JsonElement> soEgresso = new()
+        Dictionary<string, FatoResolvido> soEgresso = new()
         {
-            ["PCD"] = JsonSerializer.SerializeToElement(false),
-            ["QUILOMBOLA"] = JsonSerializer.SerializeToElement(false),
-            ["EGRESSO_ESCOLA_PUBLICA"] = JsonSerializer.SerializeToElement(true),
+            ["PCD"] = FatoResolvido.Resolvido(JsonSerializer.SerializeToElement(false)),
+            ["QUILOMBOLA"] = FatoResolvido.Resolvido(JsonSerializer.SerializeToElement(false)),
+            ["EGRESSO_ESCOLA_PUBLICA"] = FatoResolvido.Resolvido(JsonSerializer.SerializeToElement(true)),
         };
         predicado.Avaliar(soEgresso).Should().Be(Ternario.Verdadeiro, "a segunda cláusula sozinha já satisfaz o OU");
     }
@@ -74,10 +74,10 @@ public sealed class PredicadoDnfTests
         Result<PredicadoDnf> resultado = PredicadoDnf.CriarDeCondicoesAgrupadas([(1, Booleana("SEXO_DESCONHECIDO", true))]);
         PredicadoDnf predicado = resultado.Value!;
 
-        Action avaliar = () => predicado.Avaliar(new Dictionary<string, JsonElement>());
+        Action avaliar = () => predicado.Avaliar(new Dictionary<string, FatoResolvido>());
 
         avaliar.Should().NotThrow();
-        predicado.Avaliar(new Dictionary<string, JsonElement>()).Should().Be(Ternario.Indeterminado);
+        predicado.Avaliar(new Dictionary<string, FatoResolvido>()).Should().Be(Ternario.Indeterminado);
     }
 
     // ── Story #554 (PR #896, issue #892) — extensão dinâmica/multivalorada ──
@@ -97,9 +97,9 @@ public sealed class PredicadoDnfTests
         PredicadoDnf predicado = PredicadoDnf.CriarDeCondicoesAgrupadas(
             [(1, Categorica("MODALIDADE", Operador.Igual, StringJson("LB_PPI")))]).Value!;
 
-        Dictionary<string, JsonElement> fatos = new()
+        Dictionary<string, FatoResolvido> fatos = new()
         {
-            ["MODALIDADE"] = ArrayJson("LB_PPI", "AC"),
+            ["MODALIDADE"] = FatoResolvido.Resolvido(ArrayJson("LB_PPI", "AC")),
         };
 
         predicado.Avaliar(fatos).Should().Be(Ternario.Verdadeiro, "LB_PPI pertence ao conjunto [LB_PPI, AC] do candidato");
@@ -111,9 +111,9 @@ public sealed class PredicadoDnfTests
         PredicadoDnf predicado = PredicadoDnf.CriarDeCondicoesAgrupadas(
             [(1, Categorica("MODALIDADE", Operador.Igual, StringJson("LB_Q")))]).Value!;
 
-        Dictionary<string, JsonElement> fatos = new()
+        Dictionary<string, FatoResolvido> fatos = new()
         {
-            ["MODALIDADE"] = ArrayJson("LB_PPI", "AC"),
+            ["MODALIDADE"] = FatoResolvido.Resolvido(ArrayJson("LB_PPI", "AC")),
         };
 
         predicado.Avaliar(fatos).Should().Be(Ternario.Falso);
@@ -125,9 +125,9 @@ public sealed class PredicadoDnfTests
         PredicadoDnf predicado = PredicadoDnf.CriarDeCondicoesAgrupadas(
             [(1, Categorica("MODALIDADE", Operador.Em, ArrayJson("LB_PPI", "LB_Q")))]).Value!;
 
-        Dictionary<string, JsonElement> fatos = new()
+        Dictionary<string, FatoResolvido> fatos = new()
         {
-            ["MODALIDADE"] = ArrayJson("AC"),
+            ["MODALIDADE"] = FatoResolvido.Resolvido(ArrayJson("AC")),
         };
 
         predicado.Avaliar(fatos).Should().Be(Ternario.Falso, "[AC] intersecta [LB_PPI, LB_Q] em vazio");
@@ -139,9 +139,9 @@ public sealed class PredicadoDnfTests
         PredicadoDnf predicado = PredicadoDnf.CriarDeCondicoesAgrupadas(
             [(1, Categorica("MODALIDADE", Operador.Em, ArrayJson("LB_PPI", "LB_Q")))]).Value!;
 
-        Dictionary<string, JsonElement> fatos = new()
+        Dictionary<string, FatoResolvido> fatos = new()
         {
-            ["MODALIDADE"] = ArrayJson("AC", "LB_PPI"),
+            ["MODALIDADE"] = FatoResolvido.Resolvido(ArrayJson("AC", "LB_PPI")),
         };
 
         predicado.Avaliar(fatos).Should().Be(Ternario.Verdadeiro, "[AC, LB_PPI] intersecta [LB_PPI, LB_Q] em [LB_PPI], não vazio");
@@ -153,7 +153,7 @@ public sealed class PredicadoDnfTests
         PredicadoDnf predicado = PredicadoDnf.CriarDeCondicoesAgrupadas(
             [(1, Categorica("SEXO", Operador.Igual, StringJson("MASCULINO")))]).Value!;
 
-        Dictionary<string, JsonElement> fatos = new() { ["SEXO"] = StringJson("MASCULINO") };
+        Dictionary<string, FatoResolvido> fatos = new() { ["SEXO"] = FatoResolvido.Resolvido(StringJson("MASCULINO")) };
 
         predicado.Avaliar(fatos).Should().Be(Ternario.Verdadeiro, "fato escalar (não-array) segue o ramo original, sem mudança de comportamento");
     }
@@ -163,8 +163,8 @@ public sealed class PredicadoDnfTests
     private static PredicadoDnf Predicado(params (int Clausula, CondicaoDnf Condicao)[] linhas) =>
         PredicadoDnf.CriarDeCondicoesAgrupadas(linhas).Value!;
 
-    private static Dictionary<string, JsonElement> Fatos(string chave, JsonElement valor) =>
-        new() { [chave] = valor };
+    private static Dictionary<string, FatoResolvido> Fatos(string chave, JsonElement valor) =>
+        new(StringComparer.Ordinal) { [chave] = FatoResolvido.Resolvido(valor) };
 
     [Theory(DisplayName = "DIFERENTE escalar: nega IGUAL quando o fato está resolvido")]
     [InlineData("FEMININO", Ternario.Verdadeiro)]
@@ -181,7 +181,7 @@ public sealed class PredicadoDnfTests
     {
         PredicadoDnf predicado = Predicado((1, Categorica("SEXO", Operador.Diferente, StringJson("MASCULINO"))));
 
-        predicado.Avaliar(new Dictionary<string, JsonElement>()).Should().Be(Ternario.Indeterminado);
+        predicado.Avaliar(new Dictionary<string, FatoResolvido>()).Should().Be(Ternario.Indeterminado);
     }
 
     [Theory(DisplayName = "NAO_EM categórico: nega EM quando o fato está resolvido")]
@@ -200,7 +200,7 @@ public sealed class PredicadoDnfTests
     {
         PredicadoDnf predicado = Predicado((1, Categorica("COR_RACA", Operador.NaoEm, ArrayJson("PRETA"))));
 
-        predicado.Avaliar(new Dictionary<string, JsonElement>()).Should().Be(Ternario.Indeterminado);
+        predicado.Avaliar(new Dictionary<string, FatoResolvido>()).Should().Be(Ternario.Indeterminado);
     }
 
     [Fact(DisplayName = "EM [] com fato resolvido é Falso (interseção vazia)")]
@@ -225,17 +225,31 @@ public sealed class PredicadoDnfTests
         PredicadoDnf emVazio = Predicado((1, Categorica("COR_RACA", Operador.Em, ArrayJson())));
         PredicadoDnf naoEmVazio = Predicado((1, Categorica("COR_RACA", Operador.NaoEm, ArrayJson())));
 
-        emVazio.Avaliar(new Dictionary<string, JsonElement>()).Should().Be(Ternario.Indeterminado);
-        naoEmVazio.Avaliar(new Dictionary<string, JsonElement>()).Should().Be(Ternario.Indeterminado);
+        emVazio.Avaliar(new Dictionary<string, FatoResolvido>()).Should().Be(Ternario.Indeterminado);
+        naoEmVazio.Avaliar(new Dictionary<string, FatoResolvido>()).Should().Be(Ternario.Indeterminado);
     }
 
-    [Fact(DisplayName = "Fato presente porém null é Indeterminado, não Falso")]
-    public void Avaliar_FatoNulo_Indeterminado()
+    [Fact(DisplayName = "Fato presente com estado Indeterminado é Indeterminado, não Falso")]
+    public void Avaliar_FatoIndeterminado_Indeterminado()
     {
         PredicadoDnf predicado = Predicado((1, Booleana("PCD", true)));
+
+        Dictionary<string, FatoResolvido> fatos = new(StringComparer.Ordinal) { ["PCD"] = FatoResolvido.Indeterminado() };
+
+        predicado.Avaliar(fatos).Should().Be(Ternario.Indeterminado);
+    }
+
+    [Fact(DisplayName = "Um fato sem valor não pode ser construído como resolvido — o estado é declarado, nunca inferido do nulo")]
+    public void FatoResolvido_ResolvidoComNulo_Recusado()
+    {
         using JsonDocument nulo = JsonDocument.Parse("null");
 
-        predicado.Avaliar(Fatos("PCD", nulo.RootElement.Clone())).Should().Be(Ternario.Indeterminado);
+        Action comNulo = () => FatoResolvido.Resolvido(nulo.RootElement.Clone());
+        Action comIndefinido = () => FatoResolvido.Resolvido(default);
+
+        comNulo.Should().Throw<ArgumentException>(
+            "aceitar null como resolvido reintroduziria a ambiguidade entre não-aplicável e indeterminado");
+        comIndefinido.Should().Throw<ArgumentException>();
     }
 
     [Fact(DisplayName = "Comparação numérica sobre valor de tipo incoerente é Indeterminado, nunca lança")]
@@ -276,7 +290,7 @@ public sealed class PredicadoDnfTests
             (1, Booleana("PCD", true)),
             (1, Booleana("FATO_AUSENTE", true)));
 
-        Dictionary<string, JsonElement> fatos = new() { ["PCD"] = JsonSerializer.SerializeToElement(true) };
+        Dictionary<string, FatoResolvido> fatos = new() { ["PCD"] = FatoResolvido.Resolvido(JsonSerializer.SerializeToElement(true)) };
 
         // PCD=true (Verdadeiro) E FATO_AUSENTE (Indeterminado) -> Indeterminado.
         predicado.Avaliar(fatos).Should().Be(Ternario.Indeterminado);
@@ -290,10 +304,10 @@ public sealed class PredicadoDnfTests
             (2, Booleana("FATO_AUSENTE", true)),
             (3, Booleana("QUILOMBOLA", true)));
 
-        Dictionary<string, JsonElement> fatos = new()
+        Dictionary<string, FatoResolvido> fatos = new()
         {
-            ["EGRESSO_ESCOLA_PUBLICA"] = JsonSerializer.SerializeToElement(true),
-            ["QUILOMBOLA"] = JsonSerializer.SerializeToElement(false),
+            ["EGRESSO_ESCOLA_PUBLICA"] = FatoResolvido.Resolvido(JsonSerializer.SerializeToElement(true)),
+            ["QUILOMBOLA"] = FatoResolvido.Resolvido(JsonSerializer.SerializeToElement(false)),
         };
 
         predicado.Avaliar(fatos).Should().Be(Ternario.Verdadeiro);
@@ -306,7 +320,7 @@ public sealed class PredicadoDnfTests
             (1, Booleana("QUILOMBOLA", true)),
             (2, Booleana("FATO_AUSENTE", true)));
 
-        Dictionary<string, JsonElement> fatos = new() { ["QUILOMBOLA"] = JsonSerializer.SerializeToElement(false) };
+        Dictionary<string, FatoResolvido> fatos = new() { ["QUILOMBOLA"] = FatoResolvido.Resolvido(JsonSerializer.SerializeToElement(false)) };
 
         predicado.Avaliar(fatos).Should().Be(Ternario.Indeterminado);
     }
@@ -318,12 +332,120 @@ public sealed class PredicadoDnfTests
             (1, Booleana("QUILOMBOLA", true)),
             (2, Booleana("PCD", true)));
 
-        Dictionary<string, JsonElement> fatos = new()
+        Dictionary<string, FatoResolvido> fatos = new()
         {
-            ["QUILOMBOLA"] = JsonSerializer.SerializeToElement(false),
-            ["PCD"] = JsonSerializer.SerializeToElement(false),
+            ["QUILOMBOLA"] = FatoResolvido.Resolvido(JsonSerializer.SerializeToElement(false)),
+            ["PCD"] = FatoResolvido.Resolvido(JsonSerializer.SerializeToElement(false)),
         };
 
         predicado.Avaliar(fatos).Should().Be(Ternario.Falso);
+    }
+
+    // ── Story #926 — NÃO_APLICÁVEL é estado próprio do átomo, distinto de INDETERMINADO ──
+
+    private static Dictionary<string, FatoResolvido> Estados(params (string Fato, FatoResolvido Estado)[] entradas) =>
+        entradas.ToDictionary(static e => e.Fato, static e => e.Estado, StringComparer.Ordinal);
+
+    [Theory(DisplayName = "Átomo sobre fato NÃO_APLICÁVEL é não-aplicável para todo operador — a negação não inverte a inaplicabilidade")]
+    [InlineData(Operador.Igual)]
+    [InlineData(Operador.Diferente)]
+    [InlineData(Operador.Em)]
+    [InlineData(Operador.NaoEm)]
+    [InlineData(Operador.MaiorIgual)]
+    [InlineData(Operador.MenorIgual)]
+    public void Atomo_SobreFatoNaoAplicavel_NuncaEhVerdadeiro(Operador operador)
+    {
+        JsonElement valor = operador switch
+        {
+            Operador.Em or Operador.NaoEm => ArrayJson("SIM"),
+            Operador.MaiorIgual or Operador.MenorIgual => JsonSerializer.SerializeToElement(18),
+            _ => StringJson("SIM"),
+        };
+        PredicadoDnf predicado = Predicado((1, Categorica("CONCORRER_PCD", operador, valor)));
+
+        Ternario resultado = predicado.Avaliar(Estados(("CONCORRER_PCD", FatoResolvido.NaoAplicavel())));
+
+        resultado.Should().Be(
+            Ternario.Falso,
+            "o candidato não é PcD, então o opt-in não se aplica — nem satisfaz o gatilho, nem fica pendente esperando resposta");
+    }
+
+    [Fact(DisplayName = "Um fato resolvido sobrevive ao descarte do documento que o originou")]
+    public void FatoResolvido_SobreviveAoDescarteDoDocumentoDeOrigem()
+    {
+        FatoResolvido fato;
+        using (JsonDocument documento = JsonDocument.Parse("\"MASCULINO\""))
+        {
+            fato = FatoResolvido.Resolvido(documento.RootElement);
+        }
+
+        PredicadoDnf predicado = Predicado((1, Categorica("SEXO", Operador.Igual, StringJson("MASCULINO"))));
+
+        Action avaliar = () => predicado.Avaliar(Estados(("SEXO", fato)));
+
+        avaliar.Should().NotThrow<ObjectDisposedException>(
+            "o valor é clonado na construção — sem isso, o fato ficaria preso ao tempo de vida do documento que o produziu");
+        predicado.Avaliar(Estados(("SEXO", fato))).Should().Be(Ternario.Verdadeiro);
+    }
+
+    [Fact(DisplayName = "Cláusula E com VERDADEIRO e NÃO_APLICÁVEL resolve Falso — o não-aplicável colapsa, não é ignorado")]
+    public void Clausula_VerdadeiroComNaoAplicavel_Falso()
+    {
+        PredicadoDnf predicado = Predicado(
+            (1, Booleana("EGRESSO_ESCOLA_PUBLICA", true)),
+            (1, Categorica("CONCORRER_Q", Operador.Igual, StringJson("SIM"))));
+
+        Ternario resultado = predicado.Avaliar(Estados(
+            ("EGRESSO_ESCOLA_PUBLICA", FatoResolvido.Resolvido(JsonSerializer.SerializeToElement(true))),
+            ("CONCORRER_Q", FatoResolvido.NaoAplicavel())));
+
+        resultado.Should().Be(
+            Ternario.Falso,
+            "sem o colapso o átomo não-aplicável seria ignorado e a cláusula resolveria verdadeiro por um opt-in que nem foi perguntado");
+    }
+
+    [Fact(DisplayName = "Cláusula E com NÃO_APLICÁVEL e INDETERMINADO resolve Falso — o não-aplicável é definitivo e vence a pendência")]
+    public void Clausula_NaoAplicavelComIndeterminado_Falso()
+    {
+        PredicadoDnf predicado = Predicado(
+            (1, Categorica("CONCORRER_Q", Operador.Igual, StringJson("SIM"))),
+            (1, Booleana("PCD", true)));
+
+        Ternario resultado = predicado.Avaliar(Estados(
+            ("CONCORRER_Q", FatoResolvido.NaoAplicavel()),
+            ("PCD", FatoResolvido.Indeterminado())));
+
+        resultado.Should().Be(
+            Ternario.Falso,
+            "a cláusula já é impossível pelo átomo não-aplicável — esperar a resposta pendente do outro fato não mudaria o resultado");
+    }
+
+    [Fact(DisplayName = "DNF misto: cláusula não-aplicável e cláusula pendente resolvem Indeterminado — os dois estados não colapsam num só")]
+    public void Dnf_ClausulaNaoAplicavelComClausulaIndeterminada_Indeterminado()
+    {
+        PredicadoDnf predicado = Predicado(
+            (1, Categorica("CONCORRER_Q", Operador.Igual, StringJson("SIM"))),
+            (2, Booleana("PCD", true)));
+
+        Ternario resultado = predicado.Avaliar(Estados(
+            ("CONCORRER_Q", FatoResolvido.NaoAplicavel()),
+            ("PCD", FatoResolvido.Indeterminado())));
+
+        resultado.Should().Be(
+            Ternario.Indeterminado,
+            "a primeira cláusula está resolvida em falso, mas a segunda ainda pode virar verdadeira quando o candidato responder");
+    }
+
+    [Fact(DisplayName = "O estado vem do discriminador, não da ausência de valor: dois fatos sem valor levam a resultados opostos")]
+    public void Estado_VemDoDiscriminador_NaoDaAusenciaDeValor()
+    {
+        PredicadoDnf predicado = Predicado((1, Categorica("CONCORRER_PCD", Operador.Igual, StringJson("SIM"))));
+
+        Ternario naoAplicavel = predicado.Avaliar(Estados(("CONCORRER_PCD", FatoResolvido.NaoAplicavel())));
+        Ternario indeterminado = predicado.Avaliar(Estados(("CONCORRER_PCD", FatoResolvido.Indeterminado())));
+
+        naoAplicavel.Should().Be(Ternario.Falso, "não se aplica — a exigência que depende disso fica dispensada em definitivo");
+        indeterminado.Should().Be(Ternario.Indeterminado, "aplica-se e ainda não foi respondido — a exigência segue pendente");
+        naoAplicavel.Should().NotBe(indeterminado, "os dois carregam valor nulo e mesmo assim decidem coisas opostas");
     }
 }


### PR DESCRIPTION
## Contexto

Um fato do candidato sem valor podia significar duas coisas **opostas**, e o avaliador de predicado tratava as duas do mesmo jeito:

- **Não se aplica** — a pré-condição do campo é falsa, o campo nem chegou a ser apresentado. É resposta **definitiva**: quem depende dele fica dispensado.
- **Ainda não se sabe** — o campo se aplica e o candidato não respondeu. É **pendência**: a exigência segue em aberto.

Colapsar as duas leva a erro nos dois sentidos: dispensa exigência sobre a qual nada se sabe, ou cobra documento de quem não lhe cabe. Um candidato que não é PcD não deve ficar com a comprovação de deficiência pendente para sempre — mas um candidato que é PcD e ainda não respondeu também não pode ser dispensado dela.

Esta é a **primeira metade** da story: a álgebra que consome o estado. O grafo de pré-condições que o **produz** vem no PR seguinte, junto com a tabela materializada, o invariante de aciclicidade e a recomputação que descarta resposta obsoleta.

## O que muda

**A ambiguidade deixa de ser representável.** `FatoResolvido` carrega um discriminador ao lado do valor, e a factory de fato resolvido **recusa** valor nulo ou indefinido — a ausência de valor obriga quem monta o insumo a declarar qual dos dois casos é. O valor é clonado na construção, para o fato não ficar preso ao tempo de vida do `JsonDocument` que o originou.

**O átomo passa a ter quatro estados**, um a mais que o resultado ternário do predicado:

| Estado do fato | Estado do átomo | Vale para |
|---|---|---|
| Não-aplicável | Não-aplicável | **todo** operador, inclusive `DIFERENTE`/`NAO_EM` |
| Indeterminado, ou ausente | Indeterminado | todo operador |
| Resolvido | Verdadeiro/Falso | conforme o operador |

A negação inverte um **valor**; sobre a inaplicabilidade não há o que inverter. Um átomo `CONCORRER_PCD DIFERENTE SIM` sobre fato inaplicável é inaplicável — não verdadeiro.

**Na cláusula E o átomo não-aplicável colapsa como falso resolvido**, e o predicado continua ternário. Os quatro estados existem só no átomo — não há motor duplo. É o colapso que faz um gatilho sobre fato inaplicável resolver falso, em vez de ficar pendente esperando um valor que nunca virá.

**O avaliador de conformidade legal preserva o comportamento**: continua montando apenas a modalidade, e os demais fatos seguem **ausentes**. Na publicação não há candidato, e ausência resolve indeterminado — que ali significa "cobertura não provada", o que se quer. Materializá-los como não-aplicável afirmaria algo que não se sabe.

**Entrada nula no dicionário** é lida como ausência, não como inaplicabilidade: um adaptador descuidado não deve dispensar exigência por defeito de montagem.

## Mudança de comportamento observável

Onde um consumidor passe a declarar um fato como não-aplicável em vez de omiti-lo, o resolvedor sai de `Indeterminado` para `NaoAplicavel` — na folha e na fronteira. É a mudança pretendida, e está coberta por teste de fronteira explícito comparando os dois insumos.

## Testes

Verifiquei que os testes novos **falham sem o fix**: trocando o colapso para tratar não-aplicável como indeterminado, **7 testes quebram**. Com o código correto, todos passam.

A cobertura evita o teste que passa por acidente — `E[FALSO, NÃO_APLICÁVEL]` sozinho não provaria nada, porque o falso já vence. Por isso a suíte inclui:

- `E[VERDADEIRO, NÃO_APLICÁVEL]` → falso — sem o colapso, resolveria verdadeiro por um opt-in que nem foi perguntado
- `E[NÃO_APLICÁVEL, INDETERMINADO]` → falso — o definitivo vence a pendência
- DNF misto: cláusula não-aplicável + cláusula pendente → **indeterminado** — os dois estados não colapsam num só
- átomo sobre fato não-aplicável para os seis operadores
- dois fatos sem valor levando a resultados opostos, provando que a decisão vem do discriminador
- fato resolvido sobrevivendo ao descarte do documento de origem
- atributo não-aplicável de instância sobrescrevendo o mesmo fato resolvido do candidato

## Validação

```
dotnet build UniPlus.slnx                           → 0 erros, 0 avisos
dotnet test UniPlus.slnx                            → suíte completa, 0 falhas
dotnet format --verify-no-changes                   → 0 diagnósticos (comando exato do CI)
falsificação: colapso removido                      → 7 testes falham
```

## Fora de escopo

O grafo de pré-condições, a tabela materializada, o invariante de aciclicidade e a invalidação de resposta obsoleta — todos no PR seguinte, que fecha a story.

Refs #926
