### PR TITLE
feat(selecao): persiste a regra de derivação na configuração do processo

### DIFF
--- a/src/selecao/Unifesspa.UniPlus.Selecao.API/Errors/SelecaoDomainErrorRegistration.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.API/Errors/SelecaoDomainErrorRegistration.cs
@@ -221,6 +221,25 @@ internal sealed class SelecaoDomainErrorRegistration : IDomainErrorRegistration
         new("FatoColetado.PrecondicaoCitaFatoPosterior", new DomainErrorMapping(StatusCodes.Status422UnprocessableEntity, "uniplus.selecao.fato_coletado.precondicao_cita_fato_posterior", "A pré-condição cita um fato posterior na ordem de coleta")),
         new("FatoColetado.GrafoComCiclo", new DomainErrorMapping(StatusCodes.Status422UnprocessableEntity, "uniplus.selecao.fato_coletado.grafo_com_ciclo", "As pré-condições dos fatos formam um ciclo")),
         new("CondicaoPrecondicaoFato.ClausulaInvalida", new DomainErrorMapping(StatusCodes.Status422UnprocessableEntity, "uniplus.selecao.condicao_precondicao_fato.clausula_invalida", "O ordinal da cláusula da pré-condição não pode ser negativo")),
+        // Regra de derivação de fato (Story #927). Todas as recusas são de configuração (422): regra
+        // mal formada, ou tentativa de editá-la após a publicação enquanto o congelamento conjunto
+        // (#928) ainda não existe. Os códigos usam constantes e escapam do fitness test — registrados
+        // à mão para não caírem em 500 quando o endpoint de configuração da regra existir.
+        new("ProcessoSeletivo.RegrasDerivacaoSomenteEmRascunho", new DomainErrorMapping(StatusCodes.Status422UnprocessableEntity, "uniplus.selecao.processo_seletivo.regras_derivacao_somente_em_rascunho", "As regras de derivação só são editáveis antes da primeira publicação")),
+        new("ConfiguracaoDerivacaoFato.CodigoFatoObrigatorio", new DomainErrorMapping(StatusCodes.Status422UnprocessableEntity, "uniplus.selecao.configuracao_derivacao_fato.codigo_fato_obrigatorio", "O código do fato derivado é obrigatório")),
+        new("ConfiguracaoDerivacaoFato.SemRegras", new DomainErrorMapping(StatusCodes.Status422UnprocessableEntity, "uniplus.selecao.configuracao_derivacao_fato.sem_regras", "A derivação de um fato precisa de ao menos uma regra")),
+        new("ConfiguracaoDerivacaoFato.OrdemRegraDuplicada", new DomainErrorMapping(StatusCodes.Status422UnprocessableEntity, "uniplus.selecao.configuracao_derivacao_fato.ordem_regra_duplicada", "Duas regras da mesma derivação têm a mesma ordem")),
+        new("ConfiguracaoDerivacaoFato.CodigoFatoDuplicado", new DomainErrorMapping(StatusCodes.Status422UnprocessableEntity, "uniplus.selecao.configuracao_derivacao_fato.codigo_fato_duplicado", "Um fato tem mais de uma configuração de derivação neste processo")),
+        new("RegraDerivacaoConfigurada.OrdemInvalida", new DomainErrorMapping(StatusCodes.Status422UnprocessableEntity, "uniplus.selecao.regra_derivacao_configurada.ordem_invalida", "A ordem da regra não pode ser negativa")),
+        new("RegraDerivacaoConfigurada.ContribuiObrigatorio", new DomainErrorMapping(StatusCodes.Status422UnprocessableEntity, "uniplus.selecao.regra_derivacao_configurada.contribui_obrigatorio", "Uma regra de derivação precisa contribuir um código")),
+        new("CondicaoRegraDerivacao.ClausulaInvalida", new DomainErrorMapping(StatusCodes.Status422UnprocessableEntity, "uniplus.selecao.condicao_regra_derivacao.clausula_invalida", "O ordinal da cláusula da regra não pode ser negativo")),
+        // Códigos do value object da regra (motor), que ParaRegrasDerivacao pode devolver ao
+        // reconstruir a regra contra o domínio do fato.
+        new("RegraDerivacao.ContribuiObrigatorio", new DomainErrorMapping(StatusCodes.Status422UnprocessableEntity, "uniplus.selecao.regra_derivacao.contribui_obrigatorio", "Uma regra de derivação precisa contribuir um código")),
+        new("RegrasDerivacaoFato.SemRegras", new DomainErrorMapping(StatusCodes.Status422UnprocessableEntity, "uniplus.selecao.regras_derivacao_fato.sem_regras", "A derivação de um fato precisa de ao menos uma regra")),
+        new("RegrasDerivacaoFato.ContribuiForaDoDominio", new DomainErrorMapping(StatusCodes.Status422UnprocessableEntity, "uniplus.selecao.regras_derivacao_fato.contribui_fora_do_dominio", "Uma regra contribui um código fora do domínio do fato")),
+        new("RegrasDerivacaoFato.DependenciasIncoerentes", new DomainErrorMapping(StatusCodes.Status422UnprocessableEntity, "uniplus.selecao.regras_derivacao_fato.dependencias_incoerentes", "As dependências declaradas não são exatamente os fatos citados")),
+        new("RegrasDerivacaoFato.DerivacaoAutorreferente", new DomainErrorMapping(StatusCodes.Status422UnprocessableEntity, "uniplus.selecao.regras_derivacao_fato.derivacao_autorreferente", "Um fato derivado não pode depender de si mesmo")),
         new("ProcessoSeletivo.DocumentoNaoEncontrado", new DomainErrorMapping(StatusCodes.Status422UnprocessableEntity, "uniplus.selecao.processo_seletivo.documento_nao_encontrado", "Documento do Edital não encontrado ou não pertence a este processo")),
         new("ProcessoSeletivo.DocumentoNaoConfirmado", new DomainErrorMapping(StatusCodes.Status422UnprocessableEntity, "uniplus.selecao.processo_seletivo.documento_nao_confirmado", "Somente um documento confirmado pode ser referenciado na publicação")),
         // Story #919 (RN08): defesa em profundidade — o vocabulário de fatos é fechado e

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Domain/Entities/CondicaoRegraDerivacao.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Domain/Entities/CondicaoRegraDerivacao.cs
@@ -1,0 +1,86 @@
+namespace Unifesspa.UniPlus.Selecao.Domain.Entities;
+
+using System.Text.Json;
+
+using Enums;
+
+using Unifesspa.UniPlus.Kernel.Domain.Entities;
+using Unifesspa.UniPlus.Kernel.Results;
+using Unifesspa.UniPlus.Selecao.Domain.ValueObjects;
+
+/// <summary>
+/// Uma condição do predicado <c>quando</c> de uma <see cref="RegraDerivacaoConfigurada"/> (Story
+/// #927) — a forma <b>relacional</b> (linha com ordinal de cláusula) da tripla
+/// <c>{ Fato, Operador, Valor }</c>. Agrupadas por <see cref="Clausula"/> (OU entre cláusulas, E
+/// dentro), formam o predicado que ativa a regra.
+/// </summary>
+/// <remarks>
+/// Mesma forma de <see cref="CondicaoPrecondicaoFato"/> e <see cref="CondicaoGatilho"/>, e
+/// deliberadamente separada delas: os três ciclos de vida são distintos (pré-condição do campo,
+/// gatilho da exigência, regra de derivação), e cada um é substituído com o seu pai. O reúso está
+/// onde importa — todas produzem <see cref="CondicaoDnf"/> e são avaliadas pelo mesmo
+/// <see cref="ValueObjects.PredicadoDnf"/>.
+/// </remarks>
+public sealed class CondicaoRegraDerivacao : EntityBase
+{
+    public Guid RegraDerivacaoConfiguradaId { get; private set; }
+
+    /// <summary>Ordinal da cláusula — OU entre cláusulas, E dentro da mesma cláusula.</summary>
+    public int Clausula { get; private set; }
+
+    /// <summary>Código do fato citado no predicado da regra.</summary>
+    public string Fato { get; private set; } = string.Empty;
+
+    public Operador Operador { get; private set; }
+
+    public JsonElement Valor { get; private set; }
+
+    private CondicaoRegraDerivacao() { }
+
+    /// <summary>
+    /// Cria a condição validando a <b>forma</b> via <see cref="CondicaoDnf.Criar"/>. A validação
+    /// semântica — fato no vocabulário fechado, operador × domínio, valor × domínio — é do
+    /// <see cref="Services.PredicadoDnfValidador"/>, resolvido pela Application, que tem acesso ao
+    /// vocabulário cross-módulo.
+    /// </summary>
+    public static Result<CondicaoRegraDerivacao> Criar(int clausula, string fato, Operador operador, JsonElement valor)
+    {
+        if (clausula < 0)
+        {
+            return Result<CondicaoRegraDerivacao>.Failure(new DomainError(
+                CondicaoRegraDerivacaoErrorCodes.ClausulaInvalida,
+                "O ordinal da cláusula não pode ser negativo."));
+        }
+
+        Result<CondicaoDnf> condicaoResult = CondicaoDnf.Criar(fato, operador, valor);
+        if (condicaoResult.IsFailure)
+        {
+            return Result<CondicaoRegraDerivacao>.Failure(condicaoResult.Error!);
+        }
+
+        CondicaoDnf condicao = condicaoResult.Value!;
+        return Result<CondicaoRegraDerivacao>.Success(new CondicaoRegraDerivacao
+        {
+            Clausula = clausula,
+            Fato = condicao.Fato,
+            Operador = condicao.Operador,
+            Valor = condicao.Valor,
+        });
+    }
+
+    internal void VincularRegra(Guid regraDerivacaoConfiguradaId) =>
+        RegraDerivacaoConfiguradaId = regraDerivacaoConfiguradaId;
+
+    /// <summary>
+    /// Reconstrói o VO a partir da linha persistida. A forma foi provada em <see cref="Criar"/>, mas
+    /// o banco não a impõe: propaga o <see cref="Result{T}"/> para que uma linha corrompida recuse
+    /// como falha de domínio, nunca lance ao reidratar.
+    /// </summary>
+    internal Result<CondicaoDnf> ParaCondicaoDnf() => CondicaoDnf.Criar(Fato, Operador, Valor);
+}
+
+/// <summary>Códigos de erro de <see cref="CondicaoRegraDerivacao"/>.</summary>
+public static class CondicaoRegraDerivacaoErrorCodes
+{
+    public const string ClausulaInvalida = "CondicaoRegraDerivacao.ClausulaInvalida";
+}

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Domain/Entities/ConfiguracaoDerivacaoFato.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Domain/Entities/ConfiguracaoDerivacaoFato.cs
@@ -1,0 +1,121 @@
+namespace Unifesspa.UniPlus.Selecao.Domain.Entities;
+
+using Unifesspa.UniPlus.Kernel.Domain.Entities;
+using Unifesspa.UniPlus.Kernel.Results;
+using Unifesspa.UniPlus.Selecao.Domain.ValueObjects;
+
+/// <summary>
+/// A configuração da derivação de um fato num processo (Story #927): o código do fato derivado e a
+/// lista de regras que o resolvem. É a forma persistida da regra que o binding
+/// <c>REGRA_DERIVACAO:{codigoDoFato}</c> referencia.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Só é editável antes da primeira publicação (processo em rascunho), como a coleta de fatos: a
+/// regra ainda não entra no envelope congelado nem na restauração, e permitir a edição sob
+/// retificação criaria estado mutável fora da configuração congelada. A edição sob retificação,
+/// junto do congelamento da regra no envelope, é entregue na story do congelamento conjunto.
+/// </para>
+/// <para>
+/// A validação aqui é <b>estrutural</b> — forma das condições, unicidade da ordem das regras. A
+/// validação <b>semântica</b> (o fato alvo é derivado com binding de regra; os fatos citados e o
+/// código contribuído pertencem ao vocabulário e ao domínio) depende de dados cross-módulo e é da
+/// Application, no comando que define a regra.
+/// </para>
+/// </remarks>
+public sealed class ConfiguracaoDerivacaoFato : EntityBase
+{
+    private readonly List<RegraDerivacaoConfigurada> _regras = [];
+
+    public Guid ProcessoSeletivoId { get; private set; }
+
+    /// <summary>Código do fato derivado que estas regras resolvem.</summary>
+    public string CodigoFato { get; private set; } = string.Empty;
+
+    public IReadOnlyCollection<RegraDerivacaoConfigurada> Regras => _regras.AsReadOnly();
+
+    private ConfiguracaoDerivacaoFato() { }
+
+    public static Result<ConfiguracaoDerivacaoFato> Criar(
+        string codigoFato,
+        IReadOnlyList<RegraDerivacaoConfigurada>? regras)
+    {
+        if (string.IsNullOrWhiteSpace(codigoFato))
+        {
+            return Result<ConfiguracaoDerivacaoFato>.Failure(new DomainError(
+                ConfiguracaoDerivacaoFatoErrorCodes.CodigoFatoObrigatorio,
+                "O código do fato derivado é obrigatório."));
+        }
+
+        IReadOnlyList<RegraDerivacaoConfigurada> lista = regras ?? [];
+        if (lista.Count == 0)
+        {
+            return Result<ConfiguracaoDerivacaoFato>.Failure(new DomainError(
+                ConfiguracaoDerivacaoFatoErrorCodes.SemRegras,
+                $"A derivação de '{codigoFato}' precisa de ao menos uma regra."));
+        }
+
+        HashSet<int> ordens = [];
+        foreach (RegraDerivacaoConfigurada regra in lista)
+        {
+            if (!ordens.Add(regra.Ordem))
+            {
+                return Result<ConfiguracaoDerivacaoFato>.Failure(new DomainError(
+                    ConfiguracaoDerivacaoFatoErrorCodes.OrdemRegraDuplicada,
+                    $"A ordem {regra.Ordem} é usada por mais de uma regra na derivação de '{codigoFato}'."));
+            }
+        }
+
+        ConfiguracaoDerivacaoFato config = new() { CodigoFato = codigoFato.Trim() };
+        foreach (RegraDerivacaoConfigurada regra in lista)
+        {
+            regra.VincularConfiguracao(config.Id);
+            config._regras.Add(regra);
+        }
+
+        return Result<ConfiguracaoDerivacaoFato>.Success(config);
+    }
+
+    internal void VincularProcessoSeletivo(Guid processoSeletivoId) =>
+        ProcessoSeletivoId = processoSeletivoId;
+
+    /// <summary>
+    /// Reconstrói o VO <see cref="RegrasDerivacaoFato"/> que o motor consome, contra o domínio de
+    /// valores do fato — que, para um fato de escopo-processo como <c>MODALIDADE</c>, é o conjunto
+    /// de modalidades ofertadas pelo processo, e não uma lista global do catálogo. O domínio é dado
+    /// pelo chamador; a reconstrução valida a coerência (dependências, auto-referência, código
+    /// contribuído no domínio) e devolve <see cref="Result{T}"/> — nunca lança.
+    /// </summary>
+    public Result<RegrasDerivacaoFato> ParaRegrasDerivacao(IReadOnlyCollection<string> dominioContribui)
+    {
+        ArgumentNullException.ThrowIfNull(dominioContribui);
+
+        List<RegraDerivacao> regras = [];
+        foreach (RegraDerivacaoConfigurada regra in _regras.OrderBy(static r => r.Ordem))
+        {
+            Result<RegraDerivacao> regraResult = regra.ParaRegraDerivacao();
+            if (regraResult.IsFailure)
+            {
+                return Result<RegrasDerivacaoFato>.Failure(regraResult.Error!);
+            }
+
+            regras.Add(regraResult.Value!);
+        }
+
+        // As dependências são recomputadas da união dos fatos citados — nunca persistidas, para não
+        // divergir das regras. A factory do VO valida a coerência que sobra.
+        IReadOnlyCollection<string> dependencias =
+            [.. regras.SelectMany(static r => r.FatosCitados).Distinct(StringComparer.Ordinal)];
+
+        return RegrasDerivacaoFato.Criar(CodigoFato, regras, dependencias, dominioContribui);
+    }
+}
+
+/// <summary>Códigos de erro de <see cref="ConfiguracaoDerivacaoFato"/>.</summary>
+public static class ConfiguracaoDerivacaoFatoErrorCodes
+{
+    public const string CodigoFatoObrigatorio = "ConfiguracaoDerivacaoFato.CodigoFatoObrigatorio";
+    public const string SemRegras = "ConfiguracaoDerivacaoFato.SemRegras";
+    public const string OrdemRegraDuplicada = "ConfiguracaoDerivacaoFato.OrdemRegraDuplicada";
+    public const string CodigoFatoDuplicado = "ConfiguracaoDerivacaoFato.CodigoFatoDuplicado";
+}

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Domain/Entities/ProcessoSeletivo.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Domain/Entities/ProcessoSeletivo.cs
@@ -77,6 +77,15 @@ public sealed class ProcessoSeletivo : SoftDeletableEntity
     /// </summary>
     public IReadOnlyCollection<FatoColetado> FatosColetados => _fatosColetados.AsReadOnly();
 
+    private readonly List<ConfiguracaoDerivacaoFato> _regrasDerivacao = [];
+
+    /// <summary>
+    /// As regras de derivação dos fatos derivados deste processo, por código de fato (Story #927):
+    /// a configuração <c>{quando, contribui}</c> que o motor usa para resolver, por exemplo,
+    /// <c>MODALIDADE</c> a partir dos fatos declarados.
+    /// </summary>
+    public IReadOnlyCollection<ConfiguracaoDerivacaoFato> RegrasDerivacao => _regrasDerivacao.AsReadOnly();
+
     private readonly List<NoExigencia> _nosExigencia = [];
     public IReadOnlyCollection<NoExigencia> NosExigencia => _nosExigencia.AsReadOnly();
 
@@ -944,6 +953,50 @@ public sealed class ProcessoSeletivo : SoftDeletableEntity
         {
             fato.VincularProcessoSeletivo(Id);
             _fatosColetados.Add(fato);
+        }
+
+        return Result.Success();
+    }
+
+    /// <summary>
+    /// Substitui integralmente as regras de derivação dos fatos derivados do processo (Story #927).
+    /// </summary>
+    /// <remarks>
+    /// Só é aceito antes da primeira publicação (processo em rascunho), como a coleta de fatos: a
+    /// regra ainda não entra no envelope congelado nem na restauração, e permitir a edição sob
+    /// retificação criaria estado mutável fora da configuração congelada. A validação aqui é
+    /// estrutural — código de fato único no processo. A validação semântica (o fato alvo é derivado
+    /// com binding de regra; fatos citados e código contribuído no vocabulário e no domínio) depende
+    /// de dados cross-módulo e é do comando na Application.
+    /// </remarks>
+    public Result DefinirRegrasDerivacao(IReadOnlyList<ConfiguracaoDerivacaoFato> regrasDerivacao)
+    {
+        ArgumentNullException.ThrowIfNull(regrasDerivacao);
+
+        if (Status != StatusProcesso.Rascunho)
+        {
+            return Result.Failure(new DomainError(
+                "ProcessoSeletivo.RegrasDerivacaoSomenteEmRascunho",
+                "As regras de derivação só podem ser definidas antes da primeira publicação — "
+                + "a edição sob retificação depende do congelamento conjunto da configuração (#928)."));
+        }
+
+        HashSet<string> codigos = new(StringComparer.Ordinal);
+        foreach (ConfiguracaoDerivacaoFato config in regrasDerivacao)
+        {
+            if (!codigos.Add(config.CodigoFato))
+            {
+                return Result.Failure(new DomainError(
+                    ConfiguracaoDerivacaoFatoErrorCodes.CodigoFatoDuplicado,
+                    $"O fato '{config.CodigoFato}' tem mais de uma configuração de derivação neste processo."));
+            }
+        }
+
+        _regrasDerivacao.Clear();
+        foreach (ConfiguracaoDerivacaoFato config in regrasDerivacao)
+        {
+            config.VincularProcessoSeletivo(Id);
+            _regrasDerivacao.Add(config);
         }
 
         return Result.Success();

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Domain/Entities/RegraDerivacaoConfigurada.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Domain/Entities/RegraDerivacaoConfigurada.cs
@@ -1,0 +1,98 @@
+namespace Unifesspa.UniPlus.Selecao.Domain.Entities;
+
+using Unifesspa.UniPlus.Kernel.Domain.Entities;
+using Unifesspa.UniPlus.Kernel.Results;
+using Unifesspa.UniPlus.Selecao.Domain.ValueObjects;
+
+/// <summary>
+/// Uma regra de derivação configurada num processo (Story #927): quando o predicado
+/// <c>quando</c> — formado pelas <see cref="Condicoes"/> — é verdadeiro, a regra contribui o código
+/// <see cref="Contribui"/> para o conjunto derivado. É a forma persistida de
+/// <see cref="ValueObjects.RegraDerivacao"/>.
+/// </summary>
+/// <remarks>
+/// A regra <b>âncora</b> (incondicional) é a que não tem condição alguma: predicado de DNF vazio,
+/// que resolve verdadeiro sempre. Não há sentinela textual — a ausência de condições é a âncora.
+/// </remarks>
+public sealed class RegraDerivacaoConfigurada : EntityBase
+{
+    private readonly List<CondicaoRegraDerivacao> _condicoes = [];
+
+    public Guid ConfiguracaoDerivacaoFatoId { get; private set; }
+
+    /// <summary>Ordinal da regra na configuração — total e único, para serialização determinística.</summary>
+    public int Ordem { get; private set; }
+
+    /// <summary>Código de valor do domínio do fato que a regra contribui quando ativa.</summary>
+    public string Contribui { get; private set; } = string.Empty;
+
+    public IReadOnlyCollection<CondicaoRegraDerivacao> Condicoes => _condicoes.AsReadOnly();
+
+    private RegraDerivacaoConfigurada() { }
+
+    public static Result<RegraDerivacaoConfigurada> Criar(
+        int ordem,
+        string contribui,
+        IReadOnlyList<CondicaoRegraDerivacao>? condicoes)
+    {
+        if (ordem < 0)
+        {
+            return Result<RegraDerivacaoConfigurada>.Failure(new DomainError(
+                RegraDerivacaoConfiguradaErrorCodes.OrdemInvalida,
+                "A ordem da regra não pode ser negativa."));
+        }
+
+        if (string.IsNullOrWhiteSpace(contribui))
+        {
+            return Result<RegraDerivacaoConfigurada>.Failure(new DomainError(
+                RegraDerivacaoConfiguradaErrorCodes.ContribuiObrigatorio,
+                "Uma regra de derivação precisa contribuir um código."));
+        }
+
+        RegraDerivacaoConfigurada regra = new() { Ordem = ordem, Contribui = contribui.Trim() };
+        foreach (CondicaoRegraDerivacao condicao in condicoes ?? [])
+        {
+            condicao.VincularRegra(regra.Id);
+            regra._condicoes.Add(condicao);
+        }
+
+        return Result<RegraDerivacaoConfigurada>.Success(regra);
+    }
+
+    internal void VincularConfiguracao(Guid configuracaoDerivacaoFatoId) =>
+        ConfiguracaoDerivacaoFatoId = configuracaoDerivacaoFatoId;
+
+    /// <summary>
+    /// Reconstrói o VO <see cref="ValueObjects.RegraDerivacao"/> — o predicado é montado das
+    /// condições agrupadas por cláusula; sem condições, o predicado é vazio (âncora).
+    /// </summary>
+    internal Result<RegraDerivacao> ParaRegraDerivacao()
+    {
+        List<(int Clausula, CondicaoDnf Condicao)> agrupadas = new(_condicoes.Count);
+        foreach (CondicaoRegraDerivacao condicao in _condicoes)
+        {
+            Result<CondicaoDnf> condicaoResult = condicao.ParaCondicaoDnf();
+            if (condicaoResult.IsFailure)
+            {
+                return Result<RegraDerivacao>.Failure(condicaoResult.Error!);
+            }
+
+            agrupadas.Add((condicao.Clausula, condicaoResult.Value!));
+        }
+
+        Result<PredicadoDnf> quandoResult = PredicadoDnf.CriarDeCondicoesAgrupadas(agrupadas);
+        if (quandoResult.IsFailure)
+        {
+            return Result<RegraDerivacao>.Failure(quandoResult.Error!);
+        }
+
+        return RegraDerivacao.Criar(quandoResult.Value!, Contribui);
+    }
+}
+
+/// <summary>Códigos de erro de <see cref="RegraDerivacaoConfigurada"/>.</summary>
+public static class RegraDerivacaoConfiguradaErrorCodes
+{
+    public const string OrdemInvalida = "RegraDerivacaoConfigurada.OrdemInvalida";
+    public const string ContribuiObrigatorio = "RegraDerivacaoConfigurada.ContribuiObrigatorio";
+}

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/Persistence/Configurations/CondicaoRegraDerivacaoConfiguration.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/Persistence/Configurations/CondicaoRegraDerivacaoConfiguration.cs
@@ -1,0 +1,63 @@
+namespace Unifesspa.UniPlus.Selecao.Infrastructure.Persistence.Configurations;
+
+using System.Text.Json;
+
+using Domain.Entities;
+using Domain.Enums;
+
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.ChangeTracking;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
+
+/// <summary>
+/// Configuração EF Core de <see cref="CondicaoRegraDerivacao"/> (Story #927) — entidade filha de
+/// <see cref="RegraDerivacaoConfigurada"/>, <c>EntityBase</c> puro (sem soft-delete). Mesmo mapeamento de
+/// <see cref="CondicaoGatilhoConfiguration"/>: o operador vai para a coluna pelo token canônico do
+/// wire, nunca por <c>enum.ToString()</c>, e o valor é <c>jsonb</c> serializado pelo texto bruto.
+/// </summary>
+public sealed class CondicaoRegraDerivacaoConfiguration : IEntityTypeConfiguration<CondicaoRegraDerivacao>
+{
+    private const int FatoMaxLength = 60;
+    private const int OperadorCodigoMaxLength = 20;
+
+    public void Configure(EntityTypeBuilder<CondicaoRegraDerivacao> builder)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+
+        builder.ToTable("condicoes_regra_derivacao");
+        builder.HasKey(c => c.Id);
+        builder.Property(c => c.Id).ValueGeneratedNever();
+
+        builder.Property(c => c.Clausula).IsRequired();
+        builder.Property(c => c.Fato).HasMaxLength(FatoMaxLength).IsRequired();
+
+        builder.Property(c => c.Operador)
+            .HasConversion(OperadorConverter)
+            .HasMaxLength(OperadorCodigoMaxLength)
+            .IsRequired();
+
+        builder.Property(c => c.Valor)
+            .HasConversion(JsonElementConverter, JsonElementComparer)
+            .HasColumnType("jsonb")
+            .IsRequired();
+    }
+
+    private static readonly ValueConverter<Operador, string> OperadorConverter =
+        new(operador => operador.ToCodigo(), codigo => OperadorCodigo.FromCodigo(codigo));
+
+    private static readonly ValueConverter<JsonElement, string> JsonElementConverter =
+        new(element => element.GetRawText(), json => Parse(json));
+
+    private static readonly ValueComparer<JsonElement> JsonElementComparer =
+        new(
+            (a, b) => a.GetRawText() == b.GetRawText(),
+            v => v.GetRawText().GetHashCode(StringComparison.Ordinal),
+            v => Parse(v.GetRawText()));
+
+    private static JsonElement Parse(string json)
+    {
+        using JsonDocument document = JsonDocument.Parse(json);
+        return document.RootElement.Clone();
+    }
+}

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/Persistence/Configurations/ConfiguracaoDerivacaoFatoConfiguration.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/Persistence/Configurations/ConfiguracaoDerivacaoFatoConfiguration.cs
@@ -1,0 +1,41 @@
+namespace Unifesspa.UniPlus.Selecao.Infrastructure.Persistence.Configurations;
+
+using Domain.Entities;
+
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+/// <summary>
+/// Configuração EF Core de <see cref="ConfiguracaoDerivacaoFato"/> (Story #927) — entidade filha de
+/// <c>ProcessoSeletivo</c>, <c>EntityBase</c> puro. Substituível por inteiro junto com o processo,
+/// mesmo padrão de <c>FatoColetado</c>.
+/// </summary>
+public sealed class ConfiguracaoDerivacaoFatoConfiguration : IEntityTypeConfiguration<ConfiguracaoDerivacaoFato>
+{
+    private const int FatoCodigoMaxLength = 60;
+
+    public void Configure(EntityTypeBuilder<ConfiguracaoDerivacaoFato> builder)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+
+        builder.ToTable("configuracoes_derivacao_fato");
+        builder.HasKey(c => c.Id);
+        builder.Property(c => c.Id).ValueGeneratedNever();
+
+        builder.Property(c => c.CodigoFato).HasMaxLength(FatoCodigoMaxLength).IsRequired();
+
+        // Um fato derivado tem no máximo uma configuração de derivação por processo — invariante do
+        // agregado, garantida também pelo índice contra qualquer caminho que não passe por ele.
+        builder.HasIndex(c => new { c.ProcessoSeletivoId, c.CodigoFato })
+            .IsUnique()
+            .HasDatabaseName("ux_configuracoes_derivacao_fato_processo_fato");
+
+        builder.HasMany(c => c.Regras)
+            .WithOne()
+            .HasForeignKey(r => r.ConfiguracaoDerivacaoFatoId)
+            .OnDelete(DeleteBehavior.Cascade);
+
+        builder.Navigation(c => c.Regras)
+            .UsePropertyAccessMode(PropertyAccessMode.Field);
+    }
+}

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/Persistence/Configurations/ProcessoSeletivoConfiguration.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/Persistence/Configurations/ProcessoSeletivoConfiguration.cs
@@ -92,6 +92,16 @@ public sealed class ProcessoSeletivoConfiguration : IEntityTypeConfiguration<Pro
         builder.Navigation(p => p.FatosColetados)
             .UsePropertyAccessMode(PropertyAccessMode.Field);
 
+        // Regras de derivação (Story #927) — mesma disciplina de FatosColetados: FK obrigatória,
+        // cascade, substituição por inteiro pelo agregado.
+        builder.HasMany(p => p.RegrasDerivacao)
+            .WithOne()
+            .HasForeignKey(c => c.ProcessoSeletivoId)
+            .OnDelete(DeleteBehavior.Cascade);
+
+        builder.Navigation(p => p.RegrasDerivacao)
+            .UsePropertyAccessMode(PropertyAccessMode.Field);
+
         // ReferenciaTemporalFatos (Story #554, PR #896) — VO 0..1 sem identidade própria,
         // owned inline em processos_seletivos (nunca entidade filha própria — ela não tem
         // Id nem ciclo de vida próprio, diferente das coleções acima).

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/Persistence/Configurations/RegraDerivacaoConfiguradaConfiguration.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/Persistence/Configurations/RegraDerivacaoConfiguradaConfiguration.cs
@@ -1,0 +1,41 @@
+namespace Unifesspa.UniPlus.Selecao.Infrastructure.Persistence.Configurations;
+
+using Domain.Entities;
+
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+/// <summary>
+/// Configuração EF Core de <see cref="RegraDerivacaoConfigurada"/> (Story #927) — entidade filha de
+/// <see cref="ConfiguracaoDerivacaoFato"/>, <c>EntityBase</c> puro.
+/// </summary>
+public sealed class RegraDerivacaoConfiguradaConfiguration : IEntityTypeConfiguration<RegraDerivacaoConfigurada>
+{
+    private const int ContribuiMaxLength = 60;
+
+    public void Configure(EntityTypeBuilder<RegraDerivacaoConfigurada> builder)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+
+        builder.ToTable("regras_derivacao_configuradas");
+        builder.HasKey(r => r.Id);
+        builder.Property(r => r.Id).ValueGeneratedNever();
+
+        builder.Property(r => r.Ordem).IsRequired();
+        builder.Property(r => r.Contribui).HasMaxLength(ContribuiMaxLength).IsRequired();
+
+        // A ordem é total e única dentro da configuração — invariante do agregado, garantida também
+        // pelo índice para a serialização determinística da regra.
+        builder.HasIndex(r => new { r.ConfiguracaoDerivacaoFatoId, r.Ordem })
+            .IsUnique()
+            .HasDatabaseName("ux_regras_derivacao_configuradas_config_ordem");
+
+        builder.HasMany(r => r.Condicoes)
+            .WithOne()
+            .HasForeignKey(c => c.RegraDerivacaoConfiguradaId)
+            .OnDelete(DeleteBehavior.Cascade);
+
+        builder.Navigation(r => r.Condicoes)
+            .UsePropertyAccessMode(PropertyAccessMode.Field);
+    }
+}

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/Persistence/Migrations/20260723123334_AddConfiguracaoDerivacaoFato.Designer.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/Persistence/Migrations/20260723123334_AddConfiguracaoDerivacaoFato.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Unifesspa.UniPlus.Selecao.Infrastructure.Persistence;
@@ -11,9 +12,11 @@ using Unifesspa.UniPlus.Selecao.Infrastructure.Persistence;
 namespace Unifesspa.UniPlus.Selecao.Infrastructure.Persistence.Migrations
 {
     [DbContext(typeof(SelecaoDbContext))]
-    partial class SelecaoDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260723123334_AddConfiguracaoDerivacaoFato")]
+    partial class AddConfiguracaoDerivacaoFato
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/Persistence/Migrations/20260723123334_AddConfiguracaoDerivacaoFato.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/Persistence/Migrations/20260723123334_AddConfiguracaoDerivacaoFato.cs
@@ -1,0 +1,124 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Unifesspa.UniPlus.Selecao.Infrastructure.Persistence.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddConfiguracaoDerivacaoFato : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "configuracoes_derivacao_fato",
+                schema: "selecao",
+                columns: table => new
+                {
+                    id = table.Column<Guid>(type: "uuid", nullable: false),
+                    processo_seletivo_id = table.Column<Guid>(type: "uuid", nullable: false),
+                    codigo_fato = table.Column<string>(type: "character varying(60)", maxLength: 60, nullable: false),
+                    created_at = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false),
+                    updated_at = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("pk_configuracoes_derivacao_fato", x => x.id);
+                    table.ForeignKey(
+                        name: "fk_configuracoes_derivacao_fato_processos_seletivos_processo_s",
+                        column: x => x.processo_seletivo_id,
+                        principalSchema: "selecao",
+                        principalTable: "processos_seletivos",
+                        principalColumn: "id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "regras_derivacao_configuradas",
+                schema: "selecao",
+                columns: table => new
+                {
+                    id = table.Column<Guid>(type: "uuid", nullable: false),
+                    configuracao_derivacao_fato_id = table.Column<Guid>(type: "uuid", nullable: false),
+                    ordem = table.Column<int>(type: "integer", nullable: false),
+                    contribui = table.Column<string>(type: "character varying(60)", maxLength: 60, nullable: false),
+                    created_at = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false),
+                    updated_at = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("pk_regras_derivacao_configuradas", x => x.id);
+                    table.ForeignKey(
+                        name: "fk_regras_derivacao_configuradas_configuracoes_derivacao_fato_",
+                        column: x => x.configuracao_derivacao_fato_id,
+                        principalSchema: "selecao",
+                        principalTable: "configuracoes_derivacao_fato",
+                        principalColumn: "id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "condicoes_regra_derivacao",
+                schema: "selecao",
+                columns: table => new
+                {
+                    id = table.Column<Guid>(type: "uuid", nullable: false),
+                    regra_derivacao_configurada_id = table.Column<Guid>(type: "uuid", nullable: false),
+                    clausula = table.Column<int>(type: "integer", nullable: false),
+                    fato = table.Column<string>(type: "character varying(60)", maxLength: 60, nullable: false),
+                    operador = table.Column<string>(type: "character varying(20)", maxLength: 20, nullable: false),
+                    valor = table.Column<string>(type: "jsonb", nullable: false),
+                    created_at = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false),
+                    updated_at = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("pk_condicoes_regra_derivacao", x => x.id);
+                    table.ForeignKey(
+                        name: "fk_condicoes_regra_derivacao_regra_derivacao_configurada_regra",
+                        column: x => x.regra_derivacao_configurada_id,
+                        principalSchema: "selecao",
+                        principalTable: "regras_derivacao_configuradas",
+                        principalColumn: "id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "ix_condicoes_regra_derivacao_regra_derivacao_configurada_id",
+                schema: "selecao",
+                table: "condicoes_regra_derivacao",
+                column: "regra_derivacao_configurada_id");
+
+            migrationBuilder.CreateIndex(
+                name: "ux_configuracoes_derivacao_fato_processo_fato",
+                schema: "selecao",
+                table: "configuracoes_derivacao_fato",
+                columns: new[] { "processo_seletivo_id", "codigo_fato" },
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "ux_regras_derivacao_configuradas_config_ordem",
+                schema: "selecao",
+                table: "regras_derivacao_configuradas",
+                columns: new[] { "configuracao_derivacao_fato_id", "ordem" },
+                unique: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "condicoes_regra_derivacao",
+                schema: "selecao");
+
+            migrationBuilder.DropTable(
+                name: "regras_derivacao_configuradas",
+                schema: "selecao");
+
+            migrationBuilder.DropTable(
+                name: "configuracoes_derivacao_fato",
+                schema: "selecao");
+        }
+    }
+}

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/Persistence/Repositories/ProcessoSeletivoRepository.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/Persistence/Repositories/ProcessoSeletivoRepository.cs
@@ -131,6 +131,11 @@ public sealed class ProcessoSeletivoRepository : IProcessoSeletivoRepository
             // seria reidratado sem aresta nenhuma: todo fato pareceria coletado
             // incondicionalmente, e campos que deveriam ser suprimidos passariam a ser exigidos.
             .Include(p => p.FatosColetados).ThenInclude(f => f.Precondicoes)
+            // Regras de derivação (Story #927) — MESMO raciocínio, nos três níveis: sem os Include, a
+            // configuração reidrataria sem regra nenhuma (ou sem as condições/o predicado de cada
+            // regra), e a substituição por inteiro faria Clear() num backing list vazio, deixando as
+            // linhas antigas no banco. O motor produziria conjunto errado ou indeterminado.
+            .Include(p => p.RegrasDerivacao).ThenInclude(c => c.Regras).ThenInclude(r => r.Condicoes)
             // AsSplitQuery obrigatório a partir desta entrega: o produto cartesiano de
             // TODAS as coleções (etapas × condições × recursos × tipos × vagas ×
             // modalidades × desempate × eliminação × fases × bancas) num único JOIN

--- a/tests/Unifesspa.UniPlus.Selecao.Domain.UnitTests/Entities/ProcessoSeletivoRegrasDerivacaoTests.cs
+++ b/tests/Unifesspa.UniPlus.Selecao.Domain.UnitTests/Entities/ProcessoSeletivoRegrasDerivacaoTests.cs
@@ -1,0 +1,147 @@
+namespace Unifesspa.UniPlus.Selecao.Domain.UnitTests.Entities;
+
+using System.Text.Json;
+
+using AwesomeAssertions;
+
+using Unifesspa.UniPlus.Kernel.Results;
+using Unifesspa.UniPlus.Selecao.Domain.Entities;
+using Unifesspa.UniPlus.Selecao.Domain.Enums;
+using Unifesspa.UniPlus.Selecao.Domain.Services;
+using Unifesspa.UniPlus.Selecao.Domain.ValueObjects;
+
+/// <summary>
+/// Story #927 — a regra de derivação persistida na configuração do processo, e a sua reconstrução no
+/// value object que o motor consome. A validação aqui é estrutural (unicidade, forma); a semântica
+/// (fato alvo derivado, domínio de contribuição) é da Application.
+/// </summary>
+public sealed class ProcessoSeletivoRegrasDerivacaoTests
+{
+    private static readonly IReadOnlyCollection<string> DominioModalidade =
+        RegrasDerivacaoModalidadeLei12711.DominioCanonico;
+
+    private static ProcessoSeletivo NovoProcesso() =>
+        ProcessoSeletivo.Criar("PS Derivação", TipoProcesso.SiSU, OrigemCandidatos.ImportacaoExterna);
+
+    private static CondicaoRegraDerivacao Cond(string fato, bool valor) =>
+        CondicaoRegraDerivacao.Criar(1, fato, Operador.Igual, JsonSerializer.SerializeToElement(valor)).Value!;
+
+    private static RegraDerivacaoConfigurada Regra(int ordem, string contribui, params (string Fato, bool Valor)[] atomos) =>
+        RegraDerivacaoConfigurada.Criar(ordem, contribui, [.. atomos.Select(a => Cond(a.Fato, a.Valor))]).Value!;
+
+    private static RegraDerivacaoConfigurada Ancora(int ordem, string contribui) =>
+        RegraDerivacaoConfigurada.Criar(ordem, contribui, condicoes: null).Value!;
+
+    private static ConfiguracaoDerivacaoFato ConfigModalidade() =>
+        ConfiguracaoDerivacaoFato.Criar("MODALIDADE",
+        [
+            Ancora(0, "AC"),
+            Regra(1, "AC_PCD", ("CONCORRER_PCD", true)),
+            Regra(2, "LI_PCD", ("CONCORRER_PCD", true), ("EGRESSO_ESCOLA_PUBLICA", true)),
+        ]).Value!;
+
+    [Fact(DisplayName = "Define e reidrata a configuração de derivação em rascunho")]
+    public void Definir_EmRascunho_Aceita()
+    {
+        ProcessoSeletivo processo = NovoProcesso();
+
+        Result resultado = processo.DefinirRegrasDerivacao([ConfigModalidade()]);
+
+        resultado.IsSuccess.Should().BeTrue(resultado.Error?.Message);
+        processo.RegrasDerivacao.Should().ContainSingle(c => c.CodigoFato == "MODALIDADE");
+        processo.RegrasDerivacao.Single().Regras.Should().HaveCount(3);
+    }
+
+    [Fact(DisplayName = "A âncora é a regra sem condição — reconstrói uma regra incondicional")]
+    public void Ancora_SemCondicao()
+    {
+        ConfiguracaoDerivacaoFato config = ConfiguracaoDerivacaoFato.Criar("MODALIDADE", [Ancora(0, "AC")]).Value!;
+
+        config.Regras.Single().Condicoes.Should().BeEmpty("a âncora não tem condição");
+
+        RegrasDerivacaoFato vo = config.ParaRegrasDerivacao(DominioModalidade).Value!;
+        vo.Regras.Single().EhAncora.Should().BeTrue("uma regra sem condição é a âncora incondicional");
+    }
+
+    [Fact(DisplayName = "Reconstrói o value object da regra que o motor consome, contra o domínio dado")]
+    public void ParaRegrasDerivacao_ReconstroiVo()
+    {
+        ConfiguracaoDerivacaoFato config = ConfigModalidade();
+
+        Result<RegrasDerivacaoFato> vo = config.ParaRegrasDerivacao(DominioModalidade);
+
+        vo.IsSuccess.Should().BeTrue(vo.Error?.Message);
+        vo.Value!.CodigoFato.Should().Be("MODALIDADE");
+        vo.Value.Regras.Should().HaveCount(3);
+        vo.Value.DependenciasDeclaradas.Should().BeEquivalentTo(["CONCORRER_PCD", "EGRESSO_ESCOLA_PUBLICA"],
+            "as dependências são recomputadas da união dos fatos citados, nunca persistidas");
+    }
+
+    [Fact(DisplayName = "Reconstrução recusa código contribuído fora do domínio dado")]
+    public void ParaRegrasDerivacao_ContribuiForaDoDominio_Falha()
+    {
+        ConfiguracaoDerivacaoFato config = ConfiguracaoDerivacaoFato.Criar("MODALIDADE",
+            [Ancora(0, "CODIGO_INEXISTENTE")]).Value!;
+
+        Result<RegrasDerivacaoFato> vo = config.ParaRegrasDerivacao(DominioModalidade);
+
+        vo.IsFailure.Should().BeTrue("um código fora do domínio congelado do processo é recusado, nunca traduzido");
+    }
+
+    [Fact(DisplayName = "Dois fatos com o mesmo código de derivação são recusados")]
+    public void CodigoFatoDuplicado_Recusado()
+    {
+        ProcessoSeletivo processo = NovoProcesso();
+
+        Result resultado = processo.DefinirRegrasDerivacao([ConfigModalidade(), ConfigModalidade()]);
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be(ConfiguracaoDerivacaoFatoErrorCodes.CodigoFatoDuplicado);
+    }
+
+    [Fact(DisplayName = "Ordem de regra duplicada na mesma configuração é recusada")]
+    public void OrdemRegraDuplicada_Recusada()
+    {
+        Result<ConfiguracaoDerivacaoFato> resultado = ConfiguracaoDerivacaoFato.Criar("MODALIDADE",
+            [Ancora(0, "AC"), Regra(0, "AC_PCD", ("CONCORRER_PCD", true))]);
+
+        resultado.IsFailure.Should().BeTrue("a ordem das regras é total, para serialização determinística");
+        resultado.Error!.Code.Should().Be(ConfiguracaoDerivacaoFatoErrorCodes.OrdemRegraDuplicada);
+    }
+
+    [Fact(DisplayName = "Configuração sem regra alguma é recusada")]
+    public void SemRegras_Recusada()
+    {
+        Result<ConfiguracaoDerivacaoFato> resultado = ConfiguracaoDerivacaoFato.Criar("MODALIDADE", regras: []);
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be(ConfiguracaoDerivacaoFatoErrorCodes.SemRegras);
+    }
+
+    [Fact(DisplayName = "Definir substitui a configuração anterior por inteiro")]
+    public void Definir_SubstituiPorInteiro()
+    {
+        ProcessoSeletivo processo = NovoProcesso();
+        processo.DefinirRegrasDerivacao([ConfigModalidade()]).IsSuccess.Should().BeTrue();
+
+        ConfiguracaoDerivacaoFato outra = ConfiguracaoDerivacaoFato.Criar("OUTRO_DERIVADO",
+            [Ancora(0, "X")]).Value!;
+        processo.DefinirRegrasDerivacao([outra]).IsSuccess.Should().BeTrue();
+
+        processo.RegrasDerivacao.Should().ContainSingle(c => c.CodigoFato == "OUTRO_DERIVADO");
+    }
+
+    [Fact(DisplayName = "As regras ficam vinculadas ao processo e as condições à regra")]
+    public void Vinculacao()
+    {
+        ProcessoSeletivo processo = NovoProcesso();
+
+        processo.DefinirRegrasDerivacao([ConfigModalidade()]).IsSuccess.Should().BeTrue();
+
+        ConfiguracaoDerivacaoFato config = processo.RegrasDerivacao.Single();
+        config.ProcessoSeletivoId.Should().Be(processo.Id);
+        config.Regras.Should().OnlyContain(r => r.ConfiguracaoDerivacaoFatoId == config.Id);
+        RegraDerivacaoConfigurada comCondicao = config.Regras.Single(r => r.Contribui == "LI_PCD");
+        comCondicao.Condicoes.Should().OnlyContain(c => c.RegraDerivacaoConfiguradaId == comCondicao.Id);
+    }
+}

--- a/tests/Unifesspa.UniPlus.Selecao.Domain.UnitTests/Entities/ProcessoSeletivoSessaoEditorialTests.cs
+++ b/tests/Unifesspa.UniPlus.Selecao.Domain.UnitTests/Entities/ProcessoSeletivoSessaoEditorialTests.cs
@@ -260,6 +260,20 @@ public sealed class ProcessoSeletivoSessaoEditorialTests
         resultado.Error!.Code.Should().Be("ProcessoSeletivo.GrafoDeFatosSomenteEmRascunho");
     }
 
+    [Fact(DisplayName = "As regras de derivação NÃO são editáveis após a publicação (aguardam o congelamento conjunto de #928)")]
+    public void DefinirRegrasDerivacao_ProcessoPublicado_Recusa()
+    {
+        ProcessoSeletivo processo = ComSessaoAberta(out _);
+
+        ConfiguracaoDerivacaoFato config = ConfiguracaoDerivacaoFato.Criar("MODALIDADE",
+            [RegraDerivacaoConfigurada.Criar(0, "AC", condicoes: null).Value!]).Value!;
+
+        Result resultado = processo.DefinirRegrasDerivacao([config]);
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be("ProcessoSeletivo.RegrasDerivacaoSomenteEmRascunho");
+    }
+
     [Fact(DisplayName = "Uma mutação RECUSADA não move a revisão — o ETag do cliente continua válido")]
     public void Definir_Recusado_NaoIncrementaRevisao()
     {

--- a/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/ProcessosSeletivos/ProcessoSeletivoPersistenciaTests.cs
+++ b/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/ProcessosSeletivos/ProcessoSeletivoPersistenciaTests.cs
@@ -1,5 +1,7 @@
 namespace Unifesspa.UniPlus.Selecao.IntegrationTests.ProcessosSeletivos;
 
+using System.Text.Json;
+
 using AwesomeAssertions;
 
 using Microsoft.EntityFrameworkCore;
@@ -7,6 +9,7 @@ using Microsoft.EntityFrameworkCore;
 using Unifesspa.UniPlus.Kernel.Results;
 using Unifesspa.UniPlus.Selecao.Domain.Entities;
 using Unifesspa.UniPlus.Selecao.Domain.Enums;
+using Unifesspa.UniPlus.Selecao.Domain.Services;
 using Unifesspa.UniPlus.Selecao.Domain.ValueObjects;
 using Unifesspa.UniPlus.Selecao.Infrastructure.Persistence;
 using Unifesspa.UniPlus.Selecao.Infrastructure.Persistence.Repositories;
@@ -119,5 +122,99 @@ public sealed class ProcessoSeletivoPersistenciaTests : IClassFixture<ProcessoSe
         recarregado!.Etapas.Should().HaveCount(2);
         recarregado.Etapas.Select(e => e.Nome).Should().BeEquivalentTo(["Prova Objetiva", "Entrevista"]);
         recarregado.CalcularDivisorMedia().Should().Be(5m);
+    }
+
+    [Fact(DisplayName = "Persiste e reidrata a regra de derivação nos três níveis, reconstruindo o value object do motor")]
+    public async Task PersisteEReidrata_RegraDerivacao()
+    {
+        ProcessoSeletivo processo = ProcessoSeletivo.Criar("PS 2026 — Derivação", TipoProcesso.SiSU, OrigemCandidatos.InscricaoPropria);
+
+        ConfiguracaoDerivacaoFato config = ConfiguracaoDerivacaoFato.Criar("MODALIDADE",
+        [
+            RegraDerivacaoConfigurada.Criar(0, "AC", condicoes: null).Value!,
+            RegraDerivacaoConfigurada.Criar(1, "AC_PCD",
+                [CondicaoRegraDerivacao.Criar(1, "CONCORRER_PCD", Operador.Igual, JsonSerializer.SerializeToElement(true)).Value!]).Value!,
+        ]).Value!;
+        processo.DefinirRegrasDerivacao([config]).IsSuccess.Should().BeTrue();
+
+        await using (SelecaoDbContext writeContext = _fixture.CreateDbContext())
+        {
+            ProcessoSeletivoRepository repository = new(writeContext, TimeProvider.System);
+            await repository.AdicionarAsync(processo, CancellationToken.None);
+            await writeContext.SaveChangesAsync(CancellationToken.None);
+        }
+
+        await using SelecaoDbContext readContext = _fixture.CreateDbContext();
+        ProcessoSeletivoRepository readRepo = new(readContext, TimeProvider.System);
+        ProcessoSeletivo? recarregado = await readRepo.ObterComConfiguracaoAsync(processo.Id, CancellationToken.None);
+
+        recarregado.Should().NotBeNull();
+        ConfiguracaoDerivacaoFato recarregadaConfig = recarregado!.RegrasDerivacao.Single();
+        recarregadaConfig.CodigoFato.Should().Be("MODALIDADE");
+        recarregadaConfig.Regras.Should().HaveCount(2, "os três níveis reidratam — a configuração, as regras e as condições");
+        recarregadaConfig.Regras.Single(r => r.Contribui == "AC_PCD").Condicoes.Should().ContainSingle(c => c.Fato == "CONCORRER_PCD");
+
+        // Round-trip completo: a reconstrução do value object que o motor consome bate com o cadastro.
+        RegrasDerivacaoFato vo = recarregadaConfig.ParaRegrasDerivacao(RegrasDerivacaoModalidadeLei12711.DominioCanonico).Value!;
+        vo.Regras.Should().HaveCount(2);
+        vo.DependenciasDeclaradas.Should().BeEquivalentTo(["CONCORRER_PCD"]);
+    }
+
+    [Fact(DisplayName = "Redefinir a regra de derivação sobre o agregado carregado apaga a árvore antiga inteira (cascade órfão nos três níveis)")]
+    public async Task RedefinirRegraDerivacao_SobreAgregadoTracked_ApagaArvoreAntiga()
+    {
+        ProcessoSeletivo processo = ProcessoSeletivo.Criar("PS 2026 — Redefinição", TipoProcesso.SiSU, OrigemCandidatos.InscricaoPropria);
+        processo.DefinirRegrasDerivacao(
+        [
+            ConfiguracaoDerivacaoFato.Criar("MODALIDADE",
+            [
+                RegraDerivacaoConfigurada.Criar(0, "AC", condicoes: null).Value!,
+                RegraDerivacaoConfigurada.Criar(1, "AC_PCD",
+                    [CondicaoRegraDerivacao.Criar(1, "CONCORRER_PCD", Operador.Igual, JsonSerializer.SerializeToElement(true)).Value!]).Value!,
+            ]).Value!,
+        ]).IsSuccess.Should().BeTrue();
+
+        await using (SelecaoDbContext writeContext = _fixture.CreateDbContext())
+        {
+            ProcessoSeletivoRepository repository = new(writeContext, TimeProvider.System);
+            await repository.AdicionarAsync(processo, CancellationToken.None);
+            await writeContext.SaveChangesAsync(CancellationToken.None);
+        }
+
+        // Substitui a configuração por inteiro sobre o agregado JÁ tracked (fluxo real de reconfiguração):
+        // Clear+Add deve marcar as regras e condições antigas como órfãs e o cascade deve deletá-las.
+        await using (SelecaoDbContext mutateContext = _fixture.CreateDbContext())
+        {
+            ProcessoSeletivoRepository repository = new(mutateContext, TimeProvider.System);
+            ProcessoSeletivo carregado = (await repository.ObterComConfiguracaoAsync(processo.Id, CancellationToken.None))!;
+
+            carregado.DefinirRegrasDerivacao(
+            [
+                ConfiguracaoDerivacaoFato.Criar("MODALIDADE",
+                [
+                    RegraDerivacaoConfigurada.Criar(0, "AC", condicoes: null).Value!,
+                ]).Value!,
+            ]).IsSuccess.Should().BeTrue();
+
+            await mutateContext.SaveChangesAsync(CancellationToken.None);
+        }
+
+        // Contexto novo: a árvore antiga inteira sumiu — sobra só a única regra âncora sem condição.
+        // Contagens escopadas a ESTE processo (a fixture é compartilhada entre testes da classe).
+        await using SelecaoDbContext readContext = _fixture.CreateDbContext();
+        Guid configId = await readContext.Set<ConfiguracaoDerivacaoFato>()
+            .Where(c => c.ProcessoSeletivoId == processo.Id).Select(c => c.Id).SingleAsync(CancellationToken.None);
+
+        List<Guid> regraIds = await readContext.Set<RegraDerivacaoConfigurada>()
+            .Where(r => r.ConfiguracaoDerivacaoFatoId == configId).Select(r => r.Id).ToListAsync(CancellationToken.None);
+        regraIds.Should().HaveCount(1, "a regra AC_PCD antiga foi apagada como órfã");
+
+        int condicoesRestantes = await readContext.Set<CondicaoRegraDerivacao>()
+            .CountAsync(c => regraIds.Contains(c.RegraDerivacaoConfiguradaId), CancellationToken.None);
+        condicoesRestantes.Should().Be(0, "a condição da regra AC_PCD antiga foi apagada em cascata");
+
+        ProcessoSeletivoRepository readRepo = new(readContext, TimeProvider.System);
+        ProcessoSeletivo recarregado = (await readRepo.ObterComConfiguracaoAsync(processo.Id, CancellationToken.None))!;
+        recarregado.RegrasDerivacao.Single().Regras.Should().ContainSingle(r => r.Contribui == "AC");
     }
 }


### PR DESCRIPTION
## Contexto

Story #927 — a regra de derivação declarativa de um fato (a matriz que resolve MODALIDADE pela Lei de Cotas, entre outros) precisa ter uma **forma persistida** na configuração do `ProcessoSeletivo`, que reconstrói o value object consumido pelo motor de derivação (já mergeado).

## O que entra

- **Agregado → tabela, três níveis:** `ConfiguracaoDerivacaoFato` (fato alvo) → `RegraDerivacaoConfigurada` (ordem + código contribuído) → `CondicaoRegraDerivacao` (cláusula do predicado `quando`). A **âncora** incondicional é a regra sem condição alguma — predicado de DNF vazio, que resolve verdadeiro sempre.
- **`ProcessoSeletivo.DefinirRegrasDerivacao`** substitui a configuração por inteiro, **restrito a rascunho** — mesmo padrão de `FatoColetado`. O congelamento e a liberação sob retificação são da fatia de RN08 (#928 §7).
- **`ParaRegrasDerivacao`** reconstrói o VO que o motor consome, **recebendo o domínio de contribuição do chamador** (MODALIDADE tem domínio de escopo-processo, não de catálogo) e **recomputando as dependências** dos fatos citados, nunca as persistindo — evita drift entre cadastro e derivação.
- **Reidratação defensiva:** propaga `Result` em vez de assumir a forma — uma linha de condição corrompida recusa como falha de domínio, nunca lança.
- **Persistência EF:** três tabelas, unicidades (processo × fato, configuração × ordem), `Include` de três níveis com `AsSplitQuery`, e cascade que apaga a árvore antiga inteira ao redefinir. Migration `AddConfiguracaoDerivacaoFato`.

## Fronteira de validação

Estrutural aqui (unicidade, ordem, forma); a **semântica** (fato alvo derivado com binding de regra, vocabulário e domínio dos códigos) é do handler Application, fora desta fatia.

## Testes

- 10 testes de domínio: âncora, reconstrução do VO, código fora do domínio, código de fato duplicado, ordem duplicada, sem regras, substituição por inteiro, vinculação, recusa fora de rascunho.
- Integração contra Postgres real: round-trip que reidrata os três níveis e reconstrói o VO; **redefinição sobre agregado tracked** provando que a árvore antiga inteira some por cascade.

Gates locais verdes: build 0/0, suíte completa, `dotnet format`, migration por `dotnet ef` sem pending.

Parte da Story #927 (persistência da regra de composição; congelamento RN08 e derivação de MODALIDADE seguem nas fatias seguintes). Não fecha a story.