### PR TITLE
feat(selecao): coleta de fatos do candidato por grafo de pré-condições

### DIFF
--- a/src/selecao/Unifesspa.UniPlus.Selecao.API/Errors/SelecaoDomainErrorRegistration.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.API/Errors/SelecaoDomainErrorRegistration.cs
@@ -206,6 +206,21 @@ internal sealed class SelecaoDomainErrorRegistration : IDomainErrorRegistration
         new("ProcessoSeletivo.ConformidadeInsuficiente", new DomainErrorMapping(StatusCodes.Status422UnprocessableEntity, "uniplus.selecao.processo_seletivo.conformidade_insuficiente", "Processo não conforme para publicação")),
         new("ProcessoSeletivo.ConformidadeLegalInsuficiente", new DomainErrorMapping(StatusCodes.Status422UnprocessableEntity, "uniplus.selecao.processo_seletivo.conformidade_legal_insuficiente", "Processo não conforme às obrigatoriedades legais vigentes")),
         new("ProcessoSeletivo.MutacaoPosPublicacaoBloqueada", new DomainErrorMapping(StatusCodes.Status422UnprocessableEntity, "uniplus.selecao.processo_seletivo.mutacao_pos_publicacao_bloqueada", "Processo publicado não aceita mutação direta da configuração")),
+        // Grafo de coleta de fatos do candidato (Story #926). Todas as recusas são de configuração
+        // (422): grafo mal formado, ou tentativa de editá-lo após a publicação enquanto o
+        // congelamento conjunto (#928) ainda não existe. Os códigos de FatoColetado usam constantes
+        // e escapam do fitness test — registrados aqui à mão para não caírem em 500 genérico quando
+        // o endpoint de configuração do grafo existir.
+        new("ProcessoSeletivo.GrafoDeFatosSomenteEmRascunho", new DomainErrorMapping(StatusCodes.Status422UnprocessableEntity, "uniplus.selecao.processo_seletivo.grafo_de_fatos_somente_em_rascunho", "O grafo de coleta de fatos só é editável antes da primeira publicação")),
+        new("FatoColetado.FatoCodigoObrigatorio", new DomainErrorMapping(StatusCodes.Status422UnprocessableEntity, "uniplus.selecao.fato_coletado.fato_codigo_obrigatorio", "O código do fato coletado é obrigatório")),
+        new("FatoColetado.OrdemInvalida", new DomainErrorMapping(StatusCodes.Status422UnprocessableEntity, "uniplus.selecao.fato_coletado.ordem_invalida", "A ordem de coleta não pode ser negativa")),
+        new("FatoColetado.PrecondicaoAutorreferente", new DomainErrorMapping(StatusCodes.Status422UnprocessableEntity, "uniplus.selecao.fato_coletado.precondicao_autorreferente", "A pré-condição de um fato cita o próprio fato")),
+        new("FatoColetado.FatoDuplicado", new DomainErrorMapping(StatusCodes.Status422UnprocessableEntity, "uniplus.selecao.fato_coletado.fato_duplicado", "Um fato aparece mais de uma vez na coleta")),
+        new("FatoColetado.OrdemDuplicada", new DomainErrorMapping(StatusCodes.Status422UnprocessableEntity, "uniplus.selecao.fato_coletado.ordem_duplicada", "A ordem de coleta precisa ser total — sem empate entre fatos")),
+        new("FatoColetado.PrecondicaoCitaFatoNaoColetado", new DomainErrorMapping(StatusCodes.Status422UnprocessableEntity, "uniplus.selecao.fato_coletado.precondicao_cita_fato_nao_coletado", "A pré-condição cita um fato que este processo não coleta")),
+        new("FatoColetado.PrecondicaoCitaFatoPosterior", new DomainErrorMapping(StatusCodes.Status422UnprocessableEntity, "uniplus.selecao.fato_coletado.precondicao_cita_fato_posterior", "A pré-condição cita um fato posterior na ordem de coleta")),
+        new("FatoColetado.GrafoComCiclo", new DomainErrorMapping(StatusCodes.Status422UnprocessableEntity, "uniplus.selecao.fato_coletado.grafo_com_ciclo", "As pré-condições dos fatos formam um ciclo")),
+        new("CondicaoPrecondicaoFato.ClausulaInvalida", new DomainErrorMapping(StatusCodes.Status422UnprocessableEntity, "uniplus.selecao.condicao_precondicao_fato.clausula_invalida", "O ordinal da cláusula da pré-condição não pode ser negativo")),
         new("ProcessoSeletivo.DocumentoNaoEncontrado", new DomainErrorMapping(StatusCodes.Status422UnprocessableEntity, "uniplus.selecao.processo_seletivo.documento_nao_encontrado", "Documento do Edital não encontrado ou não pertence a este processo")),
         new("ProcessoSeletivo.DocumentoNaoConfirmado", new DomainErrorMapping(StatusCodes.Status422UnprocessableEntity, "uniplus.selecao.processo_seletivo.documento_nao_confirmado", "Somente um documento confirmado pode ser referenciado na publicação")),
         // Story #919 (RN08): defesa em profundidade — o vocabulário de fatos é fechado e

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Domain/Entities/CondicaoPrecondicaoFato.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Domain/Entities/CondicaoPrecondicaoFato.cs
@@ -1,0 +1,85 @@
+namespace Unifesspa.UniPlus.Selecao.Domain.Entities;
+
+using System.Text.Json;
+
+using Enums;
+
+using Unifesspa.UniPlus.Kernel.Domain.Entities;
+using Unifesspa.UniPlus.Kernel.Results;
+using Unifesspa.UniPlus.Selecao.Domain.ValueObjects;
+
+/// <summary>
+/// Uma condição da pré-condição de um <see cref="FatoColetado"/> (Story #926) — a forma
+/// <b>relacional</b> (linha com ordinal de cláusula) da tripla <c>{ Fato, Operador, Valor }</c>.
+/// Agrupadas por <see cref="Clausula"/> (OU entre cláusulas, E dentro), formam o predicado que
+/// decide se o campo produtor do fato é apresentado ao candidato.
+/// </summary>
+/// <remarks>
+/// Deliberadamente separada de <see cref="CondicaoGatilho"/>, apesar da forma idêntica: aquela é
+/// filha de <see cref="DocumentoExigido"/> e responde "esta exigência se aplica?"; esta é filha de
+/// <see cref="FatoColetado"/> e responde "este campo é apresentado?". Unificá-las sob um
+/// discriminador acoplaria dois ciclos de vida distintos — a exigência é substituída com os
+/// documentos, o fato coletado com o formulário — e faria a chave estrangeira de uma valer para a
+/// outra. O reúso está onde importa: ambas produzem <see cref="CondicaoDnf"/> e são avaliadas pelo
+/// mesmo <see cref="ValueObjects.PredicadoDnf"/>.
+/// </remarks>
+public sealed class CondicaoPrecondicaoFato : EntityBase
+{
+    public Guid FatoColetadoId { get; private set; }
+
+    /// <summary>Ordinal da cláusula — OU entre cláusulas, E dentro da mesma cláusula.</summary>
+    public int Clausula { get; private set; }
+
+    /// <summary>Código do fato citado — sempre um fato <b>anterior</b> na ordem de coleta.</summary>
+    public string Fato { get; private set; } = string.Empty;
+
+    public Operador Operador { get; private set; }
+
+    public JsonElement Valor { get; private set; }
+
+    private CondicaoPrecondicaoFato() { }
+
+    /// <summary>
+    /// Cria a condição validando a <b>forma</b> via <see cref="CondicaoDnf.Criar"/>. A validação
+    /// semântica — fato no vocabulário fechado, operador × domínio, valor × domínio — é do
+    /// <see cref="Services.PredicadoDnfValidador"/>, resolvido pela Application, que tem acesso ao
+    /// vocabulário cross-módulo. A validação <b>estrutural</b> do grafo (fato citado existe na
+    /// coleta, é anterior, e não fecha ciclo) é do agregado, em
+    /// <see cref="ProcessoSeletivo.DefinirFatosColetados"/>.
+    /// </summary>
+    public static Result<CondicaoPrecondicaoFato> Criar(int clausula, string fato, Operador operador, JsonElement valor)
+    {
+        if (clausula < 0)
+        {
+            return Result<CondicaoPrecondicaoFato>.Failure(new DomainError(
+                CondicaoPrecondicaoFatoErrorCodes.ClausulaInvalida,
+                "O ordinal da cláusula não pode ser negativo."));
+        }
+
+        Result<CondicaoDnf> condicaoResult = CondicaoDnf.Criar(fato, operador, valor);
+        if (condicaoResult.IsFailure)
+        {
+            return Result<CondicaoPrecondicaoFato>.Failure(condicaoResult.Error!);
+        }
+
+        CondicaoDnf condicao = condicaoResult.Value!;
+        return Result<CondicaoPrecondicaoFato>.Success(new CondicaoPrecondicaoFato
+        {
+            Clausula = clausula,
+            Fato = condicao.Fato,
+            Operador = condicao.Operador,
+            Valor = condicao.Valor,
+        });
+    }
+
+    internal void VincularFatoColetado(Guid fatoColetadoId) => FatoColetadoId = fatoColetadoId;
+
+    /// <summary>Reconstrói o VO já validado — a forma foi provada em <see cref="Criar"/>.</summary>
+    internal CondicaoDnf ParaCondicaoDnf() => CondicaoDnf.Criar(Fato, Operador, Valor).Value!;
+}
+
+/// <summary>Códigos de erro de <see cref="CondicaoPrecondicaoFato"/>.</summary>
+public static class CondicaoPrecondicaoFatoErrorCodes
+{
+    public const string ClausulaInvalida = "CondicaoPrecondicaoFato.ClausulaInvalida";
+}

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Domain/Entities/FatoColetado.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Domain/Entities/FatoColetado.cs
@@ -1,0 +1,125 @@
+namespace Unifesspa.UniPlus.Selecao.Domain.Entities;
+
+using Unifesspa.UniPlus.Kernel.Domain.Entities;
+using Unifesspa.UniPlus.Kernel.Results;
+
+/// <summary>
+/// Um fato do vocabulário que <b>este</b> processo seletivo coleta do candidato, com a sua
+/// posição na ordem de coleta e a pré-condição que decide se o campo produtor é apresentado
+/// (Story #926).
+/// </summary>
+/// <remarks>
+/// <para>
+/// A pré-condição é <b>aresta do grafo por processo, não propriedade do catálogo</b>: o mesmo
+/// fato pode ser coletado sem gate nenhum em outro processo. Por isso vive aqui, na configuração
+/// do certame, e não em <c>FatoCandidato</c> — que é catálogo global e seed-governado (ADR-0111).
+/// </para>
+/// <para>
+/// Fato <b>sem</b> pré-condição é coletado sempre — é o caso das autodeclarações de abertura, que
+/// não dependem de nada anterior. Fato com pré-condição só é apresentado quando o predicado
+/// resolve verdadeiro; quando resolve falso, o fato vinculado passa a não-aplicável, e quando
+/// fica indeterminado, o fato o acompanha.
+/// </para>
+/// </remarks>
+public sealed class FatoColetado : EntityBase
+{
+    private readonly List<CondicaoPrecondicaoFato> _precondicoes = [];
+
+    public Guid ProcessoSeletivoId { get; private set; }
+
+    /// <summary>Código do fato no vocabulário fechado do candidato.</summary>
+    public string FatoCodigo { get; private set; } = string.Empty;
+
+    /// <summary>
+    /// Posição na ordem de coleta. Estritamente crescente e única no processo: é ela que dá
+    /// sentido a "fato anterior", e todo fato citado numa pré-condição precisa ter ordem menor
+    /// que a do fato que o cita.
+    /// </summary>
+    public int Ordem { get; private set; }
+
+    public IReadOnlyCollection<CondicaoPrecondicaoFato> Precondicoes => _precondicoes.AsReadOnly();
+
+    private FatoColetado() { }
+
+    public static Result<FatoColetado> Criar(
+        string fatoCodigo,
+        int ordem,
+        IReadOnlyList<CondicaoPrecondicaoFato>? precondicoes)
+    {
+        if (string.IsNullOrWhiteSpace(fatoCodigo))
+        {
+            return Result<FatoColetado>.Failure(new DomainError(
+                FatoColetadoErrorCodes.FatoCodigoObrigatorio,
+                "O código do fato coletado é obrigatório."));
+        }
+
+        if (ordem < 0)
+        {
+            return Result<FatoColetado>.Failure(new DomainError(
+                FatoColetadoErrorCodes.OrdemInvalida,
+                "A ordem de coleta não pode ser negativa."));
+        }
+
+        string codigo = fatoCodigo.Trim();
+        IReadOnlyList<CondicaoPrecondicaoFato> condicoes = precondicoes ?? [];
+
+        // Auto-referência é ciclo de comprimento um. Barrada aqui, na criação, porque não depende
+        // de conhecer os irmãos — e um erro específico diz mais do que o genérico de ciclo, que
+        // reportaria um caminho de um nó só. Toda a validação acontece antes de qualquer mutação:
+        // uma condição só é vinculada depois de o fato inteiro ser aceito, para nunca deixar uma
+        // instância recebida do chamador apontando para um fato que a factory acabou de recusar.
+        foreach (CondicaoPrecondicaoFato precondicao in condicoes)
+        {
+            if (string.Equals(precondicao.Fato, codigo, StringComparison.Ordinal))
+            {
+                return Result<FatoColetado>.Failure(new DomainError(
+                    FatoColetadoErrorCodes.PrecondicaoAutorreferente,
+                    $"A pré-condição do fato '{codigo}' cita o próprio fato."));
+            }
+        }
+
+        FatoColetado fato = new() { FatoCodigo = codigo, Ordem = ordem };
+        foreach (CondicaoPrecondicaoFato precondicao in condicoes)
+        {
+            precondicao.VincularFatoColetado(fato.Id);
+            fato._precondicoes.Add(precondicao);
+        }
+
+        return Result<FatoColetado>.Success(fato);
+    }
+
+    /// <summary>Indica se o fato é coletado incondicionalmente.</summary>
+    public bool SemPrecondicao => _precondicoes.Count == 0;
+
+    /// <summary>Códigos dos fatos citados na pré-condição, sem repetição.</summary>
+    public IReadOnlyCollection<string> FatosCitados =>
+        [.. _precondicoes.Select(static c => c.Fato).Distinct(StringComparer.Ordinal)];
+
+    internal void VincularProcessoSeletivo(Guid processoSeletivoId) =>
+        ProcessoSeletivoId = processoSeletivoId;
+
+    /// <summary>
+    /// O predicado de pré-condição na forma avaliável, ou <see langword="null"/> quando o fato é
+    /// coletado incondicionalmente. Um predicado sem cláusula nenhuma avaliaria falso — que é o
+    /// oposto de "sem pré-condição" —, então a ausência é representada pelo nulo, nunca por um
+    /// predicado vazio.
+    /// </summary>
+    internal ValueObjects.PredicadoDnf? ParaPredicado() =>
+        _precondicoes.Count == 0
+            ? null
+            : ValueObjects.PredicadoDnf.CriarDeCondicoesAgrupadas(
+                [.. _precondicoes.Select(static c => (c.Clausula, c.ParaCondicaoDnf()))]).Value!;
+}
+
+/// <summary>Códigos de erro de <see cref="FatoColetado"/>.</summary>
+public static class FatoColetadoErrorCodes
+{
+    public const string FatoCodigoObrigatorio = "FatoColetado.FatoCodigoObrigatorio";
+    public const string OrdemInvalida = "FatoColetado.OrdemInvalida";
+    public const string PrecondicaoAutorreferente = "FatoColetado.PrecondicaoAutorreferente";
+    public const string FatoDuplicado = "FatoColetado.FatoDuplicado";
+    public const string OrdemDuplicada = "FatoColetado.OrdemDuplicada";
+    public const string PrecondicaoCitaFatoNaoColetado = "FatoColetado.PrecondicaoCitaFatoNaoColetado";
+    public const string PrecondicaoCitaFatoPosterior = "FatoColetado.PrecondicaoCitaFatoPosterior";
+    public const string GrafoComCiclo = "FatoColetado.GrafoComCiclo";
+}

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Domain/Entities/ProcessoSeletivo.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Domain/Entities/ProcessoSeletivo.cs
@@ -912,16 +912,26 @@ public sealed class ProcessoSeletivo : SoftDeletableEntity
     /// devolve o <b>caminho</b> do ciclo, que é o que um administrador precisa para corrigir a
     /// configuração — enquanto o erro de ordem apontaria só um par de fatos.
     /// </para>
+    /// <para>
+    /// <b>Só é aceito antes da primeira publicação</b> (processo em <c>Rascunho</c>), e por isso
+    /// não recebe precondição de concorrência — em rascunho não há sessão editorial nem ETag. Ao
+    /// contrário dos demais <c>Definir*</c>, o grafo ainda não participa do congelamento nem da
+    /// restauração da configuração; enquanto essa integração não existe, permitir a edição sob
+    /// retificação criaria um estado mutável que o envelope congelado não cobre e que o descarte
+    /// da retificação não reverteria. A edição sob retificação, junto do congelamento do grafo no
+    /// envelope, é entregue na story do congelamento conjunto (#928).
+    /// </para>
     /// </remarks>
-    public Result DefinirFatosColetados(
-        IReadOnlyList<FatoColetado> fatosColetados,
-        PrecondicaoIfMatch precondicao)
+    public Result DefinirFatosColetados(IReadOnlyList<FatoColetado> fatosColetados)
     {
         ArgumentNullException.ThrowIfNull(fatosColetados);
 
-        if (MutacaoBloqueada(precondicao) is { } bloqueio)
+        if (Status != StatusProcesso.Rascunho)
         {
-            return Result.Failure(bloqueio);
+            return Result.Failure(new DomainError(
+                "ProcessoSeletivo.GrafoDeFatosSomenteEmRascunho",
+                "O grafo de coleta de fatos só pode ser definido antes da primeira publicação — "
+                + "a edição sob retificação depende do congelamento conjunto do grafo (#928)."));
         }
 
         if (ValidarGrafoDeFatos(fatosColetados) is { } erro)
@@ -936,11 +946,6 @@ public sealed class ProcessoSeletivo : SoftDeletableEntity
             _fatosColetados.Add(fato);
         }
 
-        // Numa retificação, esta escrita avança a revisão da sessão editorial — é o que faz o
-        // ETag mudar e impede que uma escrita concorrente com o If-Match antigo sobrescreva esta
-        // (mesmo controle dos demais Definir*). Fora de retificação, o rascunho é nulo e o bump
-        // é inócuo.
-        Rascunho?.IncrementarRevisao();
         return Result.Success();
     }
 

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Domain/Entities/ProcessoSeletivo.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Domain/Entities/ProcessoSeletivo.cs
@@ -68,6 +68,15 @@ public sealed class ProcessoSeletivo : SoftDeletableEntity
     /// antigo <c>DocumentoExigido.GrupoSatisfacaoId</c> (grupo plano, residual). Use
     /// <see cref="RaizesDeExigencia"/> para as raízes da floresta.
     /// </summary>
+    private readonly List<FatoColetado> _fatosColetados = [];
+
+    /// <summary>
+    /// Os fatos que este processo coleta do candidato, com a ordem de coleta e a pré-condição de
+    /// cada um (Story #926). Formam um grafo acíclico: a pré-condição de um fato só cita fatos
+    /// anteriores na ordem.
+    /// </summary>
+    public IReadOnlyCollection<FatoColetado> FatosColetados => _fatosColetados.AsReadOnly();
+
     private readonly List<NoExigencia> _nosExigencia = [];
     public IReadOnlyCollection<NoExigencia> NosExigencia => _nosExigencia.AsReadOnly();
 
@@ -763,6 +772,7 @@ public sealed class ProcessoSeletivo : SoftDeletableEntity
     /// revalidados aqui. O gatilho DNF (<c>CondicaoGatilho</c>, PR #896), a base legal
     /// (PR #898) e a idade/formato/tamanho (PR #900) não são tocados aqui.
     /// </remarks>
+
     public Result DefinirDocumentosExigidos(
         IReadOnlyList<NoExigencia> raizes,
         PrecondicaoIfMatch precondicao)
@@ -883,6 +893,162 @@ public sealed class ProcessoSeletivo : SoftDeletableEntity
 
         Rascunho?.IncrementarRevisao();
         return Result.Success();
+    }
+
+    /// <summary>
+    /// Substitui integralmente o grafo de coleta de fatos: quais fatos este processo coleta, em
+    /// que ordem, e sob qual pré-condição cada campo é apresentado (Story #926).
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Os invariantes fazem cumprir a norma de que uma pré-condição só cita <b>fatos
+    /// anteriores</b>. Isso é mais estrito do que exigir apenas aciclicidade: um grafo pode ser
+    /// acíclico e ainda assim ter um fato citando outro que vem depois dele na ordem de coleta —
+    /// o que produziria um formulário em que a pergunta depende de uma resposta ainda não dada.
+    /// </para>
+    /// <para>
+    /// A checagem de ordem sozinha já implica aciclicidade, porque um ciclo exigiria um fato com
+    /// ordem menor que a de si mesmo. A detecção de ciclo é feita mesmo assim, e antes: ela
+    /// devolve o <b>caminho</b> do ciclo, que é o que um administrador precisa para corrigir a
+    /// configuração — enquanto o erro de ordem apontaria só um par de fatos.
+    /// </para>
+    /// </remarks>
+    public Result DefinirFatosColetados(
+        IReadOnlyList<FatoColetado> fatosColetados,
+        PrecondicaoIfMatch precondicao)
+    {
+        ArgumentNullException.ThrowIfNull(fatosColetados);
+
+        if (MutacaoBloqueada(precondicao) is { } bloqueio)
+        {
+            return Result.Failure(bloqueio);
+        }
+
+        if (ValidarGrafoDeFatos(fatosColetados) is { } erro)
+        {
+            return Result.Failure(erro);
+        }
+
+        _fatosColetados.Clear();
+        foreach (FatoColetado fato in fatosColetados)
+        {
+            fato.VincularProcessoSeletivo(Id);
+            _fatosColetados.Add(fato);
+        }
+
+        // Numa retificação, esta escrita avança a revisão da sessão editorial — é o que faz o
+        // ETag mudar e impede que uma escrita concorrente com o If-Match antigo sobrescreva esta
+        // (mesmo controle dos demais Definir*). Fora de retificação, o rascunho é nulo e o bump
+        // é inócuo.
+        Rascunho?.IncrementarRevisao();
+        return Result.Success();
+    }
+
+    private static DomainError? ValidarGrafoDeFatos(IReadOnlyList<FatoColetado> fatos)
+    {
+        Dictionary<string, FatoColetado> porCodigo = new(StringComparer.Ordinal);
+        HashSet<int> ordens = [];
+
+        foreach (FatoColetado fato in fatos)
+        {
+            if (!porCodigo.TryAdd(fato.FatoCodigo, fato))
+            {
+                return new DomainError(
+                    FatoColetadoErrorCodes.FatoDuplicado,
+                    $"O fato '{fato.FatoCodigo}' aparece mais de uma vez na coleta.");
+            }
+
+            if (!ordens.Add(fato.Ordem))
+            {
+                return new DomainError(
+                    FatoColetadoErrorCodes.OrdemDuplicada,
+                    $"A ordem {fato.Ordem} é usada por mais de um fato — a ordem de coleta precisa ser total.");
+            }
+        }
+
+        // Ciclo antes de ordem: o erro de ciclo nomeia o caminho inteiro, que é acionável;
+        // o de ordem apontaria só o primeiro par fora de sequência do mesmo problema.
+        if (DetectarCiclo(porCodigo) is { } caminho)
+        {
+            return new DomainError(
+                FatoColetadoErrorCodes.GrafoComCiclo,
+                $"A pré-condição dos fatos forma um ciclo: {string.Join(" → ", caminho)}.");
+        }
+
+        foreach (FatoColetado fato in fatos)
+        {
+            foreach (string citado in fato.FatosCitados)
+            {
+                if (!porCodigo.TryGetValue(citado, out FatoColetado? anterior))
+                {
+                    return new DomainError(
+                        FatoColetadoErrorCodes.PrecondicaoCitaFatoNaoColetado,
+                        $"A pré-condição do fato '{fato.FatoCodigo}' cita '{citado}', que este processo não coleta.");
+                }
+
+                if (anterior.Ordem >= fato.Ordem)
+                {
+                    return new DomainError(
+                        FatoColetadoErrorCodes.PrecondicaoCitaFatoPosterior,
+                        $"A pré-condição do fato '{fato.FatoCodigo}' (ordem {fato.Ordem}) cita '{citado}' "
+                        + $"(ordem {anterior.Ordem}), que não é anterior — o campo dependeria de uma resposta ainda não dada.");
+                }
+            }
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Busca em profundidade com marcação tricolor, devolvendo o caminho do primeiro ciclo
+    /// encontrado — ou <see langword="null"/> quando o grafo é acíclico. A travessia segue, de
+    /// cada fato, os fatos que a sua pré-condição <b>cita</b>, de modo que um caminho reportado
+    /// <c>A → B → A</c> se lê "A cita B, B cita A".
+    /// </summary>
+    private static IReadOnlyList<string>? DetectarCiclo(Dictionary<string, FatoColetado> porCodigo)
+    {
+        HashSet<string> visitados = new(StringComparer.Ordinal);
+        HashSet<string> naPilha = new(StringComparer.Ordinal);
+        List<string> caminho = [];
+
+        foreach (string codigo in porCodigo.Keys)
+        {
+            if (Visitar(codigo) is { } ciclo)
+            {
+                return ciclo;
+            }
+        }
+
+        return null;
+
+        IReadOnlyList<string>? Visitar(string codigo)
+        {
+            if (naPilha.Contains(codigo))
+            {
+                int inicio = caminho.IndexOf(codigo);
+                return [.. caminho[inicio..], codigo];
+            }
+
+            if (!visitados.Add(codigo) || !porCodigo.TryGetValue(codigo, out FatoColetado? fato))
+            {
+                return null;
+            }
+
+            naPilha.Add(codigo);
+            caminho.Add(codigo);
+
+            foreach (string citado in fato.FatosCitados)
+            {
+                if (Visitar(citado) is { } ciclo)
+                {
+                    return ciclo;
+                }
+            }
+
+            naPilha.Remove(codigo);
+            caminho.RemoveAt(caminho.Count - 1);
+            return null;
+        }
     }
 
     /// <summary>

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Domain/Services/ResolvedorEstadoFatos.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Domain/Services/ResolvedorEstadoFatos.cs
@@ -1,0 +1,92 @@
+namespace Unifesspa.UniPlus.Selecao.Domain.Services;
+
+using System.Text.Json;
+
+using Unifesspa.UniPlus.Selecao.Domain.Entities;
+using Unifesspa.UniPlus.Selecao.Domain.Enums;
+using Unifesspa.UniPlus.Selecao.Domain.ValueObjects;
+
+/// <summary>
+/// Resolve o estado de cada fato do candidato a partir do grafo de coleta congelado e das
+/// respostas que ele efetivamente deu (Story #926). É a ponte entre a configuração — quais campos
+/// existem e sob que pré-condição — e a álgebra que avalia gatilhos.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Função pura: a mesma entrada produz sempre a mesma saída, sem tocar em banco nem em relógio.
+/// Isso é o que torna a <b>invalidação de resposta obsoleta</b> uma propriedade da resolução em
+/// vez de uma operação de escrita — quando a pré-condição de um campo passa a ser falsa, o fato
+/// resolve não-aplicável e a resposta que estava lá simplesmente não entra no resultado, sem
+/// precisar apagá-la de lugar nenhum.
+/// </para>
+/// <para>
+/// A ordem de avaliação é a ordem de coleta, que o agregado já garante ser total e coerente com
+/// as dependências: quando um fato é avaliado, todo fato que a sua pré-condição cita já está
+/// resolvido. Não há segunda passada nem ponto fixo a calcular.
+/// </para>
+/// </remarks>
+public static class ResolvedorEstadoFatos
+{
+    /// <summary>
+    /// Resolve todos os fatos coletados pelo processo.
+    /// </summary>
+    /// <param name="fatosColetados">O grafo de coleta — fatos, ordem e pré-condições.</param>
+    /// <param name="respostasBrutas">
+    /// O que o candidato respondeu, por código de fato. Uma chave que não corresponde a fato
+    /// coletado é <b>ignorada</b>: o grafo é a autoridade sobre o que existe, e uma resposta órfã
+    /// não deve criar um fato que a configuração não prevê.
+    /// </param>
+    public static IReadOnlyDictionary<string, FatoResolvido> Resolver(
+        IReadOnlyCollection<FatoColetado> fatosColetados,
+        IReadOnlyDictionary<string, JsonElement> respostasBrutas)
+    {
+        ArgumentNullException.ThrowIfNull(fatosColetados);
+        ArgumentNullException.ThrowIfNull(respostasBrutas);
+
+        Dictionary<string, FatoResolvido> resolvidos = new(StringComparer.Ordinal);
+
+        foreach (FatoColetado fato in fatosColetados.OrderBy(static f => f.Ordem))
+        {
+            resolvidos[fato.FatoCodigo] = ResolverFato(fato, respostasBrutas, resolvidos);
+        }
+
+        return resolvidos;
+    }
+
+    private static FatoResolvido ResolverFato(
+        FatoColetado fato,
+        IReadOnlyDictionary<string, JsonElement> respostasBrutas,
+        IReadOnlyDictionary<string, FatoResolvido> jaResolvidos)
+    {
+        if (fato.ParaPredicado() is { } precondicao)
+        {
+            switch (precondicao.Avaliar(jaResolvidos))
+            {
+                case Ternario.Falso:
+                    // O campo não é apresentado. Estado resolvido e definitivo — e é aqui que uma
+                    // resposta gravada antes, quando a pré-condição ainda era verdadeira, deixa de
+                    // valer: ela nem chega a ser lida.
+                    return FatoResolvido.NaoAplicavel();
+
+                case Ternario.Indeterminado:
+                    // Ainda não se sabe se o campo se aplica, porque algum fato de que ele depende
+                    // não foi respondido. Propagar a indeterminação é o comportamento fail-closed:
+                    // decidir por não-aplicável dispensaria o que talvez venha a ser exigido.
+                    return FatoResolvido.Indeterminado();
+
+                case Ternario.Verdadeiro:
+                default:
+                    break;
+            }
+        }
+
+        // O campo se aplica: o estado passa a depender só de o candidato ter respondido ou não.
+        if (!respostasBrutas.TryGetValue(fato.FatoCodigo, out JsonElement resposta)
+            || resposta.ValueKind is JsonValueKind.Null or JsonValueKind.Undefined)
+        {
+            return FatoResolvido.Indeterminado();
+        }
+
+        return FatoResolvido.Resolvido(resposta);
+    }
+}

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/Persistence/Configurations/CondicaoPrecondicaoFatoConfiguration.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/Persistence/Configurations/CondicaoPrecondicaoFatoConfiguration.cs
@@ -1,0 +1,63 @@
+namespace Unifesspa.UniPlus.Selecao.Infrastructure.Persistence.Configurations;
+
+using System.Text.Json;
+
+using Domain.Entities;
+using Domain.Enums;
+
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.ChangeTracking;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
+
+/// <summary>
+/// Configuração EF Core de <see cref="CondicaoPrecondicaoFato"/> (Story #926) — entidade filha de
+/// <see cref="FatoColetado"/>, <c>EntityBase</c> puro (sem soft-delete). Mesmo mapeamento de
+/// <see cref="CondicaoGatilhoConfiguration"/>: o operador vai para a coluna pelo token canônico do
+/// wire, nunca por <c>enum.ToString()</c>, e o valor é <c>jsonb</c> serializado pelo texto bruto.
+/// </summary>
+public sealed class CondicaoPrecondicaoFatoConfiguration : IEntityTypeConfiguration<CondicaoPrecondicaoFato>
+{
+    private const int FatoMaxLength = 60;
+    private const int OperadorCodigoMaxLength = 20;
+
+    public void Configure(EntityTypeBuilder<CondicaoPrecondicaoFato> builder)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+
+        builder.ToTable("condicoes_precondicao_fato");
+        builder.HasKey(c => c.Id);
+        builder.Property(c => c.Id).ValueGeneratedNever();
+
+        builder.Property(c => c.Clausula).IsRequired();
+        builder.Property(c => c.Fato).HasMaxLength(FatoMaxLength).IsRequired();
+
+        builder.Property(c => c.Operador)
+            .HasConversion(OperadorConverter)
+            .HasMaxLength(OperadorCodigoMaxLength)
+            .IsRequired();
+
+        builder.Property(c => c.Valor)
+            .HasConversion(JsonElementConverter, JsonElementComparer)
+            .HasColumnType("jsonb")
+            .IsRequired();
+    }
+
+    private static readonly ValueConverter<Operador, string> OperadorConverter =
+        new(operador => operador.ToCodigo(), codigo => OperadorCodigo.FromCodigo(codigo));
+
+    private static readonly ValueConverter<JsonElement, string> JsonElementConverter =
+        new(element => element.GetRawText(), json => Parse(json));
+
+    private static readonly ValueComparer<JsonElement> JsonElementComparer =
+        new(
+            (a, b) => a.GetRawText() == b.GetRawText(),
+            v => v.GetRawText().GetHashCode(StringComparison.Ordinal),
+            v => Parse(v.GetRawText()));
+
+    private static JsonElement Parse(string json)
+    {
+        using JsonDocument document = JsonDocument.Parse(json);
+        return document.RootElement.Clone();
+    }
+}

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/Persistence/Configurations/FatoColetadoConfiguration.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/Persistence/Configurations/FatoColetadoConfiguration.cs
@@ -1,0 +1,47 @@
+namespace Unifesspa.UniPlus.Selecao.Infrastructure.Persistence.Configurations;
+
+using Domain.Entities;
+
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+/// <summary>
+/// Configuração EF Core de <see cref="FatoColetado"/> (Story #926) — entidade filha de
+/// <c>ProcessoSeletivo</c>, <c>EntityBase</c> puro (sem soft-delete). Substituível por inteiro
+/// junto com o processo, mesmo padrão de <c>DocumentoExigido</c>.
+/// </summary>
+public sealed class FatoColetadoConfiguration : IEntityTypeConfiguration<FatoColetado>
+{
+    private const int FatoCodigoMaxLength = 60;
+
+    public void Configure(EntityTypeBuilder<FatoColetado> builder)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+
+        builder.ToTable("fatos_coletados");
+        builder.HasKey(f => f.Id);
+        builder.Property(f => f.Id).ValueGeneratedNever();
+
+        builder.Property(f => f.FatoCodigo).HasMaxLength(FatoCodigoMaxLength).IsRequired();
+        builder.Property(f => f.Ordem).IsRequired();
+
+        // As duas unicidades são invariantes do agregado, feitas cumprir em
+        // DefinirFatosColetados; os índices as garantem também contra escrita concorrente e
+        // contra qualquer caminho que não passe pelo agregado.
+        builder.HasIndex(f => new { f.ProcessoSeletivoId, f.FatoCodigo })
+            .IsUnique()
+            .HasDatabaseName("ux_fatos_coletados_processo_fato");
+
+        builder.HasIndex(f => new { f.ProcessoSeletivoId, f.Ordem })
+            .IsUnique()
+            .HasDatabaseName("ux_fatos_coletados_processo_ordem");
+
+        builder.HasMany(f => f.Precondicoes)
+            .WithOne()
+            .HasForeignKey(c => c.FatoColetadoId)
+            .OnDelete(DeleteBehavior.Cascade);
+
+        builder.Navigation(f => f.Precondicoes)
+            .UsePropertyAccessMode(PropertyAccessMode.Field);
+    }
+}

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/Persistence/Configurations/ProcessoSeletivoConfiguration.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/Persistence/Configurations/ProcessoSeletivoConfiguration.cs
@@ -81,6 +81,17 @@ public sealed class ProcessoSeletivoConfiguration : IEntityTypeConfiguration<Pro
             .HasForeignKey(n => n.ProcessoSeletivoId)
             .OnDelete(DeleteBehavior.Cascade);
 
+        // Grafo de coleta de fatos (Story #926) — quais fatos o processo coleta, em que ordem e
+        // sob qual pré-condição. Cascade pelo mesmo motivo dos documentos exigidos: a FK é
+        // obrigatória e o agregado substitui a coleção por inteiro.
+        builder.HasMany(p => p.FatosColetados)
+            .WithOne()
+            .HasForeignKey(f => f.ProcessoSeletivoId)
+            .OnDelete(DeleteBehavior.Cascade);
+
+        builder.Navigation(p => p.FatosColetados)
+            .UsePropertyAccessMode(PropertyAccessMode.Field);
+
         // ReferenciaTemporalFatos (Story #554, PR #896) — VO 0..1 sem identidade própria,
         // owned inline em processos_seletivos (nunca entidade filha própria — ela não tem
         // Id nem ciclo de vida próprio, diferente das coleções acima).

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/Persistence/Migrations/20260722220228_AddGrafoDeColetaDeFatos.Designer.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/Persistence/Migrations/20260722220228_AddGrafoDeColetaDeFatos.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Unifesspa.UniPlus.Selecao.Infrastructure.Persistence;
@@ -11,9 +12,11 @@ using Unifesspa.UniPlus.Selecao.Infrastructure.Persistence;
 namespace Unifesspa.UniPlus.Selecao.Infrastructure.Persistence.Migrations
 {
     [DbContext(typeof(SelecaoDbContext))]
-    partial class SelecaoDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260722220228_AddGrafoDeColetaDeFatos")]
+    partial class AddGrafoDeColetaDeFatos
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/Persistence/Migrations/20260722220228_AddGrafoDeColetaDeFatos.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/Persistence/Migrations/20260722220228_AddGrafoDeColetaDeFatos.cs
@@ -1,0 +1,97 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Unifesspa.UniPlus.Selecao.Infrastructure.Persistence.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddGrafoDeColetaDeFatos : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "fatos_coletados",
+                schema: "selecao",
+                columns: table => new
+                {
+                    id = table.Column<Guid>(type: "uuid", nullable: false),
+                    processo_seletivo_id = table.Column<Guid>(type: "uuid", nullable: false),
+                    fato_codigo = table.Column<string>(type: "character varying(60)", maxLength: 60, nullable: false),
+                    ordem = table.Column<int>(type: "integer", nullable: false),
+                    created_at = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false),
+                    updated_at = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("pk_fatos_coletados", x => x.id);
+                    table.ForeignKey(
+                        name: "fk_fatos_coletados_processos_seletivos_processo_seletivo_id",
+                        column: x => x.processo_seletivo_id,
+                        principalSchema: "selecao",
+                        principalTable: "processos_seletivos",
+                        principalColumn: "id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "condicoes_precondicao_fato",
+                schema: "selecao",
+                columns: table => new
+                {
+                    id = table.Column<Guid>(type: "uuid", nullable: false),
+                    fato_coletado_id = table.Column<Guid>(type: "uuid", nullable: false),
+                    clausula = table.Column<int>(type: "integer", nullable: false),
+                    fato = table.Column<string>(type: "character varying(60)", maxLength: 60, nullable: false),
+                    operador = table.Column<string>(type: "character varying(20)", maxLength: 20, nullable: false),
+                    valor = table.Column<string>(type: "jsonb", nullable: false),
+                    created_at = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false),
+                    updated_at = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("pk_condicoes_precondicao_fato", x => x.id);
+                    table.ForeignKey(
+                        name: "fk_condicoes_precondicao_fato_fato_coletado_fato_coletado_id",
+                        column: x => x.fato_coletado_id,
+                        principalSchema: "selecao",
+                        principalTable: "fatos_coletados",
+                        principalColumn: "id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "ix_condicoes_precondicao_fato_fato_coletado_id",
+                schema: "selecao",
+                table: "condicoes_precondicao_fato",
+                column: "fato_coletado_id");
+
+            migrationBuilder.CreateIndex(
+                name: "ux_fatos_coletados_processo_fato",
+                schema: "selecao",
+                table: "fatos_coletados",
+                columns: new[] { "processo_seletivo_id", "fato_codigo" },
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "ux_fatos_coletados_processo_ordem",
+                schema: "selecao",
+                table: "fatos_coletados",
+                columns: new[] { "processo_seletivo_id", "ordem" },
+                unique: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "condicoes_precondicao_fato",
+                schema: "selecao");
+
+            migrationBuilder.DropTable(
+                name: "fatos_coletados",
+                schema: "selecao");
+        }
+    }
+}

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/Persistence/Repositories/ProcessoSeletivoRepository.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/Persistence/Repositories/ProcessoSeletivoRepository.cs
@@ -125,6 +125,12 @@ public sealed class ProcessoSeletivoRepository : IProcessoSeletivoRepository
             // sem novo ThenInclude de Condicoes/BasesLegais do documento.
             .Include(p => p.NosExigencia).ThenInclude(n => n.DocumentoExigido)
             .Include(p => p.NosExigencia).ThenInclude(n => n.BasesLegais)
+            // Grafo de coleta de fatos (Story #926) — MESMO raciocínio: sem o Include, a coleção
+            // tracked nasce vazia e DefinirFatosColetados faria Clear() num backing list já vazio,
+            // deixando as linhas antigas no banco. Sem o ThenInclude das pré-condições, o grafo
+            // seria reidratado sem aresta nenhuma: todo fato pareceria coletado
+            // incondicionalmente, e campos que deveriam ser suprimidos passariam a ser exigidos.
+            .Include(p => p.FatosColetados).ThenInclude(f => f.Precondicoes)
             // AsSplitQuery obrigatório a partir desta entrega: o produto cartesiano de
             // TODAS as coleções (etapas × condições × recursos × tipos × vagas ×
             // modalidades × desempate × eliminação × fases × bancas) num único JOIN

--- a/tests/Unifesspa.UniPlus.Selecao.Domain.UnitTests/Entities/ProcessoSeletivoFatosColetadosTests.cs
+++ b/tests/Unifesspa.UniPlus.Selecao.Domain.UnitTests/Entities/ProcessoSeletivoFatosColetadosTests.cs
@@ -1,0 +1,180 @@
+namespace Unifesspa.UniPlus.Selecao.Domain.UnitTests.Entities;
+
+using System.Text.Json;
+
+using AwesomeAssertions;
+
+using Unifesspa.UniPlus.Kernel.Results;
+using Unifesspa.UniPlus.Selecao.Domain.Entities;
+using Unifesspa.UniPlus.Selecao.Domain.Enums;
+using Unifesspa.UniPlus.Selecao.Domain.ValueObjects;
+
+/// <summary>
+/// Story #926 — invariantes do grafo de coleta de fatos. A norma não pede apenas um grafo acíclico:
+/// pede que a pré-condição de um fato cite somente fatos <b>anteriores</b> na ordem de coleta, o que
+/// é mais estrito e é o que impede um formulário em que a pergunta depende de resposta ainda não dada.
+/// </summary>
+public sealed class ProcessoSeletivoFatosColetadosTests
+{
+    private static JsonElement Sim => JsonSerializer.SerializeToElement(true);
+
+    private static ProcessoSeletivo NovoProcesso() =>
+        ProcessoSeletivo.Criar("PS Coleta de Fatos", TipoProcesso.SiSU, OrigemCandidatos.ImportacaoExterna);
+
+    private static CondicaoPrecondicaoFato Cond(string fato) =>
+        CondicaoPrecondicaoFato.Criar(0, fato, Operador.Igual, Sim).Value!;
+
+    private static FatoColetado Fato(string codigo, int ordem, params string[] cita) =>
+        FatoColetado.Criar(codigo, ordem, [.. cita.Select(Cond)]).Value!;
+
+    [Fact(DisplayName = "Grafo válido é aceito: cada pré-condição cita apenas fatos anteriores")]
+    public void GrafoValido_Aceito()
+    {
+        ProcessoSeletivo processo = NovoProcesso();
+
+        Result resultado = processo.DefinirFatosColetados(
+            [Fato("PCD", 0), Fato("EGRESSO_ESCOLA_PUBLICA", 1), Fato("CONCORRER_PCD", 2, "PCD")],
+            PrecondicaoIfMatch.Ausente);
+
+        resultado.IsSuccess.Should().BeTrue();
+        processo.FatosColetados.Should().HaveCount(3);
+    }
+
+    [Fact(DisplayName = "Pré-condição que cita fato posterior é recusada, mesmo sem ciclo")]
+    public void CitaFatoPosterior_Recusado()
+    {
+        ProcessoSeletivo processo = NovoProcesso();
+
+        // Grafo perfeitamente acíclico: CONCORRER_PCD depende de PCD e nada depende de CONCORRER_PCD.
+        // Mas PCD vem DEPOIS na ordem de coleta, então a pergunta seria feita antes da resposta existir.
+        Result resultado = processo.DefinirFatosColetados(
+            [Fato("CONCORRER_PCD", 0, "PCD"), Fato("PCD", 1)],
+            PrecondicaoIfMatch.Ausente);
+
+        resultado.IsFailure.Should().BeTrue("aciclicidade sozinha não garante que a dependência venha antes");
+        resultado.Error!.Code.Should().Be(FatoColetadoErrorCodes.PrecondicaoCitaFatoPosterior);
+    }
+
+    [Fact(DisplayName = "Ciclo é recusado com erro nomeado que mostra o caminho")]
+    public void Ciclo_RecusadoComCaminho()
+    {
+        ProcessoSeletivo processo = NovoProcesso();
+
+        Result resultado = processo.DefinirFatosColetados(
+            [Fato("A", 0, "C"), Fato("B", 1, "A"), Fato("C", 2, "B")],
+            PrecondicaoIfMatch.Ausente);
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be(FatoColetadoErrorCodes.GrafoComCiclo);
+        resultado.Error.Message.Should().Contain("→", "o caminho do ciclo é o que torna o erro acionável para quem configura");
+        foreach (string participante in new[] { "A", "B", "C" })
+        {
+            resultado.Error.Message.Should().Contain(participante);
+        }
+    }
+
+    [Fact(DisplayName = "Ciclo reportado exclui o prefixo de entrada — só os fatos que realmente fecham o ciclo")]
+    public void Ciclo_ReportaSoOCiclo_NaoOCaminhoDeEntrada()
+    {
+        ProcessoSeletivo processo = NovoProcesso();
+
+        // ENTRADA cita A; A e B formam o ciclo (A cita B, B cita A). O caminho reportado deve ser
+        // "A → B → A", nunca "ENTRADA → A → B → A": ENTRADA leva ao ciclo mas não faz parte dele.
+        Result resultado = processo.DefinirFatosColetados(
+            [Fato("ENTRADA", 0, "A"), Fato("A", 1, "B"), Fato("B", 2, "A")],
+            PrecondicaoIfMatch.Ausente);
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be(FatoColetadoErrorCodes.GrafoComCiclo);
+        resultado.Error.Message.Should().NotContain(
+            "ENTRADA",
+            "ENTRADA leva ao ciclo mas não pertence a ele — reportá-la confundiria quem procura a aresta a remover");
+        resultado.Error.Message.Should().Contain("A → B → A");
+    }
+
+    [Fact(DisplayName = "Pré-condição que cita fato não coletado pelo processo é recusada")]
+    public void CitaFatoNaoColetado_Recusado()
+    {
+        ProcessoSeletivo processo = NovoProcesso();
+
+        Result resultado = processo.DefinirFatosColetados(
+            [Fato("CONCORRER_PCD", 0, "PCD")],
+            PrecondicaoIfMatch.Ausente);
+
+        resultado.IsFailure.Should().BeTrue("o gate ficaria preso a um fato que este processo nunca vai resolver");
+        resultado.Error!.Code.Should().Be(FatoColetadoErrorCodes.PrecondicaoCitaFatoNaoColetado);
+    }
+
+    [Fact(DisplayName = "Fato citando a si mesmo é recusado na criação, antes de chegar ao grafo")]
+    public void Autorreferencia_Recusada()
+    {
+        Result<FatoColetado> resultado = FatoColetado.Criar("PCD", 0, [Cond("PCD")]);
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be(FatoColetadoErrorCodes.PrecondicaoAutorreferente);
+    }
+
+    [Fact(DisplayName = "Código de fato repetido na coleta é recusado")]
+    public void FatoDuplicado_Recusado()
+    {
+        ProcessoSeletivo processo = NovoProcesso();
+
+        Result resultado = processo.DefinirFatosColetados(
+            [Fato("PCD", 0), Fato("PCD", 1)],
+            PrecondicaoIfMatch.Ausente);
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be(FatoColetadoErrorCodes.FatoDuplicado);
+    }
+
+    [Fact(DisplayName = "Ordem repetida é recusada — a ordem de coleta precisa ser total")]
+    public void OrdemDuplicada_Recusada()
+    {
+        ProcessoSeletivo processo = NovoProcesso();
+
+        Result resultado = processo.DefinirFatosColetados(
+            [Fato("PCD", 0), Fato("EGRESSO_ESCOLA_PUBLICA", 0)],
+            PrecondicaoIfMatch.Ausente);
+
+        resultado.IsFailure.Should().BeTrue(
+            "com empate de ordem, 'anterior' deixa de ser decidível entre os dois fatos");
+        resultado.Error!.Code.Should().Be(FatoColetadoErrorCodes.OrdemDuplicada);
+    }
+
+    [Fact(DisplayName = "Definir a coleta substitui a anterior por inteiro")]
+    public void Definir_SubstituiPorInteiro()
+    {
+        ProcessoSeletivo processo = NovoProcesso();
+        processo.DefinirFatosColetados([Fato("PCD", 0), Fato("EGRESSO_ESCOLA_PUBLICA", 1)], PrecondicaoIfMatch.Ausente)
+            .IsSuccess.Should().BeTrue();
+
+        processo.DefinirFatosColetados([Fato("SEXO", 0)], PrecondicaoIfMatch.Ausente).IsSuccess.Should().BeTrue();
+
+        processo.FatosColetados.Should().HaveCount(1);
+        processo.FatosColetados.Single().FatoCodigo.Should().Be("SEXO");
+    }
+
+    [Fact(DisplayName = "Coleta vazia é aceita — um processo pode não coletar fato nenhum do candidato")]
+    public void ColetaVazia_Aceita()
+    {
+        ProcessoSeletivo processo = NovoProcesso();
+
+        Result resultado = processo.DefinirFatosColetados([], PrecondicaoIfMatch.Ausente);
+
+        resultado.IsSuccess.Should().BeTrue();
+        processo.FatosColetados.Should().BeEmpty();
+    }
+
+    [Fact(DisplayName = "Os fatos coletados ficam vinculados ao processo")]
+    public void FatosVinculadosAoProcesso()
+    {
+        ProcessoSeletivo processo = NovoProcesso();
+
+        processo.DefinirFatosColetados([Fato("PCD", 0), Fato("CONCORRER_PCD", 1, "PCD")], PrecondicaoIfMatch.Ausente)
+            .IsSuccess.Should().BeTrue();
+
+        processo.FatosColetados.Should().OnlyContain(f => f.ProcessoSeletivoId == processo.Id);
+        FatoColetado comPrecondicao = processo.FatosColetados.Single(f => f.FatoCodigo == "CONCORRER_PCD");
+        comPrecondicao.Precondicoes.Should().OnlyContain(c => c.FatoColetadoId == comPrecondicao.Id);
+    }
+}

--- a/tests/Unifesspa.UniPlus.Selecao.Domain.UnitTests/Entities/ProcessoSeletivoFatosColetadosTests.cs
+++ b/tests/Unifesspa.UniPlus.Selecao.Domain.UnitTests/Entities/ProcessoSeletivoFatosColetadosTests.cs
@@ -33,8 +33,7 @@ public sealed class ProcessoSeletivoFatosColetadosTests
         ProcessoSeletivo processo = NovoProcesso();
 
         Result resultado = processo.DefinirFatosColetados(
-            [Fato("PCD", 0), Fato("EGRESSO_ESCOLA_PUBLICA", 1), Fato("CONCORRER_PCD", 2, "PCD")],
-            PrecondicaoIfMatch.Ausente);
+            [Fato("PCD", 0), Fato("EGRESSO_ESCOLA_PUBLICA", 1), Fato("CONCORRER_PCD", 2, "PCD")]);
 
         resultado.IsSuccess.Should().BeTrue();
         processo.FatosColetados.Should().HaveCount(3);
@@ -48,8 +47,7 @@ public sealed class ProcessoSeletivoFatosColetadosTests
         // Grafo perfeitamente acíclico: CONCORRER_PCD depende de PCD e nada depende de CONCORRER_PCD.
         // Mas PCD vem DEPOIS na ordem de coleta, então a pergunta seria feita antes da resposta existir.
         Result resultado = processo.DefinirFatosColetados(
-            [Fato("CONCORRER_PCD", 0, "PCD"), Fato("PCD", 1)],
-            PrecondicaoIfMatch.Ausente);
+            [Fato("CONCORRER_PCD", 0, "PCD"), Fato("PCD", 1)]);
 
         resultado.IsFailure.Should().BeTrue("aciclicidade sozinha não garante que a dependência venha antes");
         resultado.Error!.Code.Should().Be(FatoColetadoErrorCodes.PrecondicaoCitaFatoPosterior);
@@ -61,8 +59,7 @@ public sealed class ProcessoSeletivoFatosColetadosTests
         ProcessoSeletivo processo = NovoProcesso();
 
         Result resultado = processo.DefinirFatosColetados(
-            [Fato("A", 0, "C"), Fato("B", 1, "A"), Fato("C", 2, "B")],
-            PrecondicaoIfMatch.Ausente);
+            [Fato("A", 0, "C"), Fato("B", 1, "A"), Fato("C", 2, "B")]);
 
         resultado.IsFailure.Should().BeTrue();
         resultado.Error!.Code.Should().Be(FatoColetadoErrorCodes.GrafoComCiclo);
@@ -81,8 +78,7 @@ public sealed class ProcessoSeletivoFatosColetadosTests
         // ENTRADA cita A; A e B formam o ciclo (A cita B, B cita A). O caminho reportado deve ser
         // "A → B → A", nunca "ENTRADA → A → B → A": ENTRADA leva ao ciclo mas não faz parte dele.
         Result resultado = processo.DefinirFatosColetados(
-            [Fato("ENTRADA", 0, "A"), Fato("A", 1, "B"), Fato("B", 2, "A")],
-            PrecondicaoIfMatch.Ausente);
+            [Fato("ENTRADA", 0, "A"), Fato("A", 1, "B"), Fato("B", 2, "A")]);
 
         resultado.IsFailure.Should().BeTrue();
         resultado.Error!.Code.Should().Be(FatoColetadoErrorCodes.GrafoComCiclo);
@@ -98,8 +94,7 @@ public sealed class ProcessoSeletivoFatosColetadosTests
         ProcessoSeletivo processo = NovoProcesso();
 
         Result resultado = processo.DefinirFatosColetados(
-            [Fato("CONCORRER_PCD", 0, "PCD")],
-            PrecondicaoIfMatch.Ausente);
+            [Fato("CONCORRER_PCD", 0, "PCD")]);
 
         resultado.IsFailure.Should().BeTrue("o gate ficaria preso a um fato que este processo nunca vai resolver");
         resultado.Error!.Code.Should().Be(FatoColetadoErrorCodes.PrecondicaoCitaFatoNaoColetado);
@@ -120,8 +115,7 @@ public sealed class ProcessoSeletivoFatosColetadosTests
         ProcessoSeletivo processo = NovoProcesso();
 
         Result resultado = processo.DefinirFatosColetados(
-            [Fato("PCD", 0), Fato("PCD", 1)],
-            PrecondicaoIfMatch.Ausente);
+            [Fato("PCD", 0), Fato("PCD", 1)]);
 
         resultado.IsFailure.Should().BeTrue();
         resultado.Error!.Code.Should().Be(FatoColetadoErrorCodes.FatoDuplicado);
@@ -133,8 +127,7 @@ public sealed class ProcessoSeletivoFatosColetadosTests
         ProcessoSeletivo processo = NovoProcesso();
 
         Result resultado = processo.DefinirFatosColetados(
-            [Fato("PCD", 0), Fato("EGRESSO_ESCOLA_PUBLICA", 0)],
-            PrecondicaoIfMatch.Ausente);
+            [Fato("PCD", 0), Fato("EGRESSO_ESCOLA_PUBLICA", 0)]);
 
         resultado.IsFailure.Should().BeTrue(
             "com empate de ordem, 'anterior' deixa de ser decidível entre os dois fatos");
@@ -145,10 +138,10 @@ public sealed class ProcessoSeletivoFatosColetadosTests
     public void Definir_SubstituiPorInteiro()
     {
         ProcessoSeletivo processo = NovoProcesso();
-        processo.DefinirFatosColetados([Fato("PCD", 0), Fato("EGRESSO_ESCOLA_PUBLICA", 1)], PrecondicaoIfMatch.Ausente)
+        processo.DefinirFatosColetados([Fato("PCD", 0), Fato("EGRESSO_ESCOLA_PUBLICA", 1)])
             .IsSuccess.Should().BeTrue();
 
-        processo.DefinirFatosColetados([Fato("SEXO", 0)], PrecondicaoIfMatch.Ausente).IsSuccess.Should().BeTrue();
+        processo.DefinirFatosColetados([Fato("SEXO", 0)]).IsSuccess.Should().BeTrue();
 
         processo.FatosColetados.Should().HaveCount(1);
         processo.FatosColetados.Single().FatoCodigo.Should().Be("SEXO");
@@ -159,7 +152,7 @@ public sealed class ProcessoSeletivoFatosColetadosTests
     {
         ProcessoSeletivo processo = NovoProcesso();
 
-        Result resultado = processo.DefinirFatosColetados([], PrecondicaoIfMatch.Ausente);
+        Result resultado = processo.DefinirFatosColetados([]);
 
         resultado.IsSuccess.Should().BeTrue();
         processo.FatosColetados.Should().BeEmpty();
@@ -170,7 +163,7 @@ public sealed class ProcessoSeletivoFatosColetadosTests
     {
         ProcessoSeletivo processo = NovoProcesso();
 
-        processo.DefinirFatosColetados([Fato("PCD", 0), Fato("CONCORRER_PCD", 1, "PCD")], PrecondicaoIfMatch.Ausente)
+        processo.DefinirFatosColetados([Fato("PCD", 0), Fato("CONCORRER_PCD", 1, "PCD")])
             .IsSuccess.Should().BeTrue();
 
         processo.FatosColetados.Should().OnlyContain(f => f.ProcessoSeletivoId == processo.Id);

--- a/tests/Unifesspa.UniPlus.Selecao.Domain.UnitTests/Entities/ProcessoSeletivoSessaoEditorialTests.cs
+++ b/tests/Unifesspa.UniPlus.Selecao.Domain.UnitTests/Entities/ProcessoSeletivoSessaoEditorialTests.cs
@@ -246,6 +246,21 @@ public sealed class ProcessoSeletivoSessaoEditorialTests
         rascunho.Revisao.Should().Be(3);
     }
 
+    [Fact(DisplayName = "Definir o grafo de coleta de fatos sob sessão INCREMENTA a revisão — sem isso, um ETag obsoleto sobrescreveria a escrita")]
+    public void DefinirFatosColetados_ComSessao_IncrementaRevisao()
+    {
+        ProcessoSeletivo processo = ComSessaoAberta(out RascunhoRetificacao rascunho);
+        rascunho.Revisao.Should().Be(1);
+
+        FatoColetado fato = FatoColetado.Criar("PCD", 0, null).Value!;
+        processo.DefinirFatosColetados([fato], PrecondicaoIfMatch.DeTags([rascunho.ETag]))
+            .IsSuccess.Should().BeTrue();
+
+        rascunho.Revisao.Should().Be(
+            2,
+            "a escrita do grafo de fatos é mutação como qualquer outra — se a revisão não avançasse, uma escrita concorrente com o If-Match antigo passaria e sobrescreveria esta");
+    }
+
     [Fact(DisplayName = "Uma mutação RECUSADA não move a revisão — o ETag do cliente continua válido")]
     public void Definir_Recusado_NaoIncrementaRevisao()
     {

--- a/tests/Unifesspa.UniPlus.Selecao.Domain.UnitTests/Entities/ProcessoSeletivoSessaoEditorialTests.cs
+++ b/tests/Unifesspa.UniPlus.Selecao.Domain.UnitTests/Entities/ProcessoSeletivoSessaoEditorialTests.cs
@@ -246,19 +246,18 @@ public sealed class ProcessoSeletivoSessaoEditorialTests
         rascunho.Revisao.Should().Be(3);
     }
 
-    [Fact(DisplayName = "Definir o grafo de coleta de fatos sob sessão INCREMENTA a revisão — sem isso, um ETag obsoleto sobrescreveria a escrita")]
-    public void DefinirFatosColetados_ComSessao_IncrementaRevisao()
+    [Fact(DisplayName = "O grafo de coleta de fatos NÃO é editável após a publicação — nem sob retificação (aguarda o congelamento conjunto de #928)")]
+    public void DefinirFatosColetados_ProcessoPublicado_Recusa()
     {
-        ProcessoSeletivo processo = ComSessaoAberta(out RascunhoRetificacao rascunho);
-        rascunho.Revisao.Should().Be(1);
+        // Publicado, com sessão de retificação aberta: os demais Definir* aceitam neste estado.
+        // O grafo de fatos não, porque ainda não entra no congelamento nem na restauração — aceitá-lo
+        // deixaria estado mutável fora do envelope congelado e sem rollback no descarte.
+        ProcessoSeletivo processo = ComSessaoAberta(out _);
 
-        FatoColetado fato = FatoColetado.Criar("PCD", 0, null).Value!;
-        processo.DefinirFatosColetados([fato], PrecondicaoIfMatch.DeTags([rascunho.ETag]))
-            .IsSuccess.Should().BeTrue();
+        Result resultado = processo.DefinirFatosColetados([FatoColetado.Criar("PCD", 0, null).Value!]);
 
-        rascunho.Revisao.Should().Be(
-            2,
-            "a escrita do grafo de fatos é mutação como qualquer outra — se a revisão não avançasse, uma escrita concorrente com o If-Match antigo passaria e sobrescreveria esta");
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be("ProcessoSeletivo.GrafoDeFatosSomenteEmRascunho");
     }
 
     [Fact(DisplayName = "Uma mutação RECUSADA não move a revisão — o ETag do cliente continua válido")]

--- a/tests/Unifesspa.UniPlus.Selecao.Domain.UnitTests/Services/ResolvedorEstadoFatosTests.cs
+++ b/tests/Unifesspa.UniPlus.Selecao.Domain.UnitTests/Services/ResolvedorEstadoFatosTests.cs
@@ -1,0 +1,230 @@
+namespace Unifesspa.UniPlus.Selecao.Domain.UnitTests.Services;
+
+using System.Text.Json;
+
+using AwesomeAssertions;
+
+using Unifesspa.UniPlus.Selecao.Domain.Entities;
+using Unifesspa.UniPlus.Selecao.Domain.Enums;
+using Unifesspa.UniPlus.Selecao.Domain.Services;
+using Unifesspa.UniPlus.Selecao.Domain.ValueObjects;
+
+/// <summary>
+/// Story #926 — o grafo de pré-condições resolvendo o estado de cada fato a partir das respostas
+/// do candidato. A tabela de coleta usada aqui é a normativa da change (dez fatos, com o gate de
+/// escola pública em todos os opt-ins de subcota exceto a dimensão PcD).
+/// </summary>
+public sealed class ResolvedorEstadoFatosTests
+{
+    private static JsonElement Sim => JsonSerializer.SerializeToElement(true);
+
+    private static JsonElement Nao => JsonSerializer.SerializeToElement(false);
+
+    private static JsonElement Cor(string valor) => JsonSerializer.SerializeToElement(valor);
+
+    private static CondicaoPrecondicaoFato Cond(string fato, Operador operador, JsonElement valor) =>
+        CondicaoPrecondicaoFato.Criar(0, fato, operador, valor).Value!;
+
+    private static FatoColetado Fato(string codigo, int ordem, params CondicaoPrecondicaoFato[] precondicoes) =>
+        FatoColetado.Criar(codigo, ordem, precondicoes).Value!;
+
+    /// <summary>
+    /// A tabela normativa de coleta. O gate de escola pública abre as subcotas; a dimensão PcD é a
+    /// exceção — é coletada antes e não depende dele, porque a modalidade de pessoa com
+    /// deficiência fora da reserva federal independe de o candidato ser egresso de escola pública.
+    /// </summary>
+    private static IReadOnlyList<FatoColetado> TabelaNormativa() =>
+    [
+        Fato("PCD", 0),
+        Fato("EGRESSO_ESCOLA_PUBLICA", 1),
+        Fato("CONCORRER_PCD", 2, Cond("PCD", Operador.Igual, Sim)),
+        Fato("CONCORRER_EP", 3, Cond("EGRESSO_ESCOLA_PUBLICA", Operador.Igual, Sim)),
+        Fato("COR_RACA", 4, Cond("EGRESSO_ESCOLA_PUBLICA", Operador.Igual, Sim)),
+        Fato("CONCORRER_PPI", 5,
+            Cond("EGRESSO_ESCOLA_PUBLICA", Operador.Igual, Sim),
+            Cond("COR_RACA", Operador.Em, JsonSerializer.SerializeToElement(new[] { "INDIGENA", "PRETA", "PARDA" }))),
+        Fato("QUILOMBOLA", 6,
+            Cond("EGRESSO_ESCOLA_PUBLICA", Operador.Igual, Sim),
+            Cond("COR_RACA", Operador.Diferente, Cor("INDIGENA"))),
+        Fato("CONCORRER_Q", 7,
+            Cond("EGRESSO_ESCOLA_PUBLICA", Operador.Igual, Sim),
+            Cond("QUILOMBOLA", Operador.Igual, Sim)),
+        Fato("BAIXA_RENDA", 8, Cond("EGRESSO_ESCOLA_PUBLICA", Operador.Igual, Sim)),
+        Fato("CONCORRER_RENDA", 9,
+            Cond("EGRESSO_ESCOLA_PUBLICA", Operador.Igual, Sim),
+            Cond("BAIXA_RENDA", Operador.Igual, Sim)),
+    ];
+
+    private static IReadOnlyDictionary<string, FatoResolvido> Resolver(params (string Fato, JsonElement Valor)[] respostas) =>
+        ResolvedorEstadoFatos.Resolver(
+            TabelaNormativa(),
+            respostas.ToDictionary(static r => r.Fato, static r => r.Valor, StringComparer.Ordinal));
+
+    [Fact(DisplayName = "Opt-in condicionado à elegibilidade não é coletado quando a autodeclaração é negativa")]
+    public void OptIn_SemElegibilidade_NaoAplicavel()
+    {
+        IReadOnlyDictionary<string, FatoResolvido> estados = Resolver(("PCD", Nao), ("EGRESSO_ESCOLA_PUBLICA", Nao));
+
+        estados["CONCORRER_PCD"].Estado.Should().Be(
+            EstadoFato.NaoAplicavel,
+            "quem não se declara com deficiência não vê a pergunta sobre concorrer na cota PcD");
+        estados["PCD"].Estado.Should().Be(EstadoFato.Resolvido);
+    }
+
+    [Fact(DisplayName = "Candidato não egresso de escola pública não vê nenhuma subcota, mas vê a dimensão PcD")]
+    public void SemEscolaPublica_SubcotasNaoAplicaveis_MasPcdSegue()
+    {
+        IReadOnlyDictionary<string, FatoResolvido> estados = Resolver(("PCD", Sim), ("EGRESSO_ESCOLA_PUBLICA", Nao));
+
+        foreach (string subcota in new[] { "CONCORRER_EP", "COR_RACA", "CONCORRER_PPI", "QUILOMBOLA", "CONCORRER_Q", "BAIXA_RENDA", "CONCORRER_RENDA" })
+        {
+            estados[subcota].Estado.Should().Be(EstadoFato.NaoAplicavel, $"'{subcota}' está atrás do gate de escola pública");
+        }
+
+        estados["CONCORRER_PCD"].Estado.Should().Be(
+            EstadoFato.Indeterminado,
+            "a dimensão PcD é a exceção ao gate — é perguntada, e aqui ainda não foi respondida");
+    }
+
+    [Fact(DisplayName = "Candidato indígena não vê o bloco quilombola, e isso não bloqueia o caminho PPI")]
+    public void Indigena_BlocoQuilombolaSuprimido_CaminhoPpiSegue()
+    {
+        IReadOnlyDictionary<string, FatoResolvido> estados = Resolver(
+            ("PCD", Nao), ("EGRESSO_ESCOLA_PUBLICA", Sim), ("COR_RACA", Cor("INDIGENA")));
+
+        estados["QUILOMBOLA"].Estado.Should().Be(
+            EstadoFato.NaoAplicavel,
+            "a exclusão mútua entre indígena e quilombola é pré-condição do bloco, não código");
+        estados["CONCORRER_Q"].Estado.Should().Be(
+            EstadoFato.NaoAplicavel,
+            "sem o bloco quilombola, o opt-in decorre não-aplicável — nunca fica pendente à espera de resposta");
+        estados["CONCORRER_PPI"].Estado.Should().Be(
+            EstadoFato.Indeterminado,
+            "indígena está no domínio PPI: a pergunta é feita e segue aberta, sem ser bloqueada pela supressão do bloco quilombola");
+    }
+
+    [Fact(DisplayName = "Candidato com cor/raça não informada VÊ o bloco quilombola — não informar não é declarar-se indígena")]
+    public void CorRacaNaoInformada_VeBlocoQuilombola()
+    {
+        IReadOnlyDictionary<string, FatoResolvido> estados = Resolver(
+            ("PCD", Nao), ("EGRESSO_ESCOLA_PUBLICA", Sim), ("COR_RACA", Cor("NAO_INFORMADO")));
+
+        estados["QUILOMBOLA"].Estado.Should().Be(
+            EstadoFato.Indeterminado,
+            "NAO_INFORMADO é diferente de INDIGENA, então a pré-condição é verdadeira e o campo é apresentado");
+        estados["CONCORRER_PPI"].Estado.Should().Be(
+            EstadoFato.NaoAplicavel,
+            "NAO_INFORMADO não pertence ao domínio PPI — aí sim o opt-in não se aplica");
+    }
+
+    [Fact(DisplayName = "Pré-condição satisfeita e campo não respondido fica pendente, nunca dispensado")]
+    public void PrecondicaoSatisfeita_SemResposta_Indeterminado()
+    {
+        IReadOnlyDictionary<string, FatoResolvido> estados = Resolver(("PCD", Sim), ("EGRESSO_ESCOLA_PUBLICA", Sim));
+
+        estados["CONCORRER_PCD"].Estado.Should().Be(
+            EstadoFato.Indeterminado,
+            "o candidato é PcD e a pergunta lhe foi feita — enquanto não responder, a exigência que depende disso segue em aberto");
+    }
+
+    [Fact(DisplayName = "Pré-condição indeterminada propaga indeterminação, não inaplicabilidade")]
+    public void PrecondicaoIndeterminada_Propaga()
+    {
+        // EGRESSO_ESCOLA_PUBLICA não respondido: tudo que está atrás do gate fica em suspenso.
+        IReadOnlyDictionary<string, FatoResolvido> estados = Resolver(("PCD", Sim));
+
+        estados["COR_RACA"].Estado.Should().Be(
+            EstadoFato.Indeterminado,
+            "decidir por não-aplicável aqui dispensaria em definitivo um campo que ainda pode vir a ser exigido");
+        estados["CONCORRER_Q"].Estado.Should().Be(
+            EstadoFato.Indeterminado,
+            "a indeterminação atravessa a cadeia inteira de dependências");
+    }
+
+    [Fact(DisplayName = "Resposta de campo que deixou de ser aplicável não é aproveitada")]
+    public void RespostaObsoleta_NaoEhAproveitada()
+    {
+        // O candidato havia se declarado egresso e respondido o bloco quilombola; depois mudou a
+        // autodeclaração de escola pública para negativa. A resposta antiga continua no insumo.
+        IReadOnlyDictionary<string, FatoResolvido> estados = Resolver(
+            ("PCD", Nao),
+            ("EGRESSO_ESCOLA_PUBLICA", Nao),
+            ("QUILOMBOLA", Sim),
+            ("CONCORRER_Q", Sim));
+
+        estados["QUILOMBOLA"].Estado.Should().Be(
+            EstadoFato.NaoAplicavel,
+            "a pré-condição passou a ser falsa — a resposta anterior não sobrevive à mudança a montante");
+        estados["QUILOMBOLA"].Valor.Should().BeNull("um fato não-aplicável nunca carrega valor");
+        estados["CONCORRER_Q"].Estado.Should().Be(EstadoFato.NaoAplicavel);
+    }
+
+    [Fact(DisplayName = "Resposta de fato que o processo não coleta é ignorada — o grafo é a autoridade")]
+    public void RespostaOrfa_Ignorada()
+    {
+        IReadOnlyDictionary<string, FatoResolvido> estados = Resolver(
+            ("PCD", Nao), ("EGRESSO_ESCOLA_PUBLICA", Nao), ("FATO_QUE_NAO_EXISTE", Sim));
+
+        estados.Should().NotContainKey(
+            "FATO_QUE_NAO_EXISTE",
+            "uma resposta órfã não pode criar um fato que a configuração do processo não prevê");
+        estados.Should().HaveCount(10, "o resultado tem exatamente os fatos coletados pelo processo");
+    }
+
+    [Fact(DisplayName = "O resolvedor avalia na ordem de coleta, não na ordem em que os fatos chegam na coleção")]
+    public void Resolver_RespeitaOrdemDeColeta_NaoOrdemDaColecao()
+    {
+        // A coleção chega embaralhada: CONCORRER_PCD (ordem 2, depende de PCD) vem ANTES de PCD
+        // (ordem 0) na lista. O candidato respondeu PCD = NÃO.
+        //
+        // Ordem CERTA (por coleta): PCD resolve primeiro, com valor NÃO; a pré-condição
+        // PCD IGUAL SIM avalia falso; CONCORRER_PCD é NÃO_APLICÁVEL.
+        // Ordem ERRADA (por coleção): CONCORRER_PCD é avaliado com PCD ainda ausente; a
+        // pré-condição fica indeterminada e CONCORRER_PCD resolve INDETERMINADO.
+        // Os dois estados são distintos — é isso que dá poder de detecção ao teste.
+        IReadOnlyList<FatoColetado> embaralhado =
+        [
+            Fato("CONCORRER_PCD", 2, Cond("PCD", Operador.Igual, Sim)),
+            Fato("EGRESSO_ESCOLA_PUBLICA", 1),
+            Fato("PCD", 0),
+        ];
+
+        IReadOnlyDictionary<string, FatoResolvido> estados = ResolvedorEstadoFatos.Resolver(
+            embaralhado,
+            new Dictionary<string, JsonElement>(StringComparer.Ordinal) { ["PCD"] = Nao });
+
+        estados["CONCORRER_PCD"].Estado.Should().Be(
+            EstadoFato.NaoAplicavel,
+            "PCD já está resolvido (=NÃO) quando o opt-in é avaliado; avaliar na ordem da coleção o deixaria indeterminado por dependência ainda não vista");
+    }
+
+    [Fact(DisplayName = "Fato sem pré-condição é sempre coletado")]
+    public void SemPrecondicao_SempreColetado()
+    {
+        IReadOnlyDictionary<string, FatoResolvido> estados = Resolver();
+
+        estados["PCD"].Estado.Should().Be(EstadoFato.Indeterminado, "é perguntado a todos — aqui apenas ainda não respondido");
+        estados["EGRESSO_ESCOLA_PUBLICA"].Estado.Should().Be(EstadoFato.Indeterminado);
+    }
+
+    [Fact(DisplayName = "Perfil completo de cotista: todos os blocos abertos resolvem com valor")]
+    public void PerfilCompleto_TudoResolvido()
+    {
+        IReadOnlyDictionary<string, FatoResolvido> estados = Resolver(
+            ("PCD", Nao),
+            ("EGRESSO_ESCOLA_PUBLICA", Sim),
+            ("COR_RACA", Cor("PARDA")),
+            ("CONCORRER_EP", Nao),
+            ("CONCORRER_PPI", Sim),
+            ("QUILOMBOLA", Nao),
+            ("BAIXA_RENDA", Sim),
+            ("CONCORRER_RENDA", Sim));
+
+        estados["CONCORRER_PPI"].Estado.Should().Be(EstadoFato.Resolvido);
+        estados["CONCORRER_RENDA"].Estado.Should().Be(EstadoFato.Resolvido);
+        estados["CONCORRER_Q"].Estado.Should().Be(
+            EstadoFato.NaoAplicavel,
+            "não se declarou quilombola, então o opt-in correspondente não é apresentado");
+        estados["CONCORRER_PCD"].Estado.Should().Be(EstadoFato.NaoAplicavel);
+    }
+}


### PR DESCRIPTION
## Contexto

A álgebra que distingue fato não-aplicável de indeterminado já está na `main`. Faltava o que **produz** esses estados: o grafo de pré-condições que decide, a partir das respostas do candidato, quais campos se aplicam.

Esta é a segunda e última metade da story.

## O que muda

**Um processo passa a declarar o grafo de coleta.** `FatoColetado` guarda o código do fato, a ordem de coleta e a pré-condição — um predicado sobre fatos anteriores, na mesma forma dos gatilhos de documento. A pré-condição é **aresta do grafo por processo, não propriedade do catálogo**: o mesmo fato pode ser coletado sem gate em outro processo, então vive na configuração do certame, não no vocabulário global.

**O invariante é mais estrito que aciclicidade.** Uma pré-condição só pode citar fatos **anteriores** na ordem de coleta. Um grafo pode ser acíclico e ainda ter um fato citando outro que vem depois — o que produziria um formulário em que a pergunta depende de resposta ainda não dada. A checagem de ordem já implica aciclicidade; a detecção de ciclo roda mesmo assim, e antes, porque devolve o **caminho** do ciclo — o que um admin precisa para corrigir —, enquanto o erro de ordem apontaria só um par.

**O resolvedor é função pura** sobre respostas brutas + grafo congelado. Produz o estado tipado de cada fato: não-aplicável (pré-condição falsa), indeterminado (verdadeira sem resposta, ou ela mesma indeterminada), resolvido (com valor). A avaliação segue a ordem de coleta, então toda dependência já está resolvida quando o fato é avaliado — uma passada, sem ponto fixo.

**A invalidação de resposta obsoleta cai fora da pureza:** quando a pré-condição de um campo passa a ser falsa, o fato resolve não-aplicável e a resposta que estava lá não entra no resultado, sem apagar nada.

## Persistência

Duas tabelas novas (`fatos_coletados`, `condicoes_precondicao_fato`), FKs em cascade e dois índices únicos — `(processo, fato)` e `(processo, ordem)`, que garantem as unicidades do agregado também contra qualquer caminho que não passe por ele. O repositório inclui o grafo com `ThenInclude` das pré-condições: sem isso, a coleção reidrataria vazia e todo campo pareceria coletado incondicionalmente.

## Revisão

Revisado com o subagente `fable` (o Codex estourou o tempo). A revisão encontrou um **P1 real** que eu corrigi: `DefinirFatosColetados` não avançava a revisão da sessão editorial, o que sob retificação permitiria um lost update — uma escrita com If-Match obsoleto sobrescreveria outra. Agora avança, como os dez `Definir*` irmãos, com teste de regressão dedicado.

Também apliquei: reconexão de um doc XML que meu método havia deslocado, correção do comentário de orientação da aresta, e endurecimento da factory para não mutar condições antes de aceitar o fato.

### Falsificação

Confirmei que os testes têm poder de detecção:
- Remover o colapso não-aplicável → falso: **6 dos 10** testes do resolvedor falham.
- Remover o `IncrementarRevisao`: o teste de retificação falha.
- Remover o `OrderBy` da avaliação: o teste de ordem embaralhada falha.

O último caso me pegou: a primeira versão do teste de ordem **passava por acidente** (com `PCD=SIM`, ordem certa e errada davam ambas indeterminado). Reescrevi com `PCD=NÃO`, que separa os dois caminhos — ordem certa dá não-aplicável, ordem errada dá indeterminado.

## Validação

```
dotnet build UniPlus.slnx           → 0 erros, 0 avisos
dotnet test UniPlus.slnx            → suíte completa, 0 falhas
dotnet format --verify-no-changes   → 0 diagnósticos (comando exato do CI)
dotnet ef migrations add            → migration gerada, dois índices únicos + cascade
```

## Fora de escopo

A entrada do grafo no envelope canônico de publicação (codec 1.5) vem no PR de canonicalização da mesma change, com o resto do snapshot. Esta entrega garante que o grafo persiste e reidrata.

Closes #926
