### PR TITLE
chore(analise): adota latest-recommended e trata as supressões (ADR-0117)

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -28,6 +28,21 @@ dotnet_diagnostic.CS8602.severity = error
 dotnet_diagnostic.CS8603.severity = error
 dotnet_diagnostic.CS8604.severity = error
 
+# Análise estática — política registrada na ADR-0117 (AnalysisLevel=latest-recommended
+# com opt-in/opt-out nomeado). Regras abaixo são decisões, não exceções pontuais.
+
+# CA1000: Result<T> usa factory methods estáticos (Success/Failure) por design — padrão
+# consagrado do Result pattern, praticado pela própria BCL (EqualityComparer<T>.Default,
+# ImmutableArray<T>.Empty). A regra mira adoção de bibliotecas públicas; não se aplica ao
+# Kernel interno. Desligada globalmente em vez de suprimida caso a caso.
+dotnet_diagnostic.CA1000.severity = none
+
+# CA1062: null-check em argumento de método público. O latest-recommended não a liga por
+# padrão, mas o código já a satisfaz (ArgumentNullException.ThrowIfNull é convenção do
+# projeto). Religada via opt-in para preservar a proteção de null-safety que o latest-all
+# dava — decisão consciente, não herança automática.
+dotnet_diagnostic.CA1062.severity = warning
+
 # Naming conventions — ordem importa: Roslyn aplica a primeira regra que casa,
 # então constantes e static readonly precisam vir ANTES da regra geral de
 # private_fields, senão IDE1006 marca `const Foo` como violação por não ter

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -140,18 +140,22 @@ Sem `SkipEnabledCheck`, o source generator sempre gera a guarda internamente —
 
 ## Supressão de análise de código
 
-`TreatWarningsAsErrors` está ligado — supressões são permanentes. Antes de suprimir, **investigar causa raiz**: warning pode apontar naming, dependência invertida ou catch-all legítimos de refactor (CA1716 "Shared" virou rename `IntegrationTests.Fixtures`, ADR-001 crosscutting).
+`AnalysisLevel=latest-recommended` + `TreatWarningsAsErrors` — política registrada na [ADR-0117](docs/adrs/0117-politica-de-analise-estatica-e-supressao.md). Regras extras de valor que o `recommended` não liga por padrão são religadas por opt-in nomeado no `.editorconfig` (ex.: `CA1062`); regras que não se aplicam ao projeto são desligadas ali com justificativa (ex.: `CA1000` para o `Result<T>`). Supressões são permanentes — antes de suprimir, **investigar causa raiz**: o warning pode apontar naming, dependência invertida ou catch-all legítimo de refactor.
 
-Adotar a técnica **mais específica** possível, sempre com `Justification` preenchida:
+Escolher o mecanismo pelo **alcance da exceção**, sempre com justificativa:
 
-1. `[SuppressMessage]` no símbolo ou `GlobalSuppressions.cs` com `Scope`/`Target`. Padrão.
-2. `.editorconfig` com glob de caminho — apenas para política de camada (ex.: `[tests/**/*.cs]` para convenções xUnit).
-3. `<NoWarn>` em csproj — evitar.
-4. `#pragma warning disable` inline — evitar; aceitável só em bloco muito localizado (ex.: `catch (Exception)` em exception boundary).
+| Alcance | Mecanismo |
+|---|---|
+| A regra não se aplica ao projeto ou a uma camada (é decisão, não exceção) | `.editorconfig`: `severity = none` (global) ou glob de caminho (camada) + comentário com o porquê |
+| A exceção pertence a um símbolo (membro ou tipo) | `[SuppressMessage]` no símbolo, ou `GlobalSuppressions.cs` com `Scope`/`Target`, com `Justification` |
+| A exceção é de 1–2 linhas dentro de um símbolo maior | `#pragma disable/restore` + comentário na mesma linha explicando o porquê |
+| Código gerado (migrations EF) | não suprimir manualmente — o tool já emite as supressões |
 
-Exemplos no repo: `src/*/API/GlobalSuppressions.cs` (CA1515/Program), `tests/*/Infrastructure/*ApiFactory.cs` (CA1515/fixture), `.editorconfig` seção `[tests/**/*.cs]`.
+**Regra de desempate:** a mesma regra suprimida 3+ vezes pelo mesmo motivo virou decisão — sobe para o `.editorconfig`. Evitar `<NoWarn>` em csproj.
 
-Docs: [SuppressMessageAttribute](https://learn.microsoft.com/dotnet/fundamentals/code-analysis/suppress-warnings), [editorconfig](https://learn.microsoft.com/dotnet/fundamentals/code-analysis/configuration-files).
+Exemplos no repo: `.editorconfig` seção `[*.cs]` (CA1000/CA1062, globais) e `[tests/**/*.cs]` (convenções xUnit), `src/*/API/GlobalSuppressions.cs` (CA1515/Program), `#pragma` de `CA1873` em `MigrationServiceCollectionExtensions` (1 linha).
+
+Docs: [ADR-0117](docs/adrs/0117-politica-de-analise-estatica-e-supressao.md), [SuppressMessageAttribute](https://learn.microsoft.com/dotnet/fundamentals/code-analysis/suppress-warnings), [editorconfig](https://learn.microsoft.com/dotnet/fundamentals/code-analysis/configuration-files).
 
 ## Comandos úteis
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -6,7 +6,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <RestorePackagesWithLockFile>true</RestorePackagesWithLockFile>
-    <AnalysisLevel>latest-all</AnalysisLevel>
+    <AnalysisLevel>latest-recommended</AnalysisLevel>
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
     <AllowMissingPrunePackageData>true</AllowMissingPrunePackageData>
   </PropertyGroup>

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Application/Abstractions/ISnapshotPublicacaoCanonicalizer.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Application/Abstractions/ISnapshotPublicacaoCanonicalizer.cs
@@ -9,9 +9,7 @@ using Domain.ValueObjects;
 /// <c>VersaoConfiguracao.Abrir</c> deriva o hash dos bytes internamente
 /// (revisão de plano, evita divergência entre bytes e hash persistidos).
 /// </summary>
-#pragma warning disable CA1819 // Properties should not return arrays — bytes canônicos, sem value-equality de record aplicável.
 public sealed record SnapshotCanonico(byte[] Bytes, string SchemaVersion, string AlgoritmoHash);
-#pragma warning restore CA1819
 
 /// <summary>
 /// Informação do ato de retificação (ADR-0103) acrescentada ao envelope como um

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Domain/Entities/VersaoConfiguracao.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Domain/Entities/VersaoConfiguracao.cs
@@ -55,9 +55,7 @@ public sealed class VersaoConfiguracao : IForensicEntity
     public string AlgoritmoHash { get; private init; } = null!;
 
     /// <summary>Bytes canônicos (ADR-0100) — a base do hash; fonte única de verdade.</summary>
-#pragma warning disable CA1819 // Properties should not return arrays — entidade EF Core mapeia bytea diretamente; sem value-equality de record.
     public byte[] ConfiguracaoCongeladaCanonica { get; private init; } = null!;
-#pragma warning restore CA1819
 
     /// <summary>Derivado por parsing UTF-8 dos bytes canônicos — só consulta (jsonb).</summary>
     public string ConfiguracaoCongelada { get; private init; } = null!;

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/Messaging/Avro/ProcessoPublicado.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/Messaging/Avro/ProcessoPublicado.cs
@@ -2,9 +2,7 @@
 // `namespace` declarado no schema Avro (Apache.Avro NET resolve a classe via
 // reflection usando <namespace>.<name> qualificado). Manter alinhado com
 // `Events/Schemas/ProcessoPublicado.avsc` em Selecao.Domain.
-#pragma warning disable CA1050 // Declare types in namespaces — namespace declarado, mas em lowercase.
 namespace unifesspa.uniplus.selecao.events;
-#pragma warning restore CA1050
 
 using System;
 using System.Diagnostics.CodeAnalysis;

--- a/src/shared/Unifesspa.UniPlus.Application.Abstractions/Messaging/ICommand.cs
+++ b/src/shared/Unifesspa.UniPlus.Application.Abstractions/Messaging/ICommand.cs
@@ -6,6 +6,4 @@ namespace Unifesspa.UniPlus.Application.Abstractions.Messaging;
 /// <see cref="ICommand{TResponse}"/> como tipo genérico — recebem sempre o tipo concreto.
 /// Ver ADR-0003.
 /// </summary>
-#pragma warning disable CA1040 // Avoid empty interfaces — este é marker interface intencional do contrato CQRS (ADR-0003).
 public interface ICommand<TResponse>;
-#pragma warning restore CA1040

--- a/src/shared/Unifesspa.UniPlus.Application.Abstractions/Messaging/IQuery.cs
+++ b/src/shared/Unifesspa.UniPlus.Application.Abstractions/Messaging/IQuery.cs
@@ -10,6 +10,4 @@ namespace Unifesspa.UniPlus.Application.Abstractions.Messaging;
 /// (e vice-versa) e permite que middleware aplique políticas distintas a cada
 /// lado do CQRS. Ver ADR-0003.
 /// </summary>
-#pragma warning disable CA1040 // Avoid empty interfaces — este é marker interface intencional do contrato CQRS (ADR-0003).
 public interface IQuery<TResponse>;
-#pragma warning restore CA1040

--- a/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Formatting/VendorMediaTypeAttribute.cs
+++ b/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Formatting/VendorMediaTypeAttribute.cs
@@ -34,9 +34,7 @@ public partial class VendorMediaTypeAttribute : ActionFilterAttribute
     public string Resource { get; init; } = string.Empty;
 
     /// <summary>Versões inteiras aceitas. A última posição é o latest usado como fallback.</summary>
-#pragma warning disable CA1819 // Properties should not return arrays
     public int[] Versions { get; init; } = [];
-#pragma warning restore CA1819
 
     public override void OnActionExecuting(ActionExecutingContext context)
     {

--- a/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Idempotency/IdempotencyEntry.cs
+++ b/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Idempotency/IdempotencyEntry.cs
@@ -42,9 +42,7 @@ public sealed class IdempotencyEntry
     /// Response body cifrado at-rest via <c>IUniPlusEncryptionService</c> com
     /// chave nomeada <c>"idempotency"</c> (ADR-0027 §"Cifragem at-rest").
     /// </summary>
-#pragma warning disable CA1819 // Properties should not return arrays — entidade EF Core mapeia bytea diretamente; record value-equality não se aplica.
     public byte[]? ResponseBodyCipher { get; set; }
-#pragma warning restore CA1819
 
     public DateTimeOffset ExpiresAt { get; set; }
 

--- a/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Idempotency/IdempotencyFilter.cs
+++ b/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Idempotency/IdempotencyFilter.cs
@@ -262,12 +262,10 @@ public sealed class IdempotencyFilter<TDbContext> : IAsyncResourceFilter
                     await _store.DeleteAsync(scope, endpoint, idempotencyKey, CancellationToken.None)
                         .ConfigureAwait(false);
                 }
-#pragma warning disable CA1031 // catch genérico justificado: delete é best-effort no rollback path; falha aqui deve cair no TTL, não substituir/mascarar a exceção original que estamos rethrowing.
                 catch
                 {
                     // Best-effort: se delete falhar, entry expira via TTL.
                 }
-#pragma warning restore CA1031
             }
             throw;
         }
@@ -411,9 +409,7 @@ public sealed class IdempotencyFilter<TDbContext> : IAsyncResourceFilter
         // teria caches separados — replay quebrado. Lowercase é prática
         // canônica de URL normalization (RFC 3986 §6.2.2.1).
         string method = context.HttpContext.Request.Method;
-#pragma warning disable CA1308 // ToLowerInvariant em URL é canônico — ToUpperInvariant deixaria a key ilegível em queries SQL diagnósticas.
         string path = context.HttpContext.Request.Path.ToString().ToLowerInvariant();
-#pragma warning restore CA1308
         return $"{method} {path}";
     }
 

--- a/src/shared/Unifesspa.UniPlus.Kernel/Domain/ValueObjects/Email.cs
+++ b/src/shared/Unifesspa.UniPlus.Kernel/Domain/ValueObjects/Email.cs
@@ -16,9 +16,7 @@ public sealed partial record Email
             return Result<Email>.Failure(new DomainError("Email.Vazio", "E-mail é obrigatório."));
 
         // E-mail é case-insensitive por RFC 5321, normalização para lowercase é intencional
-#pragma warning disable CA1308
         string normalizado = email.Trim().ToLowerInvariant();
-#pragma warning restore CA1308
 
         if (!EmailRegex().IsMatch(normalizado))
             return Result<Email>.Failure(new DomainError("Email.Invalido", "E-mail inválido."));

--- a/src/shared/Unifesspa.UniPlus.Kernel/Results/Result.cs
+++ b/src/shared/Unifesspa.UniPlus.Kernel/Results/Result.cs
@@ -39,10 +39,8 @@ public sealed class Result<T>
         Error = error;
     }
 
-#pragma warning disable CA1000 // Factory methods em tipos genéricos são padrão Result<T>
     public static Result<T> Success(T value) => new(true, value, null);
     public static Result<T> Failure(DomainError error) => new(false, default, error);
-#pragma warning restore CA1000
 
     public TResult Match<TResult>(Func<T, TResult> onSuccess, Func<DomainError, TResult> onFailure)
     {


### PR DESCRIPTION
## O que faz

Aplica a política da [ADR-0117](https://github.com/unifesspa-edu-br/uniplus-api/blob/main/docs/adrs/0117-politica-de-analise-estatica-e-supressao.md): migra `AnalysisLevel` de `latest-all` para `latest-recommended` e trata as 12 supressões inline. Resultado: **12 → 1 pragma** em código de produção não-gerado.

## Mudanças

1. **`Directory.Build.props`** — `latest-all` → `latest-recommended`. `TreatWarningsAsErrors` permanece.
2. **11 pragmas removidos** (10 arquivos):
   - 9 porque a regra deixa de ser diagnosticada em `recommended`: `CA1819` (×4), `CA1040` (×2), `CA1308` (×2), `CA1031` (×1)
   - `CA1050` em `ProcessoPublicado` — supressão morta: o tipo já está em namespace, a regra nunca dispara ali (verificado; não dispara nem sob `-all`)
   - `CA1000` em `Result<T>` — vira decisão nomeada no `.editorconfig`
3. **`.editorconfig`**:
   - `CA1000` desligada globalmente com justificativa (factory methods estáticos são padrão do Result pattern, praticado pela BCL)
   - **`CA1062` religada via opt-in** (ver decisão abaixo)
4. **`CLAUDE.md`** — seção "Supressão de análise de código": a pirâmide dá lugar ao critério por alcance da exceção da ADR-0117.

O único pragma remanescente é o `CA1873` em `MigrationServiceCollectionExtensions` — exceção pontual (avaliação cara já protegida por `IsEnabled`, caminho de startup).

## Decisão tomada — opt-in de CA1062 (confirmar)

A ADR deixou em aberto quais regras que o `-all` dava e o `recommended` não devem ser religadas. Tomei a decisão **conservadora**: religar `CA1062` (null-check em argumento público). O código já a satisfaz hoje sob `-all` (a convenção `ArgumentNullException.ThrowIfNull` está em uso), então religá-la **preserva o status quo de null-safety sem introduzir nenhum warning novo** — o build continua limpo. É 1 linha reversível se preferir o `recommended` puro. Nenhuma outra regra do `-all` foi religada.

## Validação

- Build completo da solution com `TreatWarningsAsErrors=true`: **0 warnings, 0 erros**
- Suíte unit + arch: **858 testes, 0 falhas** (Kernel, Infrastructure.Core, Application.Abstractions, ArchTests, Selecao.ArchTests)
- Confirmação da ADR: com `recommended` + os pragmas removidos, restam apenas `CA1000` (neutralizada) e `CA1873` (mantida)

Nenhuma mudança de comportamento em runtime — só configuração de analyzer e remoção de supressões.

Closes #146
