### PR TITLE
style(selecao): remove acentuação do token de estado não-aplicável

### DIFF
--- a/src/selecao/Unifesspa.UniPlus.Selecao.Domain/Services/AvaliadorConformidadeLegal.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Domain/Services/AvaliadorConformidadeLegal.cs
@@ -170,7 +170,7 @@ public static class AvaliadorConformidadeLegal
 
         // Só MODALIDADE entra: na publicação não há candidato, e todo outro fato é
         // legitimamente desconhecido. Ausência resolve INDETERMINADO, que aqui significa
-        // "cobertura não provada" — o que se quer. Materializá-los como NÃO_APLICÁVEL faria a
+        // "cobertura não provada" — o que se quer. Materializá-los como NAO_APLICAVEL faria a
         // cláusula colapsar em FALSO e afirmaria algo que não se sabe.
         Dictionary<string, FatoResolvido> fatoDaModalidade = new(StringComparer.Ordinal)
         {

--- a/tests/Unifesspa.UniPlus.Selecao.Domain.UnitTests/Services/ResolvedorArvoreSatisfacaoTests.cs
+++ b/tests/Unifesspa.UniPlus.Selecao.Domain.UnitTests/Services/ResolvedorArvoreSatisfacaoTests.cs
@@ -232,7 +232,7 @@ public sealed class ResolvedorArvoreSatisfacaoTests
         resultado.Value!.EstadosPorNo[raiz.Id].Should().Be(EstadoSatisfacao.Indeterminado);
     }
 
-    [Fact(DisplayName = "Story #926: fato ausente e fato NÃO_APLICÁVEL levam a estados opostos na fronteira do resolvedor")]
+    [Fact(DisplayName = "Story #926: fato ausente e fato NAO_APLICAVEL levam a estados opostos na fronteira do resolvedor")]
     public void Folha_FatoAusenteVersusNaoAplicavel_EstadosOpostos()
     {
         DocumentoExigido condicional = DocumentoCondicional("CONCORRER_PCD");
@@ -535,7 +535,7 @@ public sealed class ResolvedorArvoreSatisfacaoTests
 
     // ── Repetição por entidade (Story #922) ──────────────────────────────────────────────
 
-    [Fact(DisplayName = "Story #926: atributo NÃO_APLICÁVEL da instância sobrescreve o mesmo fato resolvido do candidato")]
+    [Fact(DisplayName = "Story #926: atributo NAO_APLICAVEL da instância sobrescreve o mesmo fato resolvido do candidato")]
     public void RepeticaoPorEntidade_AtributoNaoAplicavelSobrescreveFatoDoCandidato()
     {
         DocumentoExigido condicional = DocumentoCondicional("SEM_RENDA");

--- a/tests/Unifesspa.UniPlus.Selecao.Domain.UnitTests/ValueObjects/PredicadoDnfTests.cs
+++ b/tests/Unifesspa.UniPlus.Selecao.Domain.UnitTests/ValueObjects/PredicadoDnfTests.cs
@@ -341,12 +341,12 @@ public sealed class PredicadoDnfTests
         predicado.Avaliar(fatos).Should().Be(Ternario.Falso);
     }
 
-    // ── Story #926 — NÃO_APLICÁVEL é estado próprio do átomo, distinto de INDETERMINADO ──
+    // ── Story #926 — NAO_APLICAVEL é estado próprio do átomo, distinto de INDETERMINADO ──
 
     private static Dictionary<string, FatoResolvido> Estados(params (string Fato, FatoResolvido Estado)[] entradas) =>
         entradas.ToDictionary(static e => e.Fato, static e => e.Estado, StringComparer.Ordinal);
 
-    [Theory(DisplayName = "Átomo sobre fato NÃO_APLICÁVEL é não-aplicável para todo operador — a negação não inverte a inaplicabilidade")]
+    [Theory(DisplayName = "Átomo sobre fato NAO_APLICAVEL é não-aplicável para todo operador — a negação não inverte a inaplicabilidade")]
     [InlineData(Operador.Igual)]
     [InlineData(Operador.Diferente)]
     [InlineData(Operador.Em)]
@@ -388,7 +388,7 @@ public sealed class PredicadoDnfTests
         predicado.Avaliar(Estados(("SEXO", fato))).Should().Be(Ternario.Verdadeiro);
     }
 
-    [Fact(DisplayName = "Cláusula E com VERDADEIRO e NÃO_APLICÁVEL resolve Falso — o não-aplicável colapsa, não é ignorado")]
+    [Fact(DisplayName = "Cláusula E com VERDADEIRO e NAO_APLICAVEL resolve Falso — o não-aplicável colapsa, não é ignorado")]
     public void Clausula_VerdadeiroComNaoAplicavel_Falso()
     {
         PredicadoDnf predicado = Predicado(
@@ -404,7 +404,7 @@ public sealed class PredicadoDnfTests
             "sem o colapso o átomo não-aplicável seria ignorado e a cláusula resolveria verdadeiro por um opt-in que nem foi perguntado");
     }
 
-    [Fact(DisplayName = "Cláusula E com NÃO_APLICÁVEL e INDETERMINADO resolve Falso — o não-aplicável é definitivo e vence a pendência")]
+    [Fact(DisplayName = "Cláusula E com NAO_APLICAVEL e INDETERMINADO resolve Falso — o não-aplicável é definitivo e vence a pendência")]
     public void Clausula_NaoAplicavelComIndeterminado_Falso()
     {
         PredicadoDnf predicado = Predicado(


### PR DESCRIPTION
## Contexto

Os tokens de domínio em caixa alta deste repositório não levam acento — `NAO_EM`, `NAO_INFORMADO`, `MAIOR_IGUAL`, `SEGUE_CASCATA`. Conferi: não existe **nenhum** token acentuado em todo o código.

O estado de inaplicabilidade introduzido na avaliação de predicado entrou fora desse padrão, grafado com acento em comentário e em nome de teste.

## O que muda

Sete ocorrências, de `NÃO_APLICÁVEL` para `NAO_APLICAVEL`:

| Arquivo | Ocorrências |
|---|---|
| `AvaliadorConformidadeLegal.cs` | 1 (comentário) |
| `PredicadoDnfTests.cs` | 4 (nomes de teste) |
| `ResolvedorArvoreSatisfacaoTests.cs` | 2 (nomes de teste) |

Nenhuma alcançava literal de wire, nome de membro ou valor persistido — **não há mudança de comportamento**. O ganho é de consistência: um token com bytes multibyte escapa de busca textual e divide quem escreve com e sem acento, que é o que a convenção evita.

Os nomes de membro em C# (`EstadoFato.NaoAplicavel`, `EstadoAtomo.NaoAplicavel`) já estavam corretos.

## Validação

```
dotnet build UniPlus.slnx           → 0 erros, 0 avisos
dotnet test UniPlus.slnx            → suíte completa, 0 falhas
dotnet format --verify-no-changes   → 0 diagnósticos (comando exato do CI)
```

Refs #926