### PR TITLE
feat(selecao): motor de derivação de fato com a matriz de cotas da Lei 12.711

### DIFF
--- a/src/selecao/Unifesspa.UniPlus.Selecao.Domain/Services/MotorDerivacao.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Domain/Services/MotorDerivacao.cs
@@ -1,0 +1,68 @@
+namespace Unifesspa.UniPlus.Selecao.Domain.Services;
+
+using Unifesspa.UniPlus.Selecao.Domain.Enums;
+using Unifesspa.UniPlus.Selecao.Domain.ValueObjects;
+
+/// <summary>
+/// Deriva o valor de um fato a partir da sua regra de derivação e dos fatos resolvidos do candidato
+/// (Story #927). Função pura: avalia todas as regras ativas e une as contribuições.
+/// </summary>
+/// <remarks>
+/// <para>
+/// A união é de conjunto — idempotente e comutativa. Não há conflito por construção: duas regras que
+/// contribuem o mesmo código o incluem uma vez, e a ordem de avaliação não importa. Nenhuma regra
+/// ativa produz o conjunto vazio, que é um resultado <b>resolvido</b> — "concorre a nenhuma cota" é
+/// uma resposta, não uma pendência.
+/// </para>
+/// <para>
+/// O gate de dependências vem <b>antes</b> da avaliação das regras, e prevalece sobre o colapso local
+/// de uma cláusula: se qualquer dependente declarado está ausente ou indeterminado, o derivado é
+/// indeterminado como um todo (fail-closed), sem tentar unir contribuições parciais. Um dependente
+/// não-aplicável, por outro lado, é informação resolvida — não bloqueia; a regra que o cita
+/// simplesmente não contribui (a cláusula colapsa falso).
+/// </para>
+/// </remarks>
+public static class MotorDerivacao
+{
+    public static ResultadoDerivacao Derivar(
+        RegrasDerivacaoFato regras,
+        IReadOnlyDictionary<string, FatoResolvido> fatosResolvidos)
+    {
+        ArgumentNullException.ThrowIfNull(regras);
+        ArgumentNullException.ThrowIfNull(fatosResolvidos);
+
+        foreach (string dependencia in regras.DependenciasDeclaradas)
+        {
+            if (!fatosResolvidos.TryGetValue(dependencia, out FatoResolvido? fato)
+                || fato is null
+                || fato.Estado == EstadoFato.Indeterminado)
+            {
+                return ResultadoDerivacao.Indeterminado;
+            }
+        }
+
+        HashSet<string> derivado = new(StringComparer.Ordinal);
+        foreach (RegraDerivacao regra in regras.Regras)
+        {
+            switch (regra.AvaliarQuando(fatosResolvidos))
+            {
+                case Ternario.Verdadeiro:
+                    derivado.Add(regra.Contribui);
+                    break;
+
+                case Ternario.Indeterminado:
+                    // O gate garante que nenhum dependente está indeterminado por estado, mas um
+                    // fato resolvido com valor de tipo incoerente com o operador ainda avalia
+                    // indeterminado. Fail-closed: não se decide o derivado sobre uma regra que o
+                    // motor não sabe avaliar — trata-la como inativa esconderia o dado corrompido.
+                    return ResultadoDerivacao.Indeterminado;
+
+                case Ternario.Falso:
+                default:
+                    break;
+            }
+        }
+
+        return ResultadoDerivacao.Resolvido(derivado);
+    }
+}

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Domain/Services/RegrasDerivacaoModalidadeLei12711.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Domain/Services/RegrasDerivacaoModalidadeLei12711.cs
@@ -1,0 +1,78 @@
+namespace Unifesspa.UniPlus.Selecao.Domain.Services;
+
+using System.Text.Json;
+
+using Unifesspa.UniPlus.Selecao.Domain.Enums;
+using Unifesspa.UniPlus.Selecao.Domain.ValueObjects;
+
+/// <summary>
+/// Constrói a regra de derivação de <c>MODALIDADE</c> do ramo Lei 12.711/2012 (red. Lei 14.723/2023)
+/// — a matriz R0–R9 (Story #927). É a configuração normativa desse ramo, reutilizável pelo cadastro e
+/// pelos testes; um processo do ramo institucional traz a sua própria.
+/// </summary>
+/// <remarks>
+/// <para>
+/// R0 é a âncora incondicional: todo candidato concorre à ampla concorrência (concorrência dupla da
+/// Lei 14.723/2023). As demais contribuem uma cota quando o candidato optou por concorrer a ela e é
+/// elegível — a elegibilidade e o gate de escola pública são garantidos pela pré-condição do opt-in
+/// na coleta, mas cada regra ainda exige explicitamente <c>EGRESSO_ESCOLA_PUBLICA</c> das subcotas,
+/// para que o motor recuse entrada inconsistente sem depender do grafo de coleta.
+/// </para>
+/// <para>
+/// <c>LB ⊂ LI</c> é estrutural: cada regra <c>LB_*</c> repete os átomos da <c>LI_*</c> irmã mais o
+/// átomo de renda. A modalidade de pessoa com deficiência fora da reserva federal é <c>AC_PCD</c> —
+/// nunca o rótulo <c>V</c> — e independe do gate de escola pública (exceção do corpus).
+/// </para>
+/// </remarks>
+public static class RegrasDerivacaoModalidadeLei12711
+{
+    public const string CodigoFato = "MODALIDADE";
+
+    private const string ConcorrerPcd = "CONCORRER_PCD";
+    private const string ConcorrerEp = "CONCORRER_EP";
+    private const string ConcorrerPpi = "CONCORRER_PPI";
+    private const string ConcorrerQ = "CONCORRER_Q";
+    private const string ConcorrerRenda = "CONCORRER_RENDA";
+    private const string EgressoEscolaPublica = "EGRESSO_ESCOLA_PUBLICA";
+
+    /// <summary>O domínio canônico de MODALIDADE no ramo Lei 12.711.</summary>
+    public static IReadOnlyCollection<string> DominioCanonico { get; } =
+        ["AC", "AC_PCD", "LI_EP", "LB_EP", "LI_PPI", "LB_PPI", "LI_Q", "LB_Q", "LI_PCD", "LB_PCD"];
+
+    /// <summary>Constrói a matriz R0–R9 como regra de derivação de MODALIDADE.</summary>
+    public static RegrasDerivacaoFato Construir()
+    {
+        List<RegraDerivacao> regras =
+        [
+            Ancora("AC"),
+            Regra("AC_PCD", (ConcorrerPcd, true)),
+            Regra("LI_PCD", (ConcorrerPcd, true), (EgressoEscolaPublica, true)),
+            Regra("LB_PCD", (ConcorrerPcd, true), (EgressoEscolaPublica, true), (ConcorrerRenda, true)),
+            Regra("LI_EP", (EgressoEscolaPublica, true), (ConcorrerEp, true)),
+            Regra("LB_EP", (EgressoEscolaPublica, true), (ConcorrerEp, true), (ConcorrerRenda, true)),
+            Regra("LI_PPI", (EgressoEscolaPublica, true), (ConcorrerPpi, true)),
+            Regra("LB_PPI", (EgressoEscolaPublica, true), (ConcorrerPpi, true), (ConcorrerRenda, true)),
+            Regra("LI_Q", (EgressoEscolaPublica, true), (ConcorrerQ, true)),
+            Regra("LB_Q", (EgressoEscolaPublica, true), (ConcorrerQ, true), (ConcorrerRenda, true)),
+        ];
+
+        string[] dependencias =
+            [ConcorrerPcd, EgressoEscolaPublica, ConcorrerEp, ConcorrerPpi, ConcorrerQ, ConcorrerRenda];
+
+        return RegrasDerivacaoFato.Criar(CodigoFato, regras, dependencias, DominioCanonico).Value!;
+    }
+
+    private static RegraDerivacao Ancora(string contribui) =>
+        RegraDerivacao.Criar(PredicadoDnf.CriarDeCondicoesAgrupadas([]).Value!, contribui).Value!;
+
+    private static RegraDerivacao Regra(string contribui, params (string Fato, bool Valor)[] atomos)
+    {
+        // Todos os átomos de uma regra vivem na MESMA cláusula (E lógico) — a ordinal 1.
+        var linhas = atomos
+            .Select(a => (Clausula: 1, Condicao: CondicaoDnf.Criar(
+                a.Fato, Operador.Igual, JsonSerializer.SerializeToElement(a.Valor)).Value!))
+            .ToList();
+
+        return RegraDerivacao.Criar(PredicadoDnf.CriarDeCondicoesAgrupadas(linhas).Value!, contribui).Value!;
+    }
+}

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Domain/Services/RegrasDerivacaoModalidadeLei12711.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Domain/Services/RegrasDerivacaoModalidadeLei12711.cs
@@ -68,10 +68,9 @@ public static class RegrasDerivacaoModalidadeLei12711
     private static RegraDerivacao Regra(string contribui, params (string Fato, bool Valor)[] atomos)
     {
         // Todos os átomos de uma regra vivem na MESMA cláusula (E lógico) — a ordinal 1.
-        var linhas = atomos
+        List<(int Clausula, CondicaoDnf Condicao)> linhas = [.. atomos
             .Select(a => (Clausula: 1, Condicao: CondicaoDnf.Criar(
-                a.Fato, Operador.Igual, JsonSerializer.SerializeToElement(a.Valor)).Value!))
-            .ToList();
+                a.Fato, Operador.Igual, JsonSerializer.SerializeToElement(a.Valor)).Value!))];
 
         return RegraDerivacao.Criar(PredicadoDnf.CriarDeCondicoesAgrupadas(linhas).Value!, contribui).Value!;
     }

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Domain/ValueObjects/RegraDerivacao.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Domain/ValueObjects/RegraDerivacao.cs
@@ -1,0 +1,76 @@
+namespace Unifesspa.UniPlus.Selecao.Domain.ValueObjects;
+
+using Unifesspa.UniPlus.Kernel.Results;
+using Unifesspa.UniPlus.Selecao.Domain.Enums;
+
+/// <summary>
+/// Uma regra da derivação de um fato: quando o predicado <see cref="Quando"/> é verdadeiro, a regra
+/// contribui o código <see cref="Contribui"/> para o conjunto derivado (Story #927).
+/// </summary>
+/// <remarks>
+/// <para>
+/// O <see cref="Quando"/> é um predicado em forma normal disjuntiva no vocabulário fechado de fatos —
+/// sem referência a outra regra, sem construção fora do schema. A regra <b>incondicional</b> (âncora)
+/// tem <see cref="Quando"/> com <b>DNF vazio</b>: sem cláusula alguma, resolve verdadeiro sempre.
+/// </para>
+/// <para>
+/// Aqui está a diferença deliberada em relação a <see cref="PredicadoDnf.Avaliar"/>: para os
+/// consumidores genéricos, um predicado vazio significa "nunca casa" e avalia falso. A regra-âncora
+/// tem semântica própria — vazio é "sempre" —, então <see cref="AvaliarQuando"/> trata o caso vazio
+/// aqui, sem alterar o avaliador genérico.
+/// </para>
+/// </remarks>
+public sealed record RegraDerivacao
+{
+    private RegraDerivacao(PredicadoDnf quando, string contribui)
+    {
+        Quando = quando;
+        Contribui = contribui;
+    }
+
+    /// <summary>O predicado que ativa a regra. DNF vazio = incondicional (âncora).</summary>
+    public PredicadoDnf Quando { get; }
+
+    /// <summary>O código de valor do domínio do fato que a regra contribui quando ativa.</summary>
+    public string Contribui { get; }
+
+    /// <summary>Indica se a regra é incondicional — o <see cref="Quando"/> não tem cláusula alguma.</summary>
+    public bool EhAncora => Quando.Clausulas.Count == 0;
+
+    public static Result<RegraDerivacao> Criar(PredicadoDnf quando, string contribui)
+    {
+        ArgumentNullException.ThrowIfNull(quando);
+
+        if (string.IsNullOrWhiteSpace(contribui))
+        {
+            return Result<RegraDerivacao>.Failure(new DomainError(
+                RegraDerivacaoErrorCodes.ContribuiObrigatorio,
+                "Uma regra de derivação precisa contribuir um código de valor do domínio do fato."));
+        }
+
+        return Result<RegraDerivacao>.Success(new RegraDerivacao(quando, contribui.Trim()));
+    }
+
+    /// <summary>
+    /// Avalia se a regra está ativa contra os fatos resolvidos. A âncora (DNF vazio) é sempre
+    /// verdadeira; as demais delegam ao avaliador do predicado.
+    /// </summary>
+    public Ternario AvaliarQuando(IReadOnlyDictionary<string, FatoResolvido> fatosResolvidos)
+    {
+        ArgumentNullException.ThrowIfNull(fatosResolvidos);
+        return EhAncora ? Ternario.Verdadeiro : Quando.Avaliar(fatosResolvidos);
+    }
+
+    /// <summary>Os códigos de fato citados no predicado da regra, sem repetição.</summary>
+    public IReadOnlyCollection<string> FatosCitados =>
+        [.. Quando.Clausulas
+            .SelectMany(static c => c.Condicoes)
+            .Select(static cond => cond.Fato)
+            .Distinct(StringComparer.Ordinal)];
+}
+
+/// <summary>Códigos de erro de <see cref="RegraDerivacao"/>.</summary>
+public static class RegraDerivacaoErrorCodes
+{
+    public const string ContribuiObrigatorio = "RegraDerivacao.ContribuiObrigatorio";
+}

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Domain/ValueObjects/RegrasDerivacaoFato.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Domain/ValueObjects/RegrasDerivacaoFato.cs
@@ -79,6 +79,18 @@ public sealed record RegrasDerivacaoFato
         }
 
         HashSet<string> citados = new(regras.SelectMany(static r => r.FatosCitados), StringComparer.Ordinal);
+
+        // Auto-referência: uma regra que cita o próprio fato derivado exigiria que ele já estivesse
+        // resolvido para ser computado — o gate do motor o manteria indeterminado para sempre, ou o
+        // decidiria por um valor pré-computado obsoleto. É recusada no cadastro.
+        string codigoNormalizado = codigoFato.Trim();
+        if (citados.Contains(codigoNormalizado))
+        {
+            return Result<RegrasDerivacaoFato>.Failure(new DomainError(
+                RegrasDerivacaoFatoErrorCodes.DerivacaoAutorreferente,
+                $"A derivação de '{codigoNormalizado}' cita o próprio fato — um derivado não pode depender de si mesmo."));
+        }
+
         HashSet<string> declarados = new(dependenciasDeclaradas, StringComparer.Ordinal);
 
         if (!citados.SetEquals(declarados))
@@ -107,4 +119,5 @@ public static class RegrasDerivacaoFatoErrorCodes
     public const string SemRegras = "RegrasDerivacaoFato.SemRegras";
     public const string ContribuiForaDoDominio = "RegrasDerivacaoFato.ContribuiForaDoDominio";
     public const string DependenciasIncoerentes = "RegrasDerivacaoFato.DependenciasIncoerentes";
+    public const string DerivacaoAutorreferente = "RegrasDerivacaoFato.DerivacaoAutorreferente";
 }

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Domain/ValueObjects/RegrasDerivacaoFato.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Domain/ValueObjects/RegrasDerivacaoFato.cs
@@ -1,0 +1,110 @@
+namespace Unifesspa.UniPlus.Selecao.Domain.ValueObjects;
+
+using Unifesspa.UniPlus.Kernel.Results;
+
+/// <summary>
+/// A regra de derivação completa de um fato: a lista de regras <c>{quando, contribui}</c> mais a
+/// lista <b>explícita</b> de fatos dependentes (Story #927). É o dado de estrutura fechada que o
+/// binding <c>REGRA_DERIVACAO:</c> referencia.
+/// </summary>
+/// <remarks>
+/// <para>
+/// As dependências declaradas são <b>exatamente</b> a união dos fatos citados nos predicados das
+/// regras — nem mais, nem menos. Uma dependência a mais bloquearia o motor por um fato que nenhuma
+/// regra usa; uma a menos deixaria de fazer o motor esperar por um fato que uma regra de fato cita.
+/// Por isso a factory recusa os dois desvios.
+/// </para>
+/// <para>
+/// Todo código contribuído tem de pertencer ao domínio do fato, informado no cadastro. Um código
+/// desconhecido é recusado aqui — não há alias, e um código fora do domínio congelado daquela
+/// configuração nunca é traduzido.
+/// </para>
+/// </remarks>
+public sealed record RegrasDerivacaoFato
+{
+    private readonly HashSet<string> _dependencias;
+
+    private RegrasDerivacaoFato(string codigoFato, IReadOnlyList<RegraDerivacao> regras, HashSet<string> dependencias)
+    {
+        CodigoFato = codigoFato;
+        Regras = regras;
+        _dependencias = dependencias;
+    }
+
+    /// <summary>Código do fato derivado que estas regras resolvem.</summary>
+    public string CodigoFato { get; }
+
+    public IReadOnlyList<RegraDerivacao> Regras { get; }
+
+    /// <summary>União exata dos fatos citados pelas regras — a lista que o motor espera resolver.</summary>
+    public IReadOnlyCollection<string> DependenciasDeclaradas => _dependencias;
+
+    /// <summary>
+    /// Cria a regra de derivação de um fato validando a coerência estrutural.
+    /// </summary>
+    /// <param name="codigoFato">O fato derivado que estas regras resolvem.</param>
+    /// <param name="regras">A lista de regras — pelo menos uma.</param>
+    /// <param name="dependenciasDeclaradas">A lista explícita de fatos dependentes.</param>
+    /// <param name="dominioDoFato">
+    /// Os códigos de valor válidos do domínio do fato; cada <see cref="RegraDerivacao.Contribui"/>
+    /// precisa pertencer a ele.
+    /// </param>
+    public static Result<RegrasDerivacaoFato> Criar(
+        string codigoFato,
+        IReadOnlyList<RegraDerivacao> regras,
+        IReadOnlyCollection<string> dependenciasDeclaradas,
+        IReadOnlyCollection<string> dominioDoFato)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(codigoFato);
+        ArgumentNullException.ThrowIfNull(regras);
+        ArgumentNullException.ThrowIfNull(dependenciasDeclaradas);
+        ArgumentNullException.ThrowIfNull(dominioDoFato);
+
+        if (regras.Count == 0)
+        {
+            return Result<RegrasDerivacaoFato>.Failure(new DomainError(
+                RegrasDerivacaoFatoErrorCodes.SemRegras,
+                $"A derivação de '{codigoFato}' precisa de ao menos uma regra."));
+        }
+
+        HashSet<string> dominio = new(dominioDoFato, StringComparer.Ordinal);
+        foreach (RegraDerivacao regra in regras)
+        {
+            if (!dominio.Contains(regra.Contribui))
+            {
+                return Result<RegrasDerivacaoFato>.Failure(new DomainError(
+                    RegrasDerivacaoFatoErrorCodes.ContribuiForaDoDominio,
+                    $"A regra que contribui '{regra.Contribui}' cita um código fora do domínio de '{codigoFato}'."));
+            }
+        }
+
+        HashSet<string> citados = new(regras.SelectMany(static r => r.FatosCitados), StringComparer.Ordinal);
+        HashSet<string> declarados = new(dependenciasDeclaradas, StringComparer.Ordinal);
+
+        if (!citados.SetEquals(declarados))
+        {
+            IEnumerable<string> naoDeclarados = citados.Except(declarados, StringComparer.Ordinal);
+            IEnumerable<string> naoCitados = declarados.Except(citados, StringComparer.Ordinal);
+            string detalhe = string.Join("; ", new[]
+            {
+                naoDeclarados.Any() ? $"citados mas não declarados: {string.Join(", ", naoDeclarados.Order(StringComparer.Ordinal))}" : null,
+                naoCitados.Any() ? $"declarados mas não citados: {string.Join(", ", naoCitados.Order(StringComparer.Ordinal))}" : null,
+            }.Where(static s => s is not null));
+
+            return Result<RegrasDerivacaoFato>.Failure(new DomainError(
+                RegrasDerivacaoFatoErrorCodes.DependenciasIncoerentes,
+                $"As dependências declaradas de '{codigoFato}' devem ser exatamente os fatos citados ({detalhe})."));
+        }
+
+        return Result<RegrasDerivacaoFato>.Success(
+            new RegrasDerivacaoFato(codigoFato.Trim(), [.. regras], declarados));
+    }
+}
+
+/// <summary>Códigos de erro de <see cref="RegrasDerivacaoFato"/>.</summary>
+public static class RegrasDerivacaoFatoErrorCodes
+{
+    public const string SemRegras = "RegrasDerivacaoFato.SemRegras";
+    public const string ContribuiForaDoDominio = "RegrasDerivacaoFato.ContribuiForaDoDominio";
+    public const string DependenciasIncoerentes = "RegrasDerivacaoFato.DependenciasIncoerentes";
+}

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Domain/ValueObjects/ResultadoDerivacao.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Domain/ValueObjects/ResultadoDerivacao.cs
@@ -1,0 +1,44 @@
+namespace Unifesspa.UniPlus.Selecao.Domain.ValueObjects;
+
+using System.Collections.Frozen;
+
+using Unifesspa.UniPlus.Selecao.Domain.Enums;
+
+/// <summary>
+/// O resultado da derivação de um fato (Story #927): o estado e, quando resolvido, o conjunto de
+/// códigos contribuídos pelas regras ativas.
+/// </summary>
+/// <remarks>
+/// Um fato derivado é <see cref="EstadoFato.Indeterminado"/> quando algum dependente ainda não se
+/// sabe (fail-closed), e <see cref="EstadoFato.Resolvido"/> caso contrário — com um conjunto que pode
+/// ser vazio (nenhuma regra ativa). Não há estado não-aplicável no derivado: a inaplicabilidade de um
+/// dependente já foi absorvida pela avaliação das regras.
+/// </remarks>
+public sealed record ResultadoDerivacao
+{
+    private ResultadoDerivacao(EstadoFato estado, IReadOnlySet<string> valores)
+    {
+        Estado = estado;
+        Valores = valores;
+    }
+
+    public EstadoFato Estado { get; }
+
+    /// <summary>O conjunto derivado — vazio quando indeterminado ou quando nenhuma regra ativou.</summary>
+    public IReadOnlySet<string> Valores { get; }
+
+    /// <summary>O derivado ainda não é conhecido porque um dependente é indeterminado.</summary>
+    public static ResultadoDerivacao Indeterminado { get; } =
+        new(EstadoFato.Indeterminado, FrozenSet<string>.Empty);
+
+    /// <summary>
+    /// O derivado é conhecido — o conjunto é a união das contribuições ativas. O conjunto é
+    /// congelado na construção: <see cref="Valores"/> é imutável e não compartilha referência com o
+    /// que o motor montou, então nenhum consumidor pode contaminar o resultado por um cast.
+    /// </summary>
+    public static ResultadoDerivacao Resolvido(IReadOnlySet<string> valores)
+    {
+        ArgumentNullException.ThrowIfNull(valores);
+        return new(EstadoFato.Resolvido, valores.ToFrozenSet(StringComparer.Ordinal));
+    }
+}

--- a/tests/Unifesspa.UniPlus.Selecao.Domain.UnitTests/Services/MotorDerivacaoModalidadeTests.cs
+++ b/tests/Unifesspa.UniPlus.Selecao.Domain.UnitTests/Services/MotorDerivacaoModalidadeTests.cs
@@ -1,0 +1,317 @@
+namespace Unifesspa.UniPlus.Selecao.Domain.UnitTests.Services;
+
+using System.Text.Json;
+
+using AwesomeAssertions;
+
+using Unifesspa.UniPlus.Kernel.Results;
+using Unifesspa.UniPlus.Selecao.Domain.Enums;
+using Unifesspa.UniPlus.Selecao.Domain.Services;
+using Unifesspa.UniPlus.Selecao.Domain.ValueObjects;
+
+/// <summary>
+/// Story #927 — o motor de derivação contra a matriz R0–R9 de MODALIDADE (Lei 12.711). A tabela de
+/// combinações alcançáveis da spec entra literalmente como oráculo: cada perfil de respostas produz
+/// exatamente o conjunto normativo (antes da interseção com a oferta, que é passo da classificação).
+/// </summary>
+/// <remarks>
+/// São dezessete casos de motor: a tabela da spec tem dezoito linhas, mas a linha de
+/// <c>COR_RACA=NAO_INFORMADO</c> é sobre o <b>resolvedor de coleta</b> decidir se o bloco quilombola é
+/// apresentado — o motor recebe <c>CONCORRER_Q</c> já resolvido, e essa linha é coberta pelos testes
+/// do resolvedor, não aqui.
+/// </remarks>
+public sealed class MotorDerivacaoModalidadeTests
+{
+    private static readonly RegrasDerivacaoFato Ruleset = RegrasDerivacaoModalidadeLei12711.Construir();
+
+    private static FatoResolvido Sim => FatoResolvido.Resolvido(JsonSerializer.SerializeToElement(true));
+
+    private static FatoResolvido Nao => FatoResolvido.Resolvido(JsonSerializer.SerializeToElement(false));
+
+    private static FatoResolvido NaoAplicavel => FatoResolvido.NaoAplicavel();
+
+    private static FatoResolvido Indeterminado => FatoResolvido.Indeterminado();
+
+    /// <summary>
+    /// Monta o dicionário de fatos com defaults coerentes com a coleta: sem escola pública, os
+    /// opt-ins gatados por ela são não-aplicáveis; o teste sobrescreve o que o perfil exige.
+    /// </summary>
+    private static Dictionary<string, FatoResolvido> Fatos(params (string Fato, FatoResolvido Estado)[] overrides)
+    {
+        Dictionary<string, FatoResolvido> fatos = new(StringComparer.Ordinal)
+        {
+            ["CONCORRER_PCD"] = Nao,
+            ["EGRESSO_ESCOLA_PUBLICA"] = Nao,
+            ["CONCORRER_EP"] = NaoAplicavel,
+            ["CONCORRER_PPI"] = NaoAplicavel,
+            ["CONCORRER_Q"] = NaoAplicavel,
+            ["CONCORRER_RENDA"] = NaoAplicavel,
+        };
+        foreach ((string fato, FatoResolvido estado) in overrides)
+        {
+            fatos[fato] = estado;
+        }
+
+        return fatos;
+    }
+
+    private static string[] Derivar(Dictionary<string, FatoResolvido> fatos)
+    {
+        ResultadoDerivacao resultado = MotorDerivacao.Derivar(Ruleset, fatos);
+        resultado.Estado.Should().Be(EstadoFato.Resolvido);
+        return [.. resultado.Valores.OrderBy(v => v, StringComparer.Ordinal)];
+    }
+
+    // ── Tabela normativa de combinações alcançáveis (spec) ──────────────────────────────
+
+    [Fact(DisplayName = "Nenhuma cota / todos opt-out → {AC}")]
+    public void NenhumaCota_SoAC() =>
+        Derivar(Fatos()).Should().Equal("AC");
+
+    [Fact(DisplayName = "PcD opt-in, não escola pública → {AC, AC_PCD}")]
+    public void PcdSemEscolaPublica_AcEAcPcd() =>
+        Derivar(Fatos(("CONCORRER_PCD", Sim))).Should().Equal("AC", "AC_PCD");
+
+    [Fact(DisplayName = "PcD opt-in, escola pública, sem renda → {AC, AC_PCD, LI_PCD}")]
+    public void PcdEscolaPublicaSemRenda() =>
+        Derivar(Fatos(
+            ("CONCORRER_PCD", Sim), ("EGRESSO_ESCOLA_PUBLICA", Sim), ("CONCORRER_RENDA", Nao)))
+            .Should().Equal("AC", "AC_PCD", "LI_PCD");
+
+    [Fact(DisplayName = "PcD opt-in, escola pública, +renda → {AC, AC_PCD, LI_PCD, LB_PCD}")]
+    public void PcdEscolaPublicaComRenda() =>
+        Derivar(Fatos(
+            ("CONCORRER_PCD", Sim), ("EGRESSO_ESCOLA_PUBLICA", Sim), ("CONCORRER_RENDA", Sim)))
+            .Should().Equal("AC", "AC_PCD", "LB_PCD", "LI_PCD");
+
+    [Fact(DisplayName = "Escola pública + CONCORRER_EP, sem renda → {AC, LI_EP}")]
+    public void EscolaPublicaEpSemRenda() =>
+        Derivar(Fatos(
+            ("EGRESSO_ESCOLA_PUBLICA", Sim), ("CONCORRER_EP", Sim), ("CONCORRER_RENDA", Nao)))
+            .Should().Equal("AC", "LI_EP");
+
+    [Fact(DisplayName = "Escola pública + CONCORRER_EP, +renda → {AC, LI_EP, LB_EP}")]
+    public void EscolaPublicaEpComRenda() =>
+        Derivar(Fatos(
+            ("EGRESSO_ESCOLA_PUBLICA", Sim), ("CONCORRER_EP", Sim), ("CONCORRER_RENDA", Sim)))
+            .Should().Equal("AC", "LB_EP", "LI_EP");
+
+    [Fact(DisplayName = "Escola pública, CONCORRER_EP=NÃO, sem outra dimensão → {AC}")]
+    public void EscolaPublicaEpNao_SoAC() =>
+        Derivar(Fatos(
+            ("EGRESSO_ESCOLA_PUBLICA", Sim), ("CONCORRER_EP", Nao), ("CONCORRER_RENDA", Nao)))
+            .Should().Equal("AC");
+
+    [Fact(DisplayName = "PPI + CONCORRER_PPI, escola pública, sem renda → {AC, LI_PPI}")]
+    public void PpiEscolaPublicaSemRenda() =>
+        Derivar(Fatos(
+            ("EGRESSO_ESCOLA_PUBLICA", Sim), ("CONCORRER_PPI", Sim), ("CONCORRER_RENDA", Nao)))
+            .Should().Equal("AC", "LI_PPI");
+
+    [Fact(DisplayName = "PPI + CONCORRER_PPI, escola pública, +renda → {AC, LI_PPI, LB_PPI}")]
+    public void PpiEscolaPublicaComRenda() =>
+        Derivar(Fatos(
+            ("EGRESSO_ESCOLA_PUBLICA", Sim), ("CONCORRER_PPI", Sim), ("CONCORRER_RENDA", Sim)))
+            .Should().Equal("AC", "LB_PPI", "LI_PPI");
+
+    [Fact(DisplayName = "PPI-elegível opta por EP em vez de PPI → {AC, LI_EP}")]
+    public void PpiOptOutEpOptIn() =>
+        Derivar(Fatos(
+            ("EGRESSO_ESCOLA_PUBLICA", Sim), ("CONCORRER_PPI", Nao), ("CONCORRER_EP", Sim), ("CONCORRER_RENDA", Nao)))
+            .Should().Equal("AC", "LI_EP");
+
+    [Fact(DisplayName = "Quilombola + CONCORRER_Q, escola pública, sem renda → {AC, LI_Q}")]
+    public void QuilombolaEscolaPublicaSemRenda() =>
+        Derivar(Fatos(
+            ("EGRESSO_ESCOLA_PUBLICA", Sim), ("CONCORRER_Q", Sim), ("CONCORRER_RENDA", Nao)))
+            .Should().Equal("AC", "LI_Q");
+
+    [Fact(DisplayName = "Quilombola + CONCORRER_Q, escola pública, +renda → {AC, LI_Q, LB_Q}")]
+    public void QuilombolaEscolaPublicaComRenda() =>
+        Derivar(Fatos(
+            ("EGRESSO_ESCOLA_PUBLICA", Sim), ("CONCORRER_Q", Sim), ("CONCORRER_RENDA", Sim)))
+            .Should().Equal("AC", "LB_Q", "LI_Q");
+
+    [Fact(DisplayName = "Quilombola-elegível opta por EP em vez de Q → {AC, LI_EP}")]
+    public void QuilombolaOptOutEpOptIn() =>
+        Derivar(Fatos(
+            ("EGRESSO_ESCOLA_PUBLICA", Sim), ("CONCORRER_Q", Nao), ("CONCORRER_EP", Sim), ("CONCORRER_RENDA", Nao)))
+            .Should().Equal("AC", "LI_EP");
+
+    [Fact(DisplayName = "CONCORRER_Q não-aplicável (não quilombola) não concede cota Q")]
+    public void ConcorrerQNaoAplicavel_SemCotaQ() =>
+        Derivar(Fatos(
+            ("EGRESSO_ESCOLA_PUBLICA", Sim), ("CONCORRER_Q", NaoAplicavel), ("CONCORRER_EP", Sim), ("CONCORRER_RENDA", Nao)))
+            .Should().Equal("AC", "LI_EP");
+
+    [Fact(DisplayName = "PPI + Q simultâneos (preto/pardo quilombola), escola pública, sem renda → {AC, LI_PPI, LI_Q}")]
+    public void PpiEQSimultaneos() =>
+        Derivar(Fatos(
+            ("EGRESSO_ESCOLA_PUBLICA", Sim), ("CONCORRER_PPI", Sim), ("CONCORRER_Q", Sim), ("CONCORRER_RENDA", Nao)))
+            .Should().Equal("AC", "LI_PPI", "LI_Q");
+
+    [Fact(DisplayName = "PPI + Q simultâneos, +renda → {AC, LI_PPI, LB_PPI, LI_Q, LB_Q}")]
+    public void PpiEQSimultaneosComRenda() =>
+        Derivar(Fatos(
+            ("EGRESSO_ESCOLA_PUBLICA", Sim), ("CONCORRER_PPI", Sim), ("CONCORRER_Q", Sim), ("CONCORRER_RENDA", Sim)))
+            .Should().Equal("AC", "LB_PPI", "LB_Q", "LI_PPI", "LI_Q");
+
+    [Fact(DisplayName = "PcD + PPI + EP, escola pública, +renda → união das oito modalidades")]
+    public void PcdPpiEp_UniaoCompleta() =>
+        Derivar(Fatos(
+            ("CONCORRER_PCD", Sim), ("EGRESSO_ESCOLA_PUBLICA", Sim),
+            ("CONCORRER_EP", Sim), ("CONCORRER_PPI", Sim), ("CONCORRER_RENDA", Sim)))
+            .Should().Equal("AC", "AC_PCD", "LB_EP", "LB_PCD", "LB_PPI", "LI_EP", "LI_PCD", "LI_PPI");
+
+    // ── Regras estruturais do motor ─────────────────────────────────────────────────────
+
+    [Fact(DisplayName = "Dependência indeterminada torna o derivado indeterminado (fail-closed)")]
+    public void DependenciaIndeterminada_DerivadoIndeterminado()
+    {
+        Dictionary<string, FatoResolvido> fatos = Fatos(
+            ("EGRESSO_ESCOLA_PUBLICA", Sim), ("CONCORRER_PPI", Sim), ("CONCORRER_RENDA", Indeterminado));
+
+        ResultadoDerivacao resultado = MotorDerivacao.Derivar(Ruleset, fatos);
+
+        resultado.Estado.Should().Be(
+            EstadoFato.Indeterminado,
+            "um dependente indeterminado bloqueia o derivado inteiro — não assume valor parcial");
+        resultado.Valores.Should().BeEmpty();
+    }
+
+    [Fact(DisplayName = "Fail-closed pós-gate: dependente resolvido com valor de tipo incoerente torna o derivado indeterminado")]
+    public void DependenteResolvidoComTipoIncoerente_DerivadoIndeterminado()
+    {
+        // CONCORRER_PPI resolvido como STRING em vez de booleano: passa o gate (estado Resolvido),
+        // mas o predicado da regra R6 avalia indeterminado (tipo incoerente com o operador). O motor
+        // não pode tratar a regra como inativa e devolver {AC} resolvido — seria decidir sobre dado
+        // corrompido. Deve propagar indeterminado.
+        Dictionary<string, FatoResolvido> fatos = Fatos(
+            ("EGRESSO_ESCOLA_PUBLICA", Sim),
+            ("CONCORRER_PPI", FatoResolvido.Resolvido(JsonSerializer.SerializeToElement("SIM"))),
+            ("CONCORRER_RENDA", Nao));
+
+        ResultadoDerivacao resultado = MotorDerivacao.Derivar(Ruleset, fatos);
+
+        resultado.Estado.Should().Be(
+            EstadoFato.Indeterminado,
+            "um valor resolvido que o motor não sabe comparar não pode ser silenciosamente tratado como regra inativa");
+        resultado.Valores.Should().BeEmpty();
+    }
+
+    [Fact(DisplayName = "Dependência ausente do dicionário também torna o derivado indeterminado")]
+    public void DependenciaAusente_DerivadoIndeterminado()
+    {
+        Dictionary<string, FatoResolvido> fatos = new(StringComparer.Ordinal)
+        {
+            ["CONCORRER_PCD"] = Sim,
+            // faltam as demais dependências declaradas
+        };
+
+        MotorDerivacao.Derivar(Ruleset, fatos).Estado.Should().Be(EstadoFato.Indeterminado);
+    }
+
+    [Fact(DisplayName = "Opt-out de renda (não-aplicável) mantém só as independentes de renda")]
+    public void OptOutRenda_SoLI()
+    {
+        // Renda não-aplicável é informação resolvida: não bloqueia o derivado; só faz as LB_* não
+        // contribuírem (a cláusula com CONCORRER_RENDA colapsa falso pelo átomo não-aplicável).
+        string[] derivado = Derivar(Fatos(
+            ("EGRESSO_ESCOLA_PUBLICA", Sim), ("CONCORRER_PPI", Sim), ("CONCORRER_RENDA", NaoAplicavel)));
+
+        derivado.Should().Equal("AC", "LI_PPI");
+        derivado.Should().NotContain("LB_PPI");
+    }
+
+    [Fact(DisplayName = "A âncora resolve mesmo com todo o resto não-aplicável — o conjunto nunca é vazio por dependência resolvida")]
+    public void Ancora_ResolveComRestoNaoAplicavel() =>
+        Derivar(Fatos()).Should().Equal("AC");
+
+    [Fact(DisplayName = "O conjunto resolvido é congelado — mutar a entrada depois não altera o resultado")]
+    public void ResultadoResolvido_Congelado()
+    {
+        HashSet<string> entrada = new(["AC", "LI_PPI"], StringComparer.Ordinal);
+
+        ResultadoDerivacao resultado = ResultadoDerivacao.Resolvido(entrada);
+        entrada.Add("CONTAMINADO");
+
+        resultado.Valores.Should().Equal("AC", "LI_PPI");
+        resultado.Valores.Should().NotContain("CONTAMINADO", "o conjunto é congelado na construção, sem compartilhar referência com a entrada");
+    }
+
+    [Fact(DisplayName = "União é idempotente — nenhum código aparece duas vezes")]
+    public void Uniao_Idempotente()
+    {
+        string[] derivado = Derivar(Fatos(
+            ("CONCORRER_PCD", Sim), ("EGRESSO_ESCOLA_PUBLICA", Sim),
+            ("CONCORRER_EP", Sim), ("CONCORRER_PPI", Sim), ("CONCORRER_Q", Sim), ("CONCORRER_RENDA", Sim)));
+
+        derivado.Should().OnlyHaveUniqueItems();
+    }
+
+    // ── Validações de cadastro da regra ─────────────────────────────────────────────────
+
+    [Fact(DisplayName = "Código contribuído fora do domínio do fato é recusado no cadastro")]
+    public void ContribuiForaDoDominio_Recusado()
+    {
+        RegraDerivacao regraV = RegraDerivacao.Criar(
+            PredicadoDnf.CriarDeCondicoesAgrupadas([]).Value!, "V").Value!;
+
+        Result<RegrasDerivacaoFato> resultado = RegrasDerivacaoFato.Criar(
+            "MODALIDADE", [regraV], dependenciasDeclaradas: [], RegrasDerivacaoModalidadeLei12711.DominioCanonico);
+
+        resultado.IsFailure.Should().BeTrue("V não é código canônico — a modalidade PcD fora da reserva é AC_PCD");
+        resultado.Error!.Code.Should().Be(RegrasDerivacaoFatoErrorCodes.ContribuiForaDoDominio);
+    }
+
+    [Fact(DisplayName = "AC_PCD é aceito como código canônico")]
+    public void AcPcd_Aceito()
+    {
+        RegraDerivacao regra = RegraDerivacao.Criar(
+            PredicadoDnf.CriarDeCondicoesAgrupadas([]).Value!, "AC_PCD").Value!;
+
+        RegrasDerivacaoFato.Criar(
+            "MODALIDADE", [regra], dependenciasDeclaradas: [], RegrasDerivacaoModalidadeLei12711.DominioCanonico)
+            .IsSuccess.Should().BeTrue();
+    }
+
+    [Fact(DisplayName = "Dependência declarada a mais é recusada (deve ser exatamente a união dos citados)")]
+    public void DependenciaDeclaradaAMais_Recusada()
+    {
+        RegraDerivacao regra = Regra("LI_EP", ("EGRESSO_ESCOLA_PUBLICA", true), ("CONCORRER_EP", true));
+
+        Result<RegrasDerivacaoFato> resultado = RegrasDerivacaoFato.Criar(
+            "MODALIDADE",
+            [regra],
+            dependenciasDeclaradas: ["EGRESSO_ESCOLA_PUBLICA", "CONCORRER_EP", "CONCORRER_RENDA"],
+            RegrasDerivacaoModalidadeLei12711.DominioCanonico);
+
+        resultado.IsFailure.Should().BeTrue(
+            "CONCORRER_RENDA foi declarado mas nenhuma regra o cita — bloquearia o motor por um fato que ninguém usa");
+        resultado.Error!.Code.Should().Be(RegrasDerivacaoFatoErrorCodes.DependenciasIncoerentes);
+    }
+
+    [Fact(DisplayName = "Dependência citada mas não declarada é recusada")]
+    public void DependenciaCitadaNaoDeclarada_Recusada()
+    {
+        RegraDerivacao regra = Regra("LI_EP", ("EGRESSO_ESCOLA_PUBLICA", true), ("CONCORRER_EP", true));
+
+        Result<RegrasDerivacaoFato> resultado = RegrasDerivacaoFato.Criar(
+            "MODALIDADE",
+            [regra],
+            dependenciasDeclaradas: ["EGRESSO_ESCOLA_PUBLICA"],
+            RegrasDerivacaoModalidadeLei12711.DominioCanonico);
+
+        resultado.IsFailure.Should().BeTrue("CONCORRER_EP é citado mas não declarado");
+        resultado.Error!.Code.Should().Be(RegrasDerivacaoFatoErrorCodes.DependenciasIncoerentes);
+    }
+
+    private static RegraDerivacao Regra(string contribui, params (string Fato, bool Valor)[] atomos)
+    {
+        List<(int Clausula, CondicaoDnf Condicao)> linhas = [.. atomos
+            .Select(a => (Clausula: 1, Condicao: CondicaoDnf.Criar(
+                a.Fato, Operador.Igual, JsonSerializer.SerializeToElement(a.Valor)).Value!))];
+
+        return RegraDerivacao.Criar(PredicadoDnf.CriarDeCondicoesAgrupadas(linhas).Value!, contribui).Value!;
+    }
+}

--- a/tests/Unifesspa.UniPlus.Selecao.Domain.UnitTests/Services/MotorDerivacaoModalidadeTests.cs
+++ b/tests/Unifesspa.UniPlus.Selecao.Domain.UnitTests/Services/MotorDerivacaoModalidadeTests.cs
@@ -291,6 +291,23 @@ public sealed class MotorDerivacaoModalidadeTests
         resultado.Error!.Code.Should().Be(RegrasDerivacaoFatoErrorCodes.DependenciasIncoerentes);
     }
 
+    [Fact(DisplayName = "Derivação que cita o próprio fato é recusada — um derivado não depende de si mesmo")]
+    public void DerivacaoAutorreferente_Recusada()
+    {
+        // Uma regra de MODALIDADE cujo quando cita MODALIDADE: o motor exigiria MODALIDADE resolvida
+        // para computar MODALIDADE, deixando-a indeterminada para sempre.
+        RegraDerivacao regra = Regra("AC", ("MODALIDADE", true));
+
+        Result<RegrasDerivacaoFato> resultado = RegrasDerivacaoFato.Criar(
+            "MODALIDADE",
+            [regra],
+            dependenciasDeclaradas: ["MODALIDADE"],
+            RegrasDerivacaoModalidadeLei12711.DominioCanonico);
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be(RegrasDerivacaoFatoErrorCodes.DerivacaoAutorreferente);
+    }
+
     [Fact(DisplayName = "Dependência citada mas não declarada é recusada")]
     public void DependenciaCitadaNaoDeclarada_Recusada()
     {


### PR DESCRIPTION
## Contexto

O motor de derivação puro que resolve `MODALIDADE` a partir dos fatos declarados. Núcleo da #927 — o fato foi reclassificado como derivado no PR anterior; este entrega a lógica que de fato o deriva.

## O que muda

**Regra de derivação de estrutura fechada.** Uma lista de regras `{quando, contribui}`: `quando` é um predicado no vocabulário fechado de fatos, `contribui` é um código do domínio. O motor avalia todas as ativas e **une** as contribuições — idempotente, sem ordem, sem conflito por construção.

**Âncora incondicional = DNF vazio** → resolve verdadeiro sempre. Diferença deliberada do avaliador genérico (onde vazio = nunca casa); `RegraDerivacao.AvaliarQuando` trata o caso vazio sem tocar `PredicadoDnf`.

**Dependências exatamente a união dos citados.** A factory recusa tanto "citado não declarado" quanto "declarado não citado" — uma dependência a mais bloquearia o motor por um fato que ninguém usa.

**Fail-closed em dois pontos:**
- Antes de avaliar regra alguma: dependente ausente/indeterminado → derivado indeterminado. Não-aplicável não bloqueia (é informação resolvida).
- Depois do gate: se uma regra ainda avalia indeterminado (fato resolvido com valor de tipo incoerente com o operador), o motor propaga a indeterminação em vez de tratar a regra como inativa — não decide sobre dado corrompido.

**Matriz R0–R9 da Lei 12.711** como config normativa reutilizável: âncora `AC` (concorrência dupla), `AC_PCD` para deficiência fora da reserva (nunca `V`), subcotas com `LB ⊂ LI`.

## Testes

28 testes. Os 17 casos de motor reproduzem a tabela de combinações alcançáveis da spec (a 18ª linha, `NAO_INFORMADO`, é do resolvedor de coleta, não do motor). Mais os estruturais (fail-closed, união idempotente, congelamento) e as validações de cadastro.

Revisado com o Codex em duas rodadas. A 1ª pegou um P1 real de fail-closed pós-gate (regra indeterminada por tipo incoerente sendo tratada como inativa) — corrigido e falsificado. 2ª rodada: aprovado.

## Validação

```
dotnet build UniPlus.slnx           → 0 erros, 0 avisos
dotnet test UniPlus.slnx            → suíte completa, 0 falhas
dotnet format --verify-no-changes   → 0 diagnósticos
falsificação (gate e propagação)    → testes quebram sem o fix
```

## Fora de escopo

- Congelamento da regra no envelope canônico (versão semântica do interpretador) — #928.
- Interseção com as modalidades ofertadas — passo da **classificação**, não do fato (spec).
- Plumbing da regra na configuração do `ProcessoSeletivo` (cadastro/publicação).

Refs #927
