### PR TITLE
refactor(selecao): torna explícito o perfil canônico de cada versão do envelope

### DIFF
--- a/src/selecao/Unifesspa.UniPlus.Selecao.Domain/ValueObjects/HashCanonicalComputer.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Domain/ValueObjects/HashCanonicalComputer.cs
@@ -288,6 +288,14 @@ public static class HashCanonicalComputer
     /// bytes uma vez, na publicação; o hash é derivado deles (nunca
     /// recalculado a partir de uma forma intermediária).
     /// </summary>
+    /// <remarks>
+    /// <strong>Este método é a implementação do perfil <c>canonical-json/sha256@v1</c></strong>
+    /// — o perfil sob o qual todo envelope já publicado foi congelado. Ele não muda: alterar
+    /// aqui a ordenação, a tabela de escapes, a forma dos números ou o tratamento de
+    /// <c>null</c> reescreveria retroativamente os bytes de certames encerrados, que deixariam
+    /// de reproduzir o próprio hash. Um perfil com outras regras se escreve <b>ao lado</b>,
+    /// com serialização própria, e vale só para as versões de schema que nascerem depois dele.
+    /// </remarks>
     public static byte[] ComputeSnapshotBytes(JsonObject payload)
     {
         ArgumentNullException.ThrowIfNull(payload);

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/Canonicalization/ComparadorLexicograficoDeBytes.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/Canonicalization/ComparadorLexicograficoDeBytes.cs
@@ -1,0 +1,55 @@
+namespace Unifesspa.UniPlus.Selecao.Infrastructure.Canonicalization;
+
+/// <summary>
+/// Ordem lexicográfica sobre os <b>bytes</b> — a que vale quando a chave de ordenação é o
+/// próprio conteúdo canônico de um item.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Onde uma coleção do envelope não tem chave natural, a ordem vem da <b>chave de conteúdo</b>:
+/// os bytes canônicos do próprio item (ADR-0109 D9). Comparar essa chave decodificando os bytes
+/// para <c>string</c> e usando comparação ordinal parece equivalente, e é — enquanto os bytes
+/// forem ASCII, como são sob o perfil <c>canonical-json/sha256@v1</c>, que escapa todo o resto.
+/// </para>
+/// <para>
+/// Deixa de ser no instante em que um perfil emitir texto UTF-8 literal: a ordem por unidade de
+/// código UTF-16 diverge da ordem por byte UTF-8 acima de <c>U+FFFF</c>. Um caractere da área de
+/// uso privado (<c>U+E000</c>) precede um emoji em UTF-8 e o sucede em comparação ordinal, porque
+/// o emoji é escrito como par substituto, que começa em <c>U+D800</c>. Duas configurações
+/// equivalentes ordenariam diferente conforme o texto que carregam.
+/// </para>
+/// <para>
+/// A ordem daqui é a única compatível com "os bytes canônicos do próprio item", e é a mesma que
+/// o perfil v1 já produz na prática — trocá-la agora não move nenhum envelope publicado.
+/// </para>
+/// </remarks>
+public sealed class ComparadorLexicograficoDeBytes : IComparer<byte[]>
+{
+    public static readonly ComparadorLexicograficoDeBytes Instancia = new();
+
+    private ComparadorLexicograficoDeBytes()
+    {
+    }
+
+    public int Compare(byte[]? x, byte[]? y)
+    {
+        if (ReferenceEquals(x, y))
+        {
+            return 0;
+        }
+
+        if (x is null)
+        {
+            return -1;
+        }
+
+        if (y is null)
+        {
+            return 1;
+        }
+
+        // SequenceCompareTo sobre byte compara sem sinal e resolve o prefixo pelo comprimento —
+        // que é exatamente a ordem lexicográfica de octetos.
+        return x.AsSpan().SequenceCompareTo(y.AsSpan());
+    }
+}

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/Canonicalization/EnvelopeCodecV10.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/Canonicalization/EnvelopeCodecV10.cs
@@ -25,7 +25,9 @@ public sealed class EnvelopeCodecV10 : IEnvelopeCodec
 {
     public string SchemaVersion => "1.0";
 
-    public string AlgoritmoHash => "canonical-json/sha256@v1";
+    public IPerfilCanonico Perfil => PerfilCanonicoV1.Instancia;
+
+    public string AlgoritmoHash => Perfil.Algoritmo;
 
     public bool TemEncoder => false;
 

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/Canonicalization/EnvelopeCodecV11.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/Canonicalization/EnvelopeCodecV11.cs
@@ -614,8 +614,8 @@ public sealed class EnvelopeCodecV11 : IEnvelopeCodec
     private static JsonArray OrdenarPorConteudoV11(IEnumerable<JsonObject> itens)
     {
         IOrderedEnumerable<JsonObject> ordenados = itens.OrderBy(
-            static item => System.Text.Encoding.UTF8.GetString(PerfilCanonicoV1.Instancia.Serializar(item)),
-            StringComparer.Ordinal);
+            static item => PerfilCanonicoV1.Instancia.Serializar(item),
+            ComparadorLexicograficoDeBytes.Instancia);
 
         return new JsonArray([.. ordenados.Select(static item => (JsonNode)item)]);
     }

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/Canonicalization/EnvelopeCodecV11.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/Canonicalization/EnvelopeCodecV11.cs
@@ -115,7 +115,9 @@ public sealed class EnvelopeCodecV11 : IEnvelopeCodec
 
     public string SchemaVersion => "1.1";
 
-    public string AlgoritmoHash => "canonical-json/sha256@v1";
+    public IPerfilCanonico Perfil => PerfilCanonicoV1.Instancia;
+
+    public string AlgoritmoHash => Perfil.Algoritmo;
 
     public bool TemEncoder => true;
 
@@ -178,7 +180,7 @@ public sealed class EnvelopeCodecV11 : IEnvelopeCodec
             };
         }
 
-        byte[] bytes = HashCanonicalComputer.ComputeSnapshotBytes(payload);
+        byte[] bytes = PerfilCanonicoV1.Instancia.Serializar(payload);
         return new SnapshotCanonico(bytes, SchemaVersion, AlgoritmoHash);
     }
 
@@ -612,7 +614,7 @@ public sealed class EnvelopeCodecV11 : IEnvelopeCodec
     private static JsonArray OrdenarPorConteudoV11(IEnumerable<JsonObject> itens)
     {
         IOrderedEnumerable<JsonObject> ordenados = itens.OrderBy(
-            static item => System.Text.Encoding.UTF8.GetString(HashCanonicalComputer.ComputeSnapshotBytes(item)),
+            static item => System.Text.Encoding.UTF8.GetString(PerfilCanonicoV1.Instancia.Serializar(item)),
             StringComparer.Ordinal);
 
         return new JsonArray([.. ordenados.Select(static item => (JsonNode)item)]);
@@ -629,7 +631,7 @@ public sealed class EnvelopeCodecV11 : IEnvelopeCodec
     {
         ArgumentNullException.ThrowIfNull(versao);
 
-        Result<JsonObject> parse = Parsear(versao.ConfiguracaoCongeladaCanonica);
+        Result<JsonObject> parse = Parsear(Perfil, versao.ConfiguracaoCongeladaCanonica);
         if (parse.IsFailure)
         {
             return Result<EnvelopeReidratado>.Failure(parse.Error!);
@@ -688,8 +690,23 @@ public sealed class EnvelopeCodecV11 : IEnvelopeCodec
     /// o parser escolheria uma) não é um envelope <c>1.1</c>, é outra coisa com o mesmo
     /// hash recomputado por quem o adulterou.
     /// </summary>
-    internal static Result<JsonObject> Parsear(byte[] bytes)
+    /// <remarks>
+    /// <para>
+    /// O <paramref name="perfil"/> é do <b>chamador</b>, não deste codec: os decoders das
+    /// versões seguintes reusam este parse, e "estar na forma canônica" é uma pergunta que só
+    /// tem resposta relativa às regras de bytes daquela versão. Fixar o perfil <c>v1</c> aqui
+    /// faria uma versão futura, emitida sob outro perfil, ser recusada dentro do próprio
+    /// decoder — depois de ter passado, corretamente, pelo gate do registro.
+    /// </para>
+    /// <para>
+    /// A checagem de forma repete a do <see cref="RegistroCodecsEnvelope"/> de propósito:
+    /// <c>Decodificar</c> é público e chamável direto, sem passar pelo registro.
+    /// </para>
+    /// </remarks>
+    internal static Result<JsonObject> Parsear(IPerfilCanonico perfil, byte[] bytes)
     {
+        ArgumentNullException.ThrowIfNull(perfil);
+
         JsonNode? node;
         try
         {
@@ -709,7 +726,18 @@ public sealed class EnvelopeCodecV11 : IEnvelopeCodec
                 "Os bytes congelados não são um objeto JSON."));
         }
 
-        byte[] recanonicalizado = HashCanonicalComputer.ComputeSnapshotBytes(payload);
+        byte[] recanonicalizado;
+        try
+        {
+            recanonicalizado = perfil.Serializar(payload);
+        }
+        catch (PayloadForaDoPerfilCanonicoException excecao)
+        {
+            return Result<JsonObject>.Failure(new DomainError(
+                ErrosCodecEnvelope.EnvelopeMalformado,
+                $"Os bytes congelados contêm o que o perfil '{perfil.Algoritmo}' não representa: {excecao.Message}"));
+        }
+
         if (!recanonicalizado.AsSpan().SequenceEqual(bytes))
         {
             return Result<JsonObject>.Failure(new DomainError(

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/Canonicalization/EnvelopeCodecV12.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/Canonicalization/EnvelopeCodecV12.cs
@@ -953,9 +953,9 @@ public sealed class EnvelopeCodecV12 : IEnvelopeCodec
         IOrderedEnumerable<DocumentoExigido> ordenadas = exigencias
             .OrderBy(static e => e.ExigidoNaFaseId)
             .ThenBy(static e => e.TipoDocumentoOrigemId)
-            .ThenBy(static e => System.Text.Encoding.UTF8.GetString(
-                PerfilCanonicoV1.Instancia.Serializar(SerializarExigenciaSemIdentidadeV12(e))),
-                StringComparer.Ordinal)
+            .ThenBy(
+                static e => PerfilCanonicoV1.Instancia.Serializar(SerializarExigenciaSemIdentidadeV12(e)),
+                ComparadorLexicograficoDeBytes.Instancia)
             .ThenBy(static e => e.Id);
 
         return new JsonArray([.. ordenadas.Select(static e =>
@@ -1185,8 +1185,8 @@ public sealed class EnvelopeCodecV12 : IEnvelopeCodec
     private static JsonArray OrdenarPorConteudoV12(IEnumerable<JsonObject> itens)
     {
         IOrderedEnumerable<JsonObject> ordenados = itens.OrderBy(
-            static item => System.Text.Encoding.UTF8.GetString(PerfilCanonicoV1.Instancia.Serializar(item)),
-            StringComparer.Ordinal);
+            static item => PerfilCanonicoV1.Instancia.Serializar(item),
+            ComparadorLexicograficoDeBytes.Instancia);
 
         return new JsonArray([.. ordenados.Select(static item => (JsonNode)item)]);
     }

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/Canonicalization/EnvelopeCodecV12.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/Canonicalization/EnvelopeCodecV12.cs
@@ -75,7 +75,9 @@ public sealed class EnvelopeCodecV12 : IEnvelopeCodec
 
     public string SchemaVersion => "1.2";
 
-    public string AlgoritmoHash => "canonical-json/sha256@v1";
+    public IPerfilCanonico Perfil => PerfilCanonicoV1.Instancia;
+
+    public string AlgoritmoHash => Perfil.Algoritmo;
 
     public bool TemEncoder => true;
 
@@ -87,7 +89,7 @@ public sealed class EnvelopeCodecV12 : IEnvelopeCodec
     {
         ArgumentNullException.ThrowIfNull(versao);
 
-        Result<JsonObject> parse = EnvelopeCodecV11.Parsear(versao.ConfiguracaoCongeladaCanonica);
+        Result<JsonObject> parse = EnvelopeCodecV11.Parsear(Perfil, versao.ConfiguracaoCongeladaCanonica);
         if (parse.IsFailure)
         {
             return Result<EnvelopeReidratado>.Failure(parse.Error!);
@@ -654,7 +656,7 @@ public sealed class EnvelopeCodecV12 : IEnvelopeCodec
             };
         }
 
-        byte[] bytes = HashCanonicalComputer.ComputeSnapshotBytes(payload);
+        byte[] bytes = PerfilCanonicoV1.Instancia.Serializar(payload);
         return new SnapshotCanonico(bytes, SchemaVersion, AlgoritmoHash);
     }
 
@@ -952,7 +954,7 @@ public sealed class EnvelopeCodecV12 : IEnvelopeCodec
             .OrderBy(static e => e.ExigidoNaFaseId)
             .ThenBy(static e => e.TipoDocumentoOrigemId)
             .ThenBy(static e => System.Text.Encoding.UTF8.GetString(
-                HashCanonicalComputer.ComputeSnapshotBytes(SerializarExigenciaSemIdentidadeV12(e))),
+                PerfilCanonicoV1.Instancia.Serializar(SerializarExigenciaSemIdentidadeV12(e))),
                 StringComparer.Ordinal)
             .ThenBy(static e => e.Id);
 
@@ -1183,7 +1185,7 @@ public sealed class EnvelopeCodecV12 : IEnvelopeCodec
     private static JsonArray OrdenarPorConteudoV12(IEnumerable<JsonObject> itens)
     {
         IOrderedEnumerable<JsonObject> ordenados = itens.OrderBy(
-            static item => System.Text.Encoding.UTF8.GetString(HashCanonicalComputer.ComputeSnapshotBytes(item)),
+            static item => System.Text.Encoding.UTF8.GetString(PerfilCanonicoV1.Instancia.Serializar(item)),
             StringComparer.Ordinal);
 
         return new JsonArray([.. ordenados.Select(static item => (JsonNode)item)]);

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/Canonicalization/EnvelopeCodecV13.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/Canonicalization/EnvelopeCodecV13.cs
@@ -782,9 +782,9 @@ public sealed class EnvelopeCodecV13 : IEnvelopeCodec
         IOrderedEnumerable<DocumentoExigido> ordenadas = exigencias
             .OrderBy(static e => e.ExigidoNaFaseId)
             .ThenBy(static e => e.TipoDocumentoOrigemId)
-            .ThenBy(static e => System.Text.Encoding.UTF8.GetString(
-                PerfilCanonicoV1.Instancia.Serializar(SerializarExigenciaSemIdentidadeV13(e))),
-                StringComparer.Ordinal)
+            .ThenBy(
+                static e => PerfilCanonicoV1.Instancia.Serializar(SerializarExigenciaSemIdentidadeV13(e)),
+                ComparadorLexicograficoDeBytes.Instancia)
             // Achado de revisão (Story #554, PR #903): duas exigências byte-idênticas em
             // todo o resto (mesma fase, mesmo tipo, mesmo conteúdo) empatam na chave de
             // conteúdo acima — e, ao contrário de regrasEliminacao (sem identidade), o Id
@@ -1080,8 +1080,8 @@ public sealed class EnvelopeCodecV13 : IEnvelopeCodec
     private static JsonArray OrdenarPorConteudoV13(IEnumerable<JsonObject> itens)
     {
         IOrderedEnumerable<JsonObject> ordenados = itens.OrderBy(
-            static item => System.Text.Encoding.UTF8.GetString(PerfilCanonicoV1.Instancia.Serializar(item)),
-            StringComparer.Ordinal);
+            static item => PerfilCanonicoV1.Instancia.Serializar(item),
+            ComparadorLexicograficoDeBytes.Instancia);
 
         return new JsonArray([.. ordenados.Select(static item => (JsonNode)item)]);
     }

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/Canonicalization/EnvelopeCodecV13.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/Canonicalization/EnvelopeCodecV13.cs
@@ -71,7 +71,9 @@ public sealed class EnvelopeCodecV13 : IEnvelopeCodec
 
     public string SchemaVersion => "1.3";
 
-    public string AlgoritmoHash => "canonical-json/sha256@v1";
+    public IPerfilCanonico Perfil => PerfilCanonicoV1.Instancia;
+
+    public string AlgoritmoHash => Perfil.Algoritmo;
 
     public bool TemEncoder => true;
 
@@ -83,7 +85,7 @@ public sealed class EnvelopeCodecV13 : IEnvelopeCodec
     {
         ArgumentNullException.ThrowIfNull(versao);
 
-        Result<JsonObject> parse = EnvelopeCodecV11.Parsear(versao.ConfiguracaoCongeladaCanonica);
+        Result<JsonObject> parse = EnvelopeCodecV11.Parsear(Perfil, versao.ConfiguracaoCongeladaCanonica);
         if (parse.IsFailure)
         {
             return Result<EnvelopeReidratado>.Failure(parse.Error!);
@@ -371,7 +373,7 @@ public sealed class EnvelopeCodecV13 : IEnvelopeCodec
             };
         }
 
-        byte[] bytes = HashCanonicalComputer.ComputeSnapshotBytes(payload);
+        byte[] bytes = PerfilCanonicoV1.Instancia.Serializar(payload);
         return new SnapshotCanonico(bytes, SchemaVersion, AlgoritmoHash);
     }
 
@@ -781,7 +783,7 @@ public sealed class EnvelopeCodecV13 : IEnvelopeCodec
             .OrderBy(static e => e.ExigidoNaFaseId)
             .ThenBy(static e => e.TipoDocumentoOrigemId)
             .ThenBy(static e => System.Text.Encoding.UTF8.GetString(
-                HashCanonicalComputer.ComputeSnapshotBytes(SerializarExigenciaSemIdentidadeV13(e))),
+                PerfilCanonicoV1.Instancia.Serializar(SerializarExigenciaSemIdentidadeV13(e))),
                 StringComparer.Ordinal)
             // Achado de revisão (Story #554, PR #903): duas exigências byte-idênticas em
             // todo o resto (mesma fase, mesmo tipo, mesmo conteúdo) empatam na chave de
@@ -1078,7 +1080,7 @@ public sealed class EnvelopeCodecV13 : IEnvelopeCodec
     private static JsonArray OrdenarPorConteudoV13(IEnumerable<JsonObject> itens)
     {
         IOrderedEnumerable<JsonObject> ordenados = itens.OrderBy(
-            static item => System.Text.Encoding.UTF8.GetString(HashCanonicalComputer.ComputeSnapshotBytes(item)),
+            static item => System.Text.Encoding.UTF8.GetString(PerfilCanonicoV1.Instancia.Serializar(item)),
             StringComparer.Ordinal);
 
         return new JsonArray([.. ordenados.Select(static item => (JsonNode)item)]);

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/Canonicalization/EnvelopeCodecV14.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/Canonicalization/EnvelopeCodecV14.cs
@@ -60,7 +60,9 @@ public sealed class EnvelopeCodecV14 : IEnvelopeCodec
 
     public string SchemaVersion => "1.4";
 
-    public string AlgoritmoHash => "canonical-json/sha256@v1";
+    public IPerfilCanonico Perfil => PerfilCanonicoV1.Instancia;
+
+    public string AlgoritmoHash => Perfil.Algoritmo;
 
     public bool TemEncoder => true;
 
@@ -94,7 +96,7 @@ public sealed class EnvelopeCodecV14 : IEnvelopeCodec
     {
         ArgumentNullException.ThrowIfNull(versao);
 
-        Result<JsonObject> parse = EnvelopeCodecV11.Parsear(versao.ConfiguracaoCongeladaCanonica);
+        Result<JsonObject> parse = EnvelopeCodecV11.Parsear(Perfil, versao.ConfiguracaoCongeladaCanonica);
         if (parse.IsFailure)
         {
             return Result<EnvelopeReidratado>.Failure(parse.Error!);

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/Canonicalization/IEnvelopeCodec.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/Canonicalization/IEnvelopeCodec.cs
@@ -18,7 +18,18 @@ public interface IEnvelopeCodec
 {
     string SchemaVersion { get; }
 
-    /// <summary>Algoritmo de hash que esta versão emite — parte da evidência, não detalhe.</summary>
+    /// <summary>
+    /// Regras de bytes sob as quais esta versão foi congelada. É por aqui que o gate de forma
+    /// pergunta “estes bytes são canônicos?” — a pergunta só tem resposta <b>relativa a um
+    /// perfil</b>, e a de uma versão nunca é a de outra.
+    /// </summary>
+    IPerfilCanonico Perfil { get; }
+
+    /// <summary>
+    /// Algoritmo de hash que esta versão emite — parte da evidência, não detalhe. Deriva do
+    /// <see cref="Perfil"/>: o rótulo persistido e o código que produz os bytes têm de ser a
+    /// mesma coisa dita duas vezes, nunca dois literais que alguém mantém em sincronia.
+    /// </summary>
     string AlgoritmoHash { get; }
 
     bool TemEncoder { get; }

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/Canonicalization/IPerfilCanonico.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/Canonicalization/IPerfilCanonico.cs
@@ -1,0 +1,57 @@
+namespace Unifesspa.UniPlus.Selecao.Infrastructure.Canonicalization;
+
+using System.Text.Json.Nodes;
+
+/// <summary>
+/// As regras de <b>bytes</b> de uma versão do envelope: como um payload vira a sequência
+/// exata de octetos que o certame congela, e qual digest se extrai dela.
+/// </summary>
+/// <remarks>
+/// <para>
+/// A <c>schema_version</c> versiona a <b>forma do payload</b> — quais blocos existem, o que
+/// cada um carrega. Ela não diz nada sobre como aquele payload vira bytes: ordenação de
+/// chaves, tabela de escapes, forma dos números, o que fazer com <c>null</c>. Essas regras
+/// são o <b>perfil canônico</b>, identificado à parte (<see cref="Algoritmo"/>) e persistido
+/// junto do envelope em <c>versao_configuracao.algoritmo_hash</c>.
+/// </para>
+/// <para>
+/// Duas coisas distintas, dois eixos de versionamento: um bloco novo sobe a schema_version e
+/// mantém o perfil; uma regra de escape diferente mantém a forma e <b>troca o perfil</b>. Sem
+/// essa separação, a única maneira de mudar as regras de serialização seria editar o código
+/// compartilhado por todos os codecs — e um envelope publicado há um ano deixaria de reproduzir
+/// os próprios bytes, em silêncio, no dia em que alguém trocasse um <c>Encoder</c>.
+/// </para>
+/// <para>
+/// Um perfil é <b>imutável depois que emite o primeiro envelope</b>. Mudar qualquer regra
+/// daqui para frente é criar um perfil NOVO, com identificador novo, e apontar para ele apenas
+/// as versões de schema que nascem depois.
+/// </para>
+/// </remarks>
+public interface IPerfilCanonico
+{
+    /// <summary>
+    /// Identificador do perfil, gravado com o envelope — ex.: <c>canonical-json/sha256@v1</c>.
+    /// É parte da evidência, não rótulo: é por ele que a reidratação sabe com que regras os
+    /// bytes que está lendo foram produzidos.
+    /// </summary>
+    string Algoritmo { get; }
+
+    /// <summary>
+    /// Transforma o payload nos bytes canônicos do perfil.
+    /// </summary>
+    /// <exception cref="PayloadForaDoPerfilCanonicoException">
+    /// Quando o payload viola uma regra que o perfil recusa em vez de normalizar. Perfis mais
+    /// estritos que o <c>v1</c> não “consertam” o payload em silêncio — um valor que o perfil
+    /// não sabe representar tem de estourar aqui, e não virar bytes que ninguém pediu.
+    /// </exception>
+    byte[] Serializar(JsonObject payload);
+
+    /// <summary>
+    /// Digest hex minúsculo dos bytes <b>já canônicos</b> — sobre a evidência lida, nunca sobre
+    /// um payload reconstruído. Separado de <see cref="Serializar"/> de propósito: o gate de
+    /// integridade hasheia os bytes que vieram do banco; o gate de forma reserializa e compara.
+    /// Fundi-los convidaria a hashear o que se acabou de gerar, que é justamente o que não
+    /// prova nada.
+    /// </summary>
+    string HashHex(byte[] bytes);
+}

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/Canonicalization/PayloadForaDoPerfilCanonicoException.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/Canonicalization/PayloadForaDoPerfilCanonicoException.cs
@@ -1,0 +1,35 @@
+namespace Unifesspa.UniPlus.Selecao.Infrastructure.Canonicalization;
+
+/// <summary>
+/// O payload contém algo que o perfil canônico recusa representar.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Recusar é a alternativa a normalizar. Um perfil que “conserta” o payload — omite a chave
+/// cujo valor é <c>null</c>, arredonda o número que não cabe na escala — produz bytes que
+/// ninguém escreveu, e o envelope deixa de dizer o que a configuração dizia.
+/// </para>
+/// <para>
+/// É erro de programação no caminho de <b>emissão</b> (o gate de publicação já deveria ter
+/// recusado a configuração antes de canonicalizar) e envelope malformado no caminho de
+/// <b>leitura</b> — onde <see cref="RegistroCodecsEnvelope"/> a converte em recusa nomeada, em
+/// vez de deixar escapar como falha não tratada.
+/// </para>
+/// </remarks>
+public sealed class PayloadForaDoPerfilCanonicoException : InvalidOperationException
+{
+    public PayloadForaDoPerfilCanonicoException(string message)
+        : base(message)
+    {
+    }
+
+    public PayloadForaDoPerfilCanonicoException(string message, Exception innerException)
+        : base(message, innerException)
+    {
+    }
+
+    public PayloadForaDoPerfilCanonicoException()
+        : base("O payload viola o perfil canônico.")
+    {
+    }
+}

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/Canonicalization/PerfilCanonicoV1.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/Canonicalization/PerfilCanonicoV1.cs
@@ -1,0 +1,59 @@
+namespace Unifesspa.UniPlus.Selecao.Infrastructure.Canonicalization;
+
+using System.Text.Json.Nodes;
+
+using Unifesspa.UniPlus.Selecao.Domain.ValueObjects;
+
+/// <summary>
+/// O perfil com que todo envelope das versões <c>1.0</c> a <c>1.4</c> foi congelado —
+/// <c>canonical-json/sha256@v1</c>. <b>Congelado</b>: descreve o que já está publicado, e por
+/// isso não muda mais.
+/// </summary>
+/// <remarks>
+/// <para>
+/// As regras, tais como são (ADR-0100):
+/// </para>
+/// <list type="number">
+///   <item>chaves de todo objeto reordenadas recursivamente por comparação ordinal; arrays
+///   preservam a ordem, que é semântica;</item>
+///   <item><c>null</c> explícito é <b>preservado</b> — o envelope distingue “campo ausente”
+///   de “campo presente e vazio”, e blocos publicados dependem disso (o número do ato ainda
+///   não atribuído, por exemplo);</item>
+///   <item>serialização por <c>Utf8JsonWriter</c> sem indentação e <b>sem encoder próprio</b>,
+///   o que significa o encoder padrão do runtime: escapa aspas, contrabarra e controles nas
+///   formas curtas, e escapa em <c>\uXXXX</c> com <b>hex maiúsculo</b> tudo o que estiver fora
+///   do latim básico — inclusive os caracteres sensíveis a HTML (<c>&lt;</c>, <c>&gt;</c>,
+///   <c>&amp;</c>, <c>'</c>, <c>+</c>) e toda letra acentuada;</item>
+///   <item>digest SHA-256, hex minúsculo, sobre os bytes assim produzidos.</item>
+/// </list>
+/// <para>
+/// O item 3 nunca foi decisão deliberada — é o comportamento padrão do serializador, e é
+/// exatamente por isso que ele precisa estar escrito e coberto por vetores fixos. Um perfil
+/// posterior pode preferir literais UTF-8 e hex minúsculo; o que ele não pode é <b>ser este</b>.
+/// </para>
+/// <para>
+/// A implementação delega a <see cref="HashCanonicalComputer"/>, que continua sendo o código
+/// v1 compartilhado. A consequência prática, e o motivo de este tipo existir: um perfil novo
+/// se escreve <b>ao lado</b>, com serialização própria — nunca editando aquele computador, que
+/// hoje está no caminho dos bytes de todo envelope já publicado.
+/// </para>
+/// </remarks>
+public sealed class PerfilCanonicoV1 : IPerfilCanonico
+{
+    /// <summary>
+    /// Instância única — o perfil não tem estado, e os encoders congelados (<c>static</c> por
+    /// construção) referenciam esta constante em vez de receberem o perfil por parâmetro: a
+    /// versão <c>1.1</c> emite sob o perfil <c>v1</c> por definição, não por configuração.
+    /// </summary>
+    public static readonly PerfilCanonicoV1 Instancia = new();
+
+    private PerfilCanonicoV1()
+    {
+    }
+
+    public string Algoritmo => "canonical-json/sha256@v1";
+
+    public byte[] Serializar(JsonObject payload) => HashCanonicalComputer.ComputeSnapshotBytes(payload);
+
+    public string HashHex(byte[] bytes) => HashCanonicalComputer.ComputeSha256Hex(bytes);
+}

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/Canonicalization/RegistroCodecsEnvelope.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/Canonicalization/RegistroCodecsEnvelope.cs
@@ -37,11 +37,58 @@ public sealed class RegistroCodecsEnvelope : IRegistroCodecsEnvelope
     private readonly Dictionary<string, IEnvelopeCodec> _codecs;
 
     public RegistroCodecsEnvelope()
+        : this(
+            [new EnvelopeCodecV10(), new EnvelopeCodecV11(), new EnvelopeCodecV12(), new EnvelopeCodecV13(), new EnvelopeCodecV14()],
+            new EnvelopeCodecV14().SchemaVersion)
     {
-        IEnvelopeCodec[] codecs =
-            [new EnvelopeCodecV10(), new EnvelopeCodecV11(), new EnvelopeCodecV12(), new EnvelopeCodecV13(), new EnvelopeCodecV14()];
-        _codecs = codecs.ToDictionary(static c => c.SchemaVersion, StringComparer.Ordinal);
-        SchemaVersionDeEmissaoCorrente = new EnvelopeCodecV14().SchemaVersion;
+    }
+
+    /// <summary>
+    /// Registro montado com um conjunto explícito de codecs — o caminho por onde os testes
+    /// plugam um codec com perfil próprio para provar que os gates perguntam ao <b>perfil da
+    /// versão</b>, e não a um serializador global. As invariantes do registro de produção
+    /// valem aqui igualmente: sem elas, um registro parcial passaria despercebido justamente
+    /// no teste que deveria provar o contrário.
+    /// </summary>
+    internal RegistroCodecsEnvelope(IEnumerable<IEnvelopeCodec> codecs, string schemaVersionDeEmissaoCorrente)
+    {
+        ArgumentNullException.ThrowIfNull(codecs);
+        ArgumentException.ThrowIfNullOrWhiteSpace(schemaVersionDeEmissaoCorrente);
+
+        IEnvelopeCodec[] materializados = [.. codecs];
+        if (materializados.Length == 0)
+        {
+            throw new ArgumentException("Um registro de codecs vazio não reidrata envelope nenhum.", nameof(codecs));
+        }
+
+        string? repetida = materializados
+            .GroupBy(static c => c.SchemaVersion, StringComparer.Ordinal)
+            .FirstOrDefault(static grupo => grupo.Count() > 1)?.Key;
+        if (repetida is not null)
+        {
+            throw new ArgumentException(
+                $"A versão '{repetida}' aparece em mais de um codec — qual deles reidrata um envelope dela seria indeterminado.",
+                nameof(codecs));
+        }
+
+        _codecs = materializados.ToDictionary(static c => c.SchemaVersion, StringComparer.Ordinal);
+
+        if (!_codecs.TryGetValue(schemaVersionDeEmissaoCorrente, out IEnvelopeCodec? corrente))
+        {
+            throw new ArgumentException(
+                $"A versão de emissão corrente '{schemaVersionDeEmissaoCorrente}' não tem codec no registro.",
+                nameof(schemaVersionDeEmissaoCorrente));
+        }
+
+        if (!corrente.TemEncoder || !corrente.TemDecoder)
+        {
+            throw new ArgumentException(
+                $"A versão de emissão corrente '{schemaVersionDeEmissaoCorrente}' precisa de codec completo: sem decoder, o " +
+                "descarte de tudo o que ela congelar seria irreversível; sem encoder, seria irreverificável.",
+                nameof(schemaVersionDeEmissaoCorrente));
+        }
+
+        SchemaVersionDeEmissaoCorrente = schemaVersionDeEmissaoCorrente;
     }
 
     public string SchemaVersionDeEmissaoCorrente { get; }
@@ -82,8 +129,10 @@ public sealed class RegistroCodecsEnvelope : IRegistroCodecsEnvelope
                 $"'{codec.SchemaVersion}' emite '{codec.AlgoritmoHash}'."));
         }
 
-        // O gate. Antes de qualquer parse: os bytes produzem o hash persistido?
-        string hash = HashCanonicalComputer.ComputeSha256Hex(versao.ConfiguracaoCongeladaCanonica);
+        // O gate. Antes de qualquer parse: os bytes produzem o hash persistido? O digest é o
+        // do PERFIL daquela versão — o algoritmo faz parte da evidência, e conferi-lo com
+        // outro seria comparar a prova consigo mesma pela régua errada.
+        string hash = codec.Perfil.HashHex(versao.ConfiguracaoCongeladaCanonica);
         if (!string.Equals(hash, versao.HashConfiguracao, StringComparison.Ordinal))
         {
             return Result<EnvelopeReidratado>.Failure(new DomainError(
@@ -92,7 +141,7 @@ public sealed class RegistroCodecsEnvelope : IRegistroCodecsEnvelope
                 "a evidência não prova o que diz provar, e não se reidrata configuração a partir dela."));
         }
 
-        if (VerificarFormaCanonica(versao.ConfiguracaoCongeladaCanonica) is { } malformado)
+        if (VerificarFormaCanonica(codec.Perfil, versao.ConfiguracaoCongeladaCanonica) is { } malformado)
         {
             return Result<EnvelopeReidratado>.Failure(malformado);
         }
@@ -164,10 +213,11 @@ public sealed class RegistroCodecsEnvelope : IRegistroCodecsEnvelope
     /// <para>
     /// O hash prova que os bytes são os que <b>foram gravados</b>. Não prova que eles são um
     /// <b>envelope</b>: quem adultera a coluna e recomputa o hash da linha passa pelo
-    /// primeiro gate inteiro. O que sobra é a <b>forma</b> — e ela é verificável sem
-    /// conhecer versão nenhuma: um envelope canônico (ADR-0100) é, por definição, o que
-    /// <c>ComputeSnapshotBytes</c> produz. Reserializar o que se leu tem de <b>reproduzir os
-    /// bytes</b>.
+    /// primeiro gate inteiro. O que sobra é a <b>forma</b> — e ela é verificável sem conhecer
+    /// a versão, mas não sem conhecer o <b>perfil</b>: um envelope canônico é, por definição,
+    /// o que o perfil daquela versão produz. Reserializar o que se leu tem de <b>reproduzir
+    /// os bytes</b>. Perguntar a um serializador global funcionaria enquanto houvesse um só
+    /// perfil e recusaria envelope legítimo no dia seguinte ao primeiro perfil novo.
     /// </para>
     /// <para>
     /// Isso recusa, de uma vez, chaves fora de ordem, espaços, e a chave <b>duplicada</b> —
@@ -176,7 +226,7 @@ public sealed class RegistroCodecsEnvelope : IRegistroCodecsEnvelope
     /// ter forma canônica diferente, e a garantia não pode depender disso).
     /// </para>
     /// </remarks>
-    private static DomainError? VerificarFormaCanonica(byte[] bytes)
+    private static DomainError? VerificarFormaCanonica(IPerfilCanonico perfil, byte[] bytes)
     {
         JsonNode? node;
         try
@@ -197,7 +247,22 @@ public sealed class RegistroCodecsEnvelope : IRegistroCodecsEnvelope
                 "Os bytes congelados não são um objeto JSON.");
         }
 
-        return HashCanonicalComputer.ComputeSnapshotBytes(payload).AsSpan().SequenceEqual(bytes)
+        byte[] recanonicalizado;
+        try
+        {
+            recanonicalizado = perfil.Serializar(payload);
+        }
+        catch (PayloadForaDoPerfilCanonicoException excecao)
+        {
+            // Um perfil estrito recusa o que não sabe representar. Vindo da LEITURA, isso é
+            // envelope malformado — recusa nomeada —, e não falha não tratada: quem grava a
+            // coluna à mão consegue produzir exatamente esse payload.
+            return new DomainError(
+                ErrosCodecEnvelope.EnvelopeMalformado,
+                $"Os bytes congelados contêm o que o perfil '{perfil.Algoritmo}' não representa: {excecao.Message}");
+        }
+
+        return recanonicalizado.AsSpan().SequenceEqual(bytes)
             ? null
             : new DomainError(
                 ErrosCodecEnvelope.IntegridadeViolada,

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/Canonicalization/SnapshotPublicacaoCanonicalizer.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/Canonicalization/SnapshotPublicacaoCanonicalizer.cs
@@ -54,7 +54,9 @@ using Unifesspa.UniPlus.Selecao.Domain.ValueObjects;
 /// critérios de desempate), identidade de negócio única quando existe
 /// (oferta/modalidade/condição/recurso por seus <c>*OrigemId</c>), e — onde
 /// não há chave natural — pela <b>chave de conteúdo</b>: os bytes canônicos
-/// do próprio item. Ordenar por <c>EntityBase.Id</c> era determinístico entre
+/// do próprio item, comparados como bytes
+/// (<see cref="ComparadorLexicograficoDeBytes"/>), não como texto decodificado.
+/// Ordenar por <c>EntityBase.Id</c> era determinístico entre
 /// leituras da MESMA linha, mas não entre <b>configurações equivalentes</b>:
 /// duas regras de eliminação idênticas inseridas em ordem inversa recebem
 /// Guids v7 distintos e produziriam bytes distintos para a mesma configuração.
@@ -624,9 +626,9 @@ public sealed class SnapshotPublicacaoCanonicalizer : ISnapshotPublicacaoCanonic
         IOrderedEnumerable<DocumentoExigido> ordenadas = exigencias
             .OrderBy(static e => e.ExigidoNaFaseId)
             .ThenBy(static e => e.TipoDocumentoOrigemId)
-            .ThenBy(static e => System.Text.Encoding.UTF8.GetString(
-                PerfilAtual.Serializar(SerializarExigenciaSemIdentidade(e))),
-                StringComparer.Ordinal)
+            .ThenBy(
+                static e => PerfilAtual.Serializar(SerializarExigenciaSemIdentidade(e)),
+                ComparadorLexicograficoDeBytes.Instancia)
             // Achado de revisão (Story #554, PR #903): duas exigências byte-idênticas em
             // todo o resto (mesma fase, mesmo tipo, mesmo conteúdo) empatam na chave de
             // conteúdo acima — e, ao contrário de regrasEliminacao (sem identidade), o Id
@@ -922,8 +924,8 @@ public sealed class SnapshotPublicacaoCanonicalizer : ISnapshotPublicacaoCanonic
     private static JsonArray OrdenarPorConteudo(IEnumerable<JsonObject> itens)
     {
         IOrderedEnumerable<JsonObject> ordenados = itens.OrderBy(
-            static item => System.Text.Encoding.UTF8.GetString(PerfilAtual.Serializar(item)),
-            StringComparer.Ordinal);
+            static item => PerfilAtual.Serializar(item),
+            ComparadorLexicograficoDeBytes.Instancia);
 
         return new JsonArray([.. ordenados.Select(static item => (JsonNode)item)]);
     }

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/Canonicalization/SnapshotPublicacaoCanonicalizer.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/Canonicalization/SnapshotPublicacaoCanonicalizer.cs
@@ -14,7 +14,7 @@ using Unifesspa.UniPlus.Selecao.Domain.ValueObjects;
 /// ADR-0109). Projeta a configuração viva do agregado num payload de 18 chaves
 /// — <b>14 blocos reais + 4 stubs</b> <c>{"status":"nao_construido"}</c> para as
 /// dimensões que a Feature #40 ainda não implementou (ADR-0100 item 10) — e
-/// devolve os bytes via <see cref="HashCanonicalComputer.ComputeSnapshotBytes"/>.
+/// devolve os bytes via <see cref="PerfilCanonicoV1"/>.
 /// <c>documentosExigidos</c> (Story #853) é um dos 14: já carrega
 /// <c>obrigatoriedades[]</c> real, com <c>exigencias[]</c> (#554) ainda
 /// aninhada como stub — o bloco nasce parcialmente real. <c>vagas</c> (issue
@@ -29,9 +29,11 @@ using Unifesspa.UniPlus.Selecao.Domain.ValueObjects;
 /// todo decimal por <see cref="HashCanonicalComputer.SerializeDecimalCanonical"/>
 /// com a escala declarada do campo; instantes por
 /// <see cref="HashCanonicalComputer.SerializeInstantCanonical"/>. A
-/// reordenação de chaves e a serialização byte-estável final acontecem em
-/// <see cref="HashCanonicalComputer.ComputeSnapshotBytes"/> — este tipo só
-/// monta o <see cref="JsonObject"/> com os valores já normalizados.
+/// reordenação de chaves e a serialização byte-estável final acontecem no
+/// <see cref="IPerfilCanonico"/> — este tipo só monta o <see cref="JsonObject"/>
+/// com os valores já normalizados. A normalização NFC é responsabilidade daqui,
+/// não do perfil: o perfil serializa o nó que recebe, e uma sequência combinante
+/// que chegasse até ele produziria bytes distintos dos da forma pré-composta.
 /// </para>
 /// <para>
 /// <strong>Leitura do bloco "vagas" vs. "distribuição" (ADR-0100 item 10):</strong>
@@ -87,7 +89,14 @@ public sealed class SnapshotPublicacaoCanonicalizer : ISnapshotPublicacaoCanonic
     /// </remarks>
     internal const string SchemaVersionAtual = "1.4";
 
-    private const string AlgoritmoHashAtual = "canonical-json/sha256@v1";
+    /// <summary>
+    /// Perfil de bytes sob o qual a emissão de hoje congela — as regras de ordenação, escape e
+    /// digest, identificadas à parte da <see cref="SchemaVersionAtual"/>. O rótulo gravado em
+    /// <c>versao_configuracao.algoritmo_hash</c> vem daqui, do mesmo objeto que produz os
+    /// bytes: literal e código andando juntos por construção, não por disciplina.
+    /// </summary>
+    private static readonly PerfilCanonicoV1 PerfilAtual = PerfilCanonicoV1.Instancia;
+
     private const int EscalaPadrao = 4;
     private const int EscalaPercentual = 2;
 
@@ -150,8 +159,8 @@ public sealed class SnapshotPublicacaoCanonicalizer : ISnapshotPublicacaoCanonic
             };
         }
 
-        byte[] bytes = HashCanonicalComputer.ComputeSnapshotBytes(payload);
-        return new SnapshotCanonico(bytes, SchemaVersionAtual, AlgoritmoHashAtual);
+        byte[] bytes = PerfilAtual.Serializar(payload);
+        return new SnapshotCanonico(bytes, SchemaVersionAtual, PerfilAtual.Algoritmo);
     }
 
     private static JsonObject SerializarPeriodo(DadosEdital dados) => new()
@@ -616,7 +625,7 @@ public sealed class SnapshotPublicacaoCanonicalizer : ISnapshotPublicacaoCanonic
             .OrderBy(static e => e.ExigidoNaFaseId)
             .ThenBy(static e => e.TipoDocumentoOrigemId)
             .ThenBy(static e => System.Text.Encoding.UTF8.GetString(
-                HashCanonicalComputer.ComputeSnapshotBytes(SerializarExigenciaSemIdentidade(e))),
+                PerfilAtual.Serializar(SerializarExigenciaSemIdentidade(e))),
                 StringComparer.Ordinal)
             // Achado de revisão (Story #554, PR #903): duas exigências byte-idênticas em
             // todo o resto (mesma fase, mesmo tipo, mesmo conteúdo) empatam na chave de
@@ -913,7 +922,7 @@ public sealed class SnapshotPublicacaoCanonicalizer : ISnapshotPublicacaoCanonic
     private static JsonArray OrdenarPorConteudo(IEnumerable<JsonObject> itens)
     {
         IOrderedEnumerable<JsonObject> ordenados = itens.OrderBy(
-            static item => System.Text.Encoding.UTF8.GetString(HashCanonicalComputer.ComputeSnapshotBytes(item)),
+            static item => System.Text.Encoding.UTF8.GetString(PerfilAtual.Serializar(item)),
             StringComparer.Ordinal);
 
         return new JsonArray([.. ordenados.Select(static item => (JsonNode)item)]);

--- a/tests/Unifesspa.UniPlus.Selecao.ArchTests/RegistroCodecsEnvelopeTests.cs
+++ b/tests/Unifesspa.UniPlus.Selecao.ArchTests/RegistroCodecsEnvelopeTests.cs
@@ -81,6 +81,42 @@ public sealed class RegistroCodecsEnvelopeTests
     }
 
     /// <summary>
+    /// Todo codec do assembly está no registro, e todo codec declara sob que <b>perfil de
+    /// bytes</b> emite.
+    /// </summary>
+    /// <remarks>
+    /// A varredura é por reflexão sobre os tipos concretos, e não sobre uma lista mantida aqui:
+    /// o caso que este teste existe para pegar é justamente o codec novo que alguém escreve e
+    /// esquece de registrar — invisível para qualquer teste que parta do registro. O
+    /// <c>AlgoritmoHash</c> conferido contra o perfil fecha o outro lado: o rótulo gravado em
+    /// <c>versao_configuracao.algoritmo_hash</c> tem de vir do mesmo objeto que produz os bytes,
+    /// nunca de um literal que alguém mantém em sincronia de memória.
+    /// </remarks>
+    [Fact(DisplayName = "CA-08 — todo codec do assembly está registrado e declara o perfil sob o qual emite")]
+    public void TodoCodec_EstaRegistrado_EDeclaraPerfil()
+    {
+        IReadOnlyList<IEnvelopeCodec> codecs =
+        [
+            .. typeof(RegistroCodecsEnvelope).Assembly.GetTypes()
+                .Where(static t => typeof(IEnvelopeCodec).IsAssignableFrom(t) && t is { IsAbstract: false, IsInterface: false })
+                .Select(static t => (IEnvelopeCodec)Activator.CreateInstance(t)!),
+        ];
+
+        codecs.Should().NotBeEmpty();
+
+        codecs.Select(static c => c.SchemaVersion).Order(StringComparer.Ordinal).Should().Equal(
+            Registro.Capacidades.Select(static c => c.SchemaVersion).Order(StringComparer.Ordinal),
+            "um codec escrito e não registrado é uma versão que o sistema sabe produzir e não sabe ler de volta");
+
+        foreach (IEnvelopeCodec codec in codecs)
+        {
+            codec.Perfil.Should().NotBeNull($"o codec '{codec.SchemaVersion}' tem de dizer sob que regras de bytes ele emite");
+            codec.AlgoritmoHash.Should().Be(codec.Perfil.Algoritmo,
+                $"o algoritmo declarado pelo codec '{codec.SchemaVersion}' é o do seu perfil, não um literal paralelo");
+        }
+    }
+
+    /// <summary>
     /// O registro pode estar perfeitamente coerente consigo mesmo e ainda assim divergir do
     /// que a <b>produção grava</b>: <c>Publicar</c> e <c>Retificar</c> injetam o
     /// <see cref="ISnapshotPublicacaoCanonicalizer"/>, não o registro. Este teste amarra os

--- a/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/ProcessosSeletivos/ComparadorLexicograficoDeBytesTests.cs
+++ b/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/ProcessosSeletivos/ComparadorLexicograficoDeBytesTests.cs
@@ -1,0 +1,66 @@
+namespace Unifesspa.UniPlus.Selecao.IntegrationTests.ProcessosSeletivos;
+
+using System.Text;
+
+using AwesomeAssertions;
+
+using Unifesspa.UniPlus.Selecao.Infrastructure.Canonicalization;
+
+using Xunit;
+
+/// <summary>
+/// A ordem da chave de conteúdo é a dos <b>bytes</b>, e ela não é a ordem ordinal do texto
+/// decodificado.
+/// </summary>
+/// <remarks>
+/// Sob o perfil <c>canonical-json/sha256@v1</c> as duas coincidem, porque tudo o que ele emite
+/// é ASCII. A divergência aparece com texto UTF-8 literal — e é para o dia em que um perfil o
+/// emitir que estes testes existem: um deles compara exatamente o par que inverte.
+/// </remarks>
+public sealed class ComparadorLexicograficoDeBytesTests
+{
+    private static byte[] Utf8(string texto) => Encoding.UTF8.GetBytes(texto);
+
+    [Fact(DisplayName = "Comparador — ordena por octeto, resolvendo o prefixo pelo comprimento")]
+    public void Ordena_PorOcteto()
+    {
+        ComparadorLexicograficoDeBytes comparador = ComparadorLexicograficoDeBytes.Instancia;
+
+        comparador.Compare([1, 2], [1, 3]).Should().BeNegative();
+        comparador.Compare([1, 2], [1, 2]).Should().Be(0);
+        comparador.Compare([1, 2], [1]).Should().BePositive("o prefixo vem antes de quem o estende");
+        comparador.Compare([0x7F], [0x80]).Should().BeNegative("os octetos são comparados sem sinal");
+    }
+
+    /// <summary>
+    /// O caso que inverte. Em UTF-8, o caractere de uso privado <c>U+E000</c> começa com
+    /// <c>0xEE</c> e o emoji com <c>0xF0</c> — o primeiro vem antes. Em UTF-16, o emoji é um par
+    /// substituto que começa em <c>U+D83D</c>, abaixo de <c>U+E000</c> — e a comparação ordinal
+    /// diz o contrário. Decodificar os bytes para comparar não é neutro.
+    /// </summary>
+    [Fact(DisplayName = "Comparador — diverge da comparação ordinal de texto acima do BMP")]
+    public void Diverge_DaComparacaoOrdinalDeTexto()
+    {
+        const string UsoPrivado = "\uE000";
+        const string Emoji = "\U0001F600";
+
+        Utf8(UsoPrivado)[0].Should().Be(0xEE);
+        Utf8(Emoji)[0].Should().Be(0xF0);
+
+        ComparadorLexicograficoDeBytes.Instancia.Compare(Utf8(UsoPrivado), Utf8(Emoji))
+            .Should().BeNegative("em UTF-8, 0xEE precede 0xF0");
+
+        StringComparer.Ordinal.Compare(UsoPrivado, Emoji)
+            .Should().BePositive("em UTF-16, o par substituto do emoji começa abaixo de U+E000 — a ordem se inverte");
+    }
+
+    [Fact(DisplayName = "Comparador — trata ausência sem estourar, como manda o contrato de IComparer")]
+    public void Trata_Ausencia()
+    {
+        ComparadorLexicograficoDeBytes comparador = ComparadorLexicograficoDeBytes.Instancia;
+
+        comparador.Compare(null, null).Should().Be(0);
+        comparador.Compare(null, []).Should().BeNegative();
+        comparador.Compare([], null).Should().BePositive();
+    }
+}

--- a/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/ProcessosSeletivos/PerfilCanonicoV1GoldenTests.cs
+++ b/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/ProcessosSeletivos/PerfilCanonicoV1GoldenTests.cs
@@ -1,0 +1,227 @@
+namespace Unifesspa.UniPlus.Selecao.IntegrationTests.ProcessosSeletivos;
+
+using System.Text;
+using System.Text.Json.Nodes;
+
+using AwesomeAssertions;
+
+using Unifesspa.UniPlus.Selecao.Domain.ValueObjects;
+using Unifesspa.UniPlus.Selecao.Infrastructure.Canonicalization;
+
+using Xunit;
+
+/// <summary>
+/// Vetores fixos do perfil <c>canonical-json/sha256@v1</c> — as regras de bytes sob as quais
+/// todo envelope das versões <c>1.0</c> a <c>1.4</c> foi congelado.
+/// </summary>
+/// <remarks>
+/// <para>
+/// As golden fixtures do envelope congelam o <b>resultado</b> de uma configuração inteira: elas
+/// pegam a mudança, mas não dizem qual regra mudou, e só cobrem os caracteres que aquela
+/// configuração por acaso contém. Estes vetores congelam as <b>regras</b>, uma a uma, incluindo
+/// as que nenhuma configuração de teste exercita hoje — controles, emoji fora do BMP,
+/// caracteres sensíveis a HTML.
+/// </para>
+/// <para>
+/// Boa parte do que está congelado aqui nunca foi decisão deliberada: é o comportamento padrão
+/// do <c>Utf8JsonWriter</c> sem encoder próprio. Escrito ou não, é o que os certames publicados
+/// têm gravado — e o que um perfil posterior, com escapes próprios, não pode alterar
+/// retroativamente. É por isso que estes vetores vêm antes de existir um segundo perfil, e não
+/// depois.
+/// </para>
+/// <para>
+/// Os literais esperados montam cada escape a partir de <see cref="Barra"/> em vez de o
+/// digitarem: uma sequência de escape escrita à mão no meio de um literal é fácil de errar em
+/// silêncio, e um vetor errado que passe verde não congela nada.
+/// </para>
+/// </remarks>
+public sealed class PerfilCanonicoV1GoldenTests
+{
+    /// <summary>A contrabarra que abre toda sequência de escape JSON.</summary>
+    private const char Barra = '\\';
+
+    private static string Serializar(JsonObject payload) =>
+        Encoding.UTF8.GetString(PerfilCanonicoV1.Instancia.Serializar(payload));
+
+    /// <summary>Escape <c>\uXXXX</c> na forma que o perfil emite — hex de quatro dígitos.</summary>
+    private static string Uni(string hex) => $"{Barra}u{hex}";
+
+    [Fact(DisplayName = "Perfil v1 — o identificador do algoritmo é o que a coluna algoritmo_hash guarda")]
+    public void Algoritmo_EOIdentificadorPersistido()
+    {
+        PerfilCanonicoV1.Instancia.Algoritmo.Should().Be("canonical-json/sha256@v1");
+    }
+
+    [Fact(DisplayName = "Perfil v1 — chaves reordenadas recursivamente por comparação ordinal")]
+    public void Chaves_ReordenadasRecursivamente()
+    {
+        JsonObject payload = new()
+        {
+            ["zeta"] = 1,
+            ["Alfa"] = new JsonObject { ["b"] = 2, ["a"] = 1 },
+            ["beta"] = new JsonArray(new JsonObject { ["y"] = 1, ["x"] = 0 }),
+        };
+
+        // Maiúsculas antes de minúsculas: é comparação ORDINAL (por code unit), não alfabética
+        // de cultura. 'A' (0x41) vem antes de 'b' (0x62) e de 'z' (0x7A).
+        Serializar(payload).Should().Be("""{"Alfa":{"a":1,"b":2},"beta":[{"x":0,"y":1}],"zeta":1}""");
+    }
+
+    [Fact(DisplayName = "Perfil v1 — a ordem dos arrays é preservada: ela é semântica")]
+    public void Arrays_PreservamOrdem()
+    {
+        JsonObject payload = new() { ["itens"] = new JsonArray("c", "a", "b") };
+
+        Serializar(payload).Should().Be("""{"itens":["c","a","b"]}""");
+    }
+
+    /// <summary>
+    /// O envelope distingue "campo ausente" de "campo presente e vazio" — o número do ato ainda
+    /// não atribuído é <c>null</c> explícito em <c>periodo.numero</c>. Um perfil que omitisse a
+    /// chave faria dois estados de negócio distintos colapsarem nos mesmos bytes.
+    /// </summary>
+    [Fact(DisplayName = "Perfil v1 — null explícito é preservado, nunca omitido")]
+    public void NullExplicito_EPreservado()
+    {
+        JsonObject payload = new() { ["numero"] = null, ["inicio"] = "2026-01-01" };
+
+        Serializar(payload).Should().Be("""{"inicio":"2026-01-01","numero":null}""");
+    }
+
+    /// <summary>
+    /// Contrabarra e os cinco controles com forma curta em JSON saem curtos; a <b>aspa dupla,
+    /// não</b> — vira <c>"</c>. É assimétrico e contraintuitivo o bastante para que só um
+    /// vetor fixo o mantenha honesto: um perfil posterior que emitisse <c>\"</c>, a forma que
+    /// qualquer leitor esperaria, produziria bytes distintos para o mesmo texto.
+    /// </summary>
+    [Fact(DisplayName = "Perfil v1 — contrabarra e controles em forma curta, mas a aspa dupla vira \\u0022")]
+    public void Escapes_FormasCurtas()
+    {
+        JsonObject payload = new()
+        {
+            ["aspas"] = "a\"b",
+            ["contrabarra"] = "a\\b",
+            ["backspace"] = "a\bb",
+            ["tab"] = "a\tb",
+            ["novaLinha"] = "a\nb",
+            ["formFeed"] = "a\fb",
+            ["retorno"] = "a\rb",
+        };
+
+        Serializar(payload).Should().Be(
+            $$"""
+            {"aspas":"a{{Uni("0022")}}b","backspace":"a{{Barra}}bb","contrabarra":"a{{Barra}}{{Barra}}b","formFeed":"a{{Barra}}fb","novaLinha":"a{{Barra}}nb","retorno":"a{{Barra}}rb","tab":"a{{Barra}}tb"}
+            """);
+    }
+
+    [Fact(DisplayName = "Perfil v1 — os demais controles saem em \\uXXXX com hex MAIÚSCULO")]
+    public void Escapes_ControlesRestantes()
+    {
+        JsonObject payload = new() { ["controles"] = "\u0001\u001F" };
+
+        Serializar(payload).Should().Be($$"""{"controles":"{{Uni("0001")}}{{Uni("001F")}}"}""");
+    }
+
+    /// <summary>
+    /// O encoder padrão do runtime escapa o que seria perigoso interpolar em HTML. O envelope
+    /// nunca é interpolado em HTML — mas os bytes publicados são estes, e é isso que conta.
+    /// </summary>
+    [Fact(DisplayName = "Perfil v1 — caracteres sensíveis a HTML são escapados")]
+    public void Escapes_SensiveisAHtml()
+    {
+        JsonObject payload = new() { ["texto"] = "<a href='x'>1 & 2 + 3</a>" };
+
+        Serializar(payload).Should().Be(
+            $$"""
+            {"texto":"{{Uni("003C")}}a href={{Uni("0027")}}x{{Uni("0027")}}{{Uni("003E")}}1 {{Uni("0026")}} 2 {{Uni("002B")}} 3{{Uni("003C")}}/a{{Uni("003E")}}"}
+            """);
+    }
+
+    /// <summary>
+    /// Tudo fora do latim básico sai escapado — inclusive toda letra acentuada do português.
+    /// A fixture <c>envelope-1.4.json</c> carrega exatamente isto.
+    /// </summary>
+    [Fact(DisplayName = "Perfil v1 — não-ASCII escapado em \\uXXXX maiúsculo, inclusive par substituto")]
+    public void Escapes_NaoAscii()
+    {
+        JsonObject payload = new()
+        {
+            ["acentuado"] = "residência",
+            ["cjk"] = "文",
+            ["foraDoBmp"] = "😀",
+        };
+
+        Serializar(payload).Should().Be(
+            $$"""
+            {"acentuado":"resid{{Uni("00EA")}}ncia","cjk":"{{Uni("6587")}}","foraDoBmp":"{{Uni("D83D")}}{{Uni("DE00")}}"}
+            """);
+    }
+
+    /// <summary>
+    /// Normalizar é do <b>caller</b>, não do perfil: o perfil serializa o nó que recebe. Sem
+    /// <see cref="HashCanonicalComputer.NormalizeNfc"/> antes, a forma pré-composta e a
+    /// sequência com acento combinante são o mesmo texto com bytes — e hashes — diferentes.
+    /// </summary>
+    [Fact(DisplayName = "Perfil v1 — NFC é responsabilidade do caller: sequência combinante produz bytes distintos")]
+    public void Nfc_ENoCaller_NaoNoPerfil()
+    {
+        const string PreComposto = "é";          // é
+        const string Combinante = "e\u0301";          // e + acento agudo combinante
+
+        string semNormalizar = Serializar(new JsonObject { ["v"] = Combinante });
+        string preComposto = Serializar(new JsonObject { ["v"] = PreComposto });
+
+        semNormalizar.Should().NotBe(preComposto,
+            "o perfil não normaliza — quem monta o payload é que chama NormalizeNfc");
+
+        string normalizadoPeloCaller = Serializar(
+            new JsonObject { ["v"] = HashCanonicalComputer.NormalizeNfc(Combinante) });
+
+        normalizadoPeloCaller.Should().Be(preComposto);
+    }
+
+    /// <summary>
+    /// Os números do envelope são, por decisão do encoder, quase todos <b>strings</b> — decimal
+    /// de negócio passa por <see cref="HashCanonicalComputer.SerializeDecimalCanonical"/> com
+    /// escala declarada. Os que sobram como <c>number</c> JSON (ordem, quantidade, contagens)
+    /// entram aqui: a forma com que o perfil v1 os escreve também é contrato.
+    /// </summary>
+    [Fact(DisplayName = "Perfil v1 — forma dos números que ficam como number JSON")]
+    public void Numeros_FormaCongelada()
+    {
+        JsonObject payload = new()
+        {
+            ["inteiro"] = 42,
+            ["negativo"] = -7,
+            ["zero"] = 0,
+            ["decimalComZeroFinal"] = JsonValue.Create(1.50m),
+            ["doubleInteiro"] = JsonValue.Create(1.0d),
+        };
+
+        Serializar(payload).Should().Be(
+            """{"decimalComZeroFinal":1.50,"doubleInteiro":1,"inteiro":42,"negativo":-7,"zero":0}""");
+    }
+
+    /// <summary>
+    /// Número que veio de <c>JsonNode.Parse</c> conserva o <b>texto original</b>, não o valor.
+    /// É a diferença entre reserializar o que se leu e reserializar o que se entendeu — e o
+    /// gate de forma depende dela: os bytes lidos do banco chegam por este caminho.
+    /// </summary>
+    [Fact(DisplayName = "Perfil v1 — número parseado conserva o texto original, não o valor")]
+    public void Numeros_ParseadosConservamOTexto()
+    {
+        JsonObject payload = JsonNode.Parse("""{"a":1.0,"b":1e2,"c":-0.0}""")!.AsObject();
+
+        Serializar(payload).Should().Be("""{"a":1.0,"b":1e2,"c":-0.0}""");
+    }
+
+    [Fact(DisplayName = "Perfil v1 — o digest é SHA-256 hex minúsculo sobre os bytes recebidos")]
+    public void HashHex_ESha256DosBytes()
+    {
+        byte[] bytes = PerfilCanonicoV1.Instancia.Serializar(new JsonObject { ["a"] = 1 });
+
+        Encoding.UTF8.GetString(bytes).Should().Be("""{"a":1}""");
+        PerfilCanonicoV1.Instancia.HashHex(bytes)
+            .Should().Be("015abd7f5cc57a2dd94b7590f04ad8084273905ee33ec5cebeae62276a97f862");
+    }
+}

--- a/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/ProcessosSeletivos/RegistroCodecsEnvelopePerfilTests.cs
+++ b/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/ProcessosSeletivos/RegistroCodecsEnvelopePerfilTests.cs
@@ -48,7 +48,11 @@ public sealed class RegistroCodecsEnvelopePerfilTests
         public string HashHex(byte[] bytes) => PerfilCanonicoV1.Instancia.HashHex(bytes);
     }
 
-    /// <summary>Perfil que recusa <c>null</c> — a estrita que a versão seguinte do envelope terá.</summary>
+    /// <summary>
+    /// Perfil que recusa <c>null</c> <b>em qualquer profundidade</b> — a estrita que a versão
+    /// seguinte do envelope terá. A recursão importa: um perfil que só olhasse a raiz deixaria
+    /// passar o <c>null</c> aninhado, que é onde ele de fato aparece num envelope.
+    /// </summary>
     private sealed class PerfilQueRecusaNulo : IPerfilCanonico
     {
         public string Algoritmo => "canonical-json-sem-nulo/sha256@teste";
@@ -56,16 +60,47 @@ public sealed class RegistroCodecsEnvelopePerfilTests
         public byte[] Serializar(JsonObject payload)
         {
             ArgumentNullException.ThrowIfNull(payload);
-            if (payload.Any(static par => par.Value is null))
-            {
-                throw new PayloadForaDoPerfilCanonicoException(
-                    "'null' não é representável neste perfil — a ausência do dado se declara antes de canonicalizar.");
-            }
-
+            RecusarNulo(payload, "$");
             return PerfilCanonicoV1.Instancia.Serializar(payload);
         }
 
         public string HashHex(byte[] bytes) => PerfilCanonicoV1.Instancia.HashHex(bytes);
+
+        private static void RecusarNulo(JsonNode no, string caminho)
+        {
+            switch (no)
+            {
+                case JsonObject objeto:
+                    foreach (KeyValuePair<string, JsonNode?> par in objeto)
+                    {
+                        Descer(par.Value, $"{caminho}.{par.Key}");
+                    }
+
+                    break;
+
+                case JsonArray array:
+                    for (int i = 0; i < array.Count; i++)
+                    {
+                        Descer(array[i], $"{caminho}[{i}]");
+                    }
+
+                    break;
+
+                default:
+                    break;
+            }
+        }
+
+        private static void Descer(JsonNode? filho, string caminho)
+        {
+            if (filho is null)
+            {
+                throw new PayloadForaDoPerfilCanonicoException(
+                    $"'{caminho}' é null, e null não é representável neste perfil — a ausência do dado se declara antes de canonicalizar.");
+            }
+
+            RecusarNulo(filho, caminho);
+        }
     }
 
     private sealed class CodecDeTeste(IPerfilCanonico perfil) : IEnvelopeCodec
@@ -145,17 +180,55 @@ public sealed class RegistroCodecsEnvelopePerfilTests
     /// O que um perfil estrito recusa vira <b>recusa nomeada</b>, não falha não tratada — quem
     /// grava a coluna à mão consegue produzir exatamente o payload que ele não representa.
     /// </summary>
-    [Fact(DisplayName = "Gate de forma — payload que o perfil recusa vira envelope malformado, não exceção")]
-    public void GateDeForma_PayloadRecusadoPeloPerfil_ViraRecusaNomeada()
+    [Theory(DisplayName = "Gate de forma — payload que o perfil recusa vira envelope malformado, não exceção")]
+    [InlineData("""{"a":null}""")]
+    [InlineData("""{"a":{"b":null}}""")]
+    [InlineData("""{"a":[1,null]}""")]
+    public void GateDeForma_PayloadRecusadoPeloPerfil_ViraRecusaNomeada(string json)
     {
         PerfilQueRecusaNulo perfil = new();
-        byte[] comNulo = PerfilCanonicoV1.Instancia.Serializar(new JsonObject { ["a"] = null });
+        byte[] comNulo = PerfilCanonicoV1.Instancia.Serializar(JsonNode.Parse(json)!.AsObject());
 
         Result<EnvelopeReidratado> resultado = RegistroCom(perfil).Reidratar(VersaoCom(perfil, comNulo));
 
         resultado.IsFailure.Should().BeTrue();
         resultado.Error!.Code.Should().Be(ErrosCodecEnvelope.EnvelopeMalformado);
         resultado.Error.Message.Should().Contain(perfil.Algoritmo);
+    }
+
+    /// <summary>
+    /// O mesmo contrato no <b>outro</b> caminho: <c>Decodificar</c> é público e chamável sem
+    /// passar pelo registro, e o parse que os decoders compartilham reserializa por conta
+    /// própria. Um tratamento que existisse só no registro deixaria escapar uma falha não
+    /// tratada por esta porta.
+    /// </summary>
+    [Fact(DisplayName = "Parse compartilhado — payload recusado pelo perfil vira envelope malformado, não exceção")]
+    public void ParseCompartilhado_PayloadRecusadoPeloPerfil_ViraRecusaNomeada()
+    {
+        PerfilQueRecusaNulo perfil = new();
+        byte[] comNulo = PerfilCanonicoV1.Instancia.Serializar(JsonNode.Parse("""{"a":{"b":null}}""")!.AsObject());
+
+        Result<JsonObject> resultado = EnvelopeCodecV11.Parsear(perfil, comNulo);
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be(ErrosCodecEnvelope.EnvelopeMalformado);
+        resultado.Error.Message.Should().Contain(perfil.Algoritmo);
+    }
+
+    /// <summary>O parse também usa o perfil recebido para julgar a forma, não um global.</summary>
+    [Fact(DisplayName = "Parse compartilhado — a forma canônica é julgada pelo perfil recebido")]
+    public void ParseCompartilhado_UsaOPerfilRecebido()
+    {
+        PerfilIndentado perfil = new();
+
+        EnvelopeCodecV11.Parsear(perfil, perfil.Serializar(PayloadQualquer()))
+            .IsSuccess.Should().BeTrue("os bytes são canônicos sob o perfil que julga");
+
+        Result<JsonObject> recusado = EnvelopeCodecV11.Parsear(
+            perfil, PerfilCanonicoV1.Instancia.Serializar(PayloadQualquer()));
+
+        recusado.IsFailure.Should().BeTrue();
+        recusado.Error!.Code.Should().Be(ErrosCodecEnvelope.IntegridadeViolada);
     }
 
     [Fact(DisplayName = "Registro — versão repetida entre codecs é recusada na construção")]

--- a/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/ProcessosSeletivos/RegistroCodecsEnvelopePerfilTests.cs
+++ b/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/ProcessosSeletivos/RegistroCodecsEnvelopePerfilTests.cs
@@ -1,0 +1,177 @@
+namespace Unifesspa.UniPlus.Selecao.IntegrationTests.ProcessosSeletivos;
+
+using System.Text;
+using System.Text.Json.Nodes;
+
+using AwesomeAssertions;
+
+using Unifesspa.UniPlus.Kernel.Results;
+using Unifesspa.UniPlus.Selecao.Application.Abstractions;
+using Unifesspa.UniPlus.Selecao.Domain.Entities;
+using Unifesspa.UniPlus.Selecao.Infrastructure.Canonicalization;
+
+using Xunit;
+
+/// <summary>
+/// Os gates da reidratação perguntam ao <b>perfil da versão</b>, e não a um serializador global.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Enquanto houver um só perfil, as duas coisas coincidem — e é justamente por coincidirem que
+/// a diferença não aparece em teste nenhum das suítes existentes. No dia do primeiro perfil
+/// novo, um gate que ainda perguntasse ao global recusaria como "fora da forma canônica" um
+/// envelope perfeitamente válido, ou aceitaria como canônico um que não é.
+/// </para>
+/// <para>
+/// O registro é montado aqui com codecs próprios, pelo construtor interno. Não é atalho de
+/// teste: é a única maneira de exercitar um perfil <b>diferente</b> antes de existir um.
+/// </para>
+/// </remarks>
+public sealed class RegistroCodecsEnvelopePerfilTests
+{
+    private const string VersaoDeTeste = "9.9";
+
+    /// <summary>
+    /// Perfil que serializa <b>indentado</b>. Os bytes que ele produz nunca coincidem com os do
+    /// perfil v1 para o mesmo payload — que é exatamente o que o torna um detector.
+    /// </summary>
+    private sealed class PerfilIndentado : IPerfilCanonico
+    {
+        public string Algoritmo => "canonical-json-indentado/sha256@teste";
+
+        public byte[] Serializar(JsonObject payload)
+        {
+            ArgumentNullException.ThrowIfNull(payload);
+            return Encoding.UTF8.GetBytes(payload.ToJsonString(new System.Text.Json.JsonSerializerOptions { WriteIndented = true }));
+        }
+
+        public string HashHex(byte[] bytes) => PerfilCanonicoV1.Instancia.HashHex(bytes);
+    }
+
+    /// <summary>Perfil que recusa <c>null</c> — a estrita que a versão seguinte do envelope terá.</summary>
+    private sealed class PerfilQueRecusaNulo : IPerfilCanonico
+    {
+        public string Algoritmo => "canonical-json-sem-nulo/sha256@teste";
+
+        public byte[] Serializar(JsonObject payload)
+        {
+            ArgumentNullException.ThrowIfNull(payload);
+            if (payload.Any(static par => par.Value is null))
+            {
+                throw new PayloadForaDoPerfilCanonicoException(
+                    "'null' não é representável neste perfil — a ausência do dado se declara antes de canonicalizar.");
+            }
+
+            return PerfilCanonicoV1.Instancia.Serializar(payload);
+        }
+
+        public string HashHex(byte[] bytes) => PerfilCanonicoV1.Instancia.HashHex(bytes);
+    }
+
+    private sealed class CodecDeTeste(IPerfilCanonico perfil) : IEnvelopeCodec
+    {
+        public string SchemaVersion => VersaoDeTeste;
+
+        public IPerfilCanonico Perfil { get; } = perfil;
+
+        public string AlgoritmoHash => Perfil.Algoritmo;
+
+        public bool TemEncoder => true;
+
+        public bool TemDecoder => true;
+
+        public string? MotivoDaRecusa => null;
+
+        public SnapshotCanonico Codificar(EntradaCanonicalizacao entrada) =>
+            new(Perfil.Serializar(PayloadQualquer()), SchemaVersion, AlgoritmoHash);
+
+        /// <summary>Chegar aqui já significa que os gates passaram — é o que os testes observam.</summary>
+        public Result<EnvelopeReidratado> Decodificar(VersaoConfiguracao versao) =>
+            Result<EnvelopeReidratado>.Failure(new DomainError(
+                "SELECAO_CODEC_DE_TESTE_ALCANCADO", "Os gates do registro deixaram passar."));
+    }
+
+    private static JsonObject PayloadQualquer() => new() { ["a"] = 1 };
+
+    private static VersaoConfiguracao VersaoCom(IPerfilCanonico perfil, byte[] bytes) =>
+        VersaoConfiguracao.Abrir(
+            processoSeletivoId: Guid.CreateVersion7(),
+            configuracaoCongeladaCanonica: bytes,
+            schemaVersion: VersaoDeTeste,
+            algoritmoHash: perfil.Algoritmo,
+            atoCriadorId: Guid.CreateVersion7(),
+            atoCriadorHash: new string('a', 64),
+            atorUsuarioSub: "user-sub-1",
+            instante: DateTimeOffset.UnixEpoch);
+
+    private static RegistroCodecsEnvelope RegistroCom(IPerfilCanonico perfil) =>
+        new([new CodecDeTeste(perfil)], VersaoDeTeste);
+
+    /// <summary>
+    /// Os bytes indentados <b>não</b> são canônicos sob o perfil v1 — mas são sob o perfil desta
+    /// versão. Um gate preso ao serializador global recusaria aqui; o gate correto deixa passar
+    /// e falha adiante, no decoder.
+    /// </summary>
+    [Fact(DisplayName = "Gate de forma — bytes canônicos sob o perfil DA VERSÃO passam, mesmo não sendo canônicos sob o v1")]
+    public void GateDeForma_UsaOPerfilDaVersao()
+    {
+        PerfilIndentado perfil = new();
+        byte[] bytes = perfil.Serializar(PayloadQualquer());
+
+        bytes.Should().NotEqual(PerfilCanonicoV1.Instancia.Serializar(PayloadQualquer()),
+            "o teste não prova nada se os dois perfis produzirem os mesmos bytes");
+
+        Result<EnvelopeReidratado> resultado = RegistroCom(perfil).Reidratar(VersaoCom(perfil, bytes));
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be("SELECAO_CODEC_DE_TESTE_ALCANCADO",
+            "os três gates — algoritmo, hash e forma — têm de ter passado para a execução chegar ao decoder");
+    }
+
+    /// <summary>O contrário: bytes canônicos sob o v1, mas não sob o perfil declarado pela versão.</summary>
+    [Fact(DisplayName = "Gate de forma — bytes canônicos sob o v1 são recusados quando a versão declara outro perfil")]
+    public void GateDeForma_RecusaBytesDeOutroPerfil()
+    {
+        PerfilIndentado perfil = new();
+        byte[] bytesV1 = PerfilCanonicoV1.Instancia.Serializar(PayloadQualquer());
+
+        Result<EnvelopeReidratado> resultado = RegistroCom(perfil).Reidratar(VersaoCom(perfil, bytesV1));
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be(ErrosCodecEnvelope.IntegridadeViolada);
+    }
+
+    /// <summary>
+    /// O que um perfil estrito recusa vira <b>recusa nomeada</b>, não falha não tratada — quem
+    /// grava a coluna à mão consegue produzir exatamente o payload que ele não representa.
+    /// </summary>
+    [Fact(DisplayName = "Gate de forma — payload que o perfil recusa vira envelope malformado, não exceção")]
+    public void GateDeForma_PayloadRecusadoPeloPerfil_ViraRecusaNomeada()
+    {
+        PerfilQueRecusaNulo perfil = new();
+        byte[] comNulo = PerfilCanonicoV1.Instancia.Serializar(new JsonObject { ["a"] = null });
+
+        Result<EnvelopeReidratado> resultado = RegistroCom(perfil).Reidratar(VersaoCom(perfil, comNulo));
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be(ErrosCodecEnvelope.EnvelopeMalformado);
+        resultado.Error.Message.Should().Contain(perfil.Algoritmo);
+    }
+
+    [Fact(DisplayName = "Registro — versão repetida entre codecs é recusada na construção")]
+    public void Registro_RecusaVersaoRepetida()
+    {
+        Action montar = () => _ = new RegistroCodecsEnvelope(
+            [new CodecDeTeste(new PerfilIndentado()), new CodecDeTeste(new PerfilIndentado())], VersaoDeTeste);
+
+        montar.Should().Throw<ArgumentException>();
+    }
+
+    [Fact(DisplayName = "Registro — versão de emissão corrente sem codec é recusada na construção")]
+    public void Registro_RecusaCorrenteSemCodec()
+    {
+        Action montar = () => _ = new RegistroCodecsEnvelope([new CodecDeTeste(new PerfilIndentado())], "8.8");
+
+        montar.Should().Throw<ArgumentException>();
+    }
+}


### PR DESCRIPTION
## O que muda

Primeira fatia de `#928-B` (§7 canonicalização/RN08). Trabalho estrutural, **sem mudar um byte da emissão atual**: separa a *forma do payload* (a `schema_version`, que diz quais blocos existem) das *regras de bytes* (ordenação de chaves, tabela de escapes, forma dos números, tratamento de `null`), que até aqui viviam implícitas num único método estático compartilhado por todos os codecs, pela emissão viva e pelos gates de reidratação.

Alterar aquele método reescreveria retroativamente os bytes de todo certame já publicado, em silêncio. Esta fatia congela essas regras num objeto nomeado — o perfil `canonical-json/sha256@v1` — para que a fatia seguinte (versão 1.5 do envelope) possa introduzir um perfil `v2` com escapes próprios **ao lado**, sem tocar no que já está congelado.

## Como

- **`IPerfilCanonico` + `PerfilCanonicoV1`.** O perfil v1 descreve o que já está congelado nas versões 1.0 a 1.4 e delega à implementação atual — por isso os bytes não mudam. Cada codec passa a declarar sob que perfil emite; `AlgoritmoHash` deriva do perfil, em vez de repetir o literal em cinco arquivos.
- **Todos os caminhos de bytes passam pelo perfil:** encoders congelados 1.1–1.3, emissão viva, e as chaves de ordenação por conteúdo.
- **Os dois gates da reidratação — digest e forma canônica — perguntam ao perfil _da versão lida_,** não a um serializador global; o parse compartilhado pelos decoders 1.1–1.4 recebe o perfil do chamador pelo mesmo motivo. Enquanto houver um só perfil as duas coisas coincidem, e é por coincidirem que a diferença não aparecia em teste nenhum: no dia do primeiro perfil novo, um gate preso ao global recusaria envelope legítimo.
- **Chave de conteúdo por bytes, não por texto.** A ordenação por conteúdo comparava os bytes decodificados como `string` ordinal, o que coincide com a ordem de octetos só enquanto tudo é ASCII. Passa a comparar bytes (`ComparadorLexicograficoDeBytes`) — a ordem que "os bytes canônicos do próprio item" sempre significou.
- **Contrato de erro do perfil estrito:** payload que um perfil recuse (o `null` que o v2 vai proibir) vira recusa nomeada de envelope malformado, nunca falha não tratada — no gate do registro **e** no parse compartilhado.

## Provas

- As golden fixtures 1.1–1.4 e os round-trips continuam batendo **byte a byte** — a emissão não mudou.
- `PerfilCanonicoV1GoldenTests`: vetores fixos que congelam o que o perfil v1 de fato emite, incluindo o que nenhuma configuração de teste exercitava — aspa dupla vira `"` (e não `\"`), não-ASCII em `\uXXXX` com hex maiúsculo (inclusive acentuação, sensíveis a HTML e pares substitutos), `null` explícito preservado, números tipados e parseados. Nada disso era decisão deliberada: é o padrão do serializador do runtime, e é o que os certames têm gravado.
- `RegistroCodecsEnvelopePerfilTests`: canários que **falham** se os gates voltarem ao serializador global (verificado por mutação local); recusa de `null` recursivo no registro e no parse direto.
- `ComparadorLexicograficoDeBytesTests`: compara o par Unicode que inverte entre a ordem de bytes UTF-8 e a ordem ordinal UTF-16.
- Fitness (ArchTests): todo codec do assembly está registrado e declara o perfil sob o qual emite.

Plano e diff revisados pelo Codex antes do merge (dois P1 do plano e um P1 do diff incorporados).

Refs #928
