### PR TITLE
feat(selecao): identidade canônica de nó e recusas de publicação (ciclo, fato citado)

### DIFF
--- a/src/selecao/Unifesspa.UniPlus.Selecao.Domain/Entities/ProcessoSeletivo.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Domain/Entities/ProcessoSeletivo.cs
@@ -1048,14 +1048,12 @@ public sealed class ProcessoSeletivo : SoftDeletableEntity
         {
             foreach (string citado in fato.FatosCitados)
             {
-                if (!porCodigo.TryGetValue(citado, out FatoColetado? anterior))
-                {
-                    return new DomainError(
-                        FatoColetadoErrorCodes.PrecondicaoCitaFatoNaoColetado,
-                        $"A pré-condição do fato '{fato.FatoCodigo}' cita '{citado}', que este processo não coleta.");
-                }
-
-                if (anterior.Ordem >= fato.Ordem)
+                // Citar um fato NÃO coletado é permitido: pode ser um fato DERIVADO, que não tem
+                // Ordem de coleta e por isso não é checável aqui isoladamente (§7.3a). A garantia
+                // de que todo fato citado existe — em coletados ∪ derivados — e de que não há
+                // ciclo vem do grafo conjunto, no gate de pré-canonicalização. Aqui só resta a
+                // anterioridade ENTRE coletados, que é a única com Ordem para comparar.
+                if (porCodigo.TryGetValue(citado, out FatoColetado? anterior) && anterior.Ordem >= fato.Ordem)
                 {
                     return new DomainError(
                         FatoColetadoErrorCodes.PrecondicaoCitaFatoPosterior,
@@ -1365,8 +1363,72 @@ public sealed class ProcessoSeletivo : SoftDeletableEntity
             return referenciaTemporal;
         }
 
+        if (PendenciaDeFatosCitados() is { } fatoCitado)
+        {
+            return fatoCitado;
+        }
+
         return PendenciaDoGrafoConjunto();
     }
+
+    /// <summary>
+    /// Todo fato citado — na pré-condição de um campo ou na condição de uma regra de derivação —
+    /// tem de existir no processo, como fato coletado ou derivado (§7.3). O grafo conjunto ignora
+    /// de propósito uma referência ausente (projeta só o que existe), então esta é a recusa que
+    /// prova a completude do vocabulário citado, antes que a aciclicidade e a ordem topológica
+    /// sejam congeladas — e é o substituto do gate isolado de <c>DefinirFatosColetados</c>, que
+    /// relaxou para deixar uma pré-condição citar um fato derivado (§7.3a).
+    /// </summary>
+    /// <remarks>
+    /// O gatilho de exigência cita fato pelo mesmo vocabulário e caberia aqui; a checagem da sua
+    /// completude fica para o mesmo passo em que a exigência passa a exigir os seus fatos
+    /// coletados (fora desta fatia).
+    /// </remarks>
+    private DomainError? PendenciaDeFatosCitados()
+    {
+        HashSet<string> universo = new(StringComparer.Ordinal);
+        foreach (FatoColetado fato in _fatosColetados)
+        {
+            universo.Add(fato.FatoCodigo);
+        }
+
+        foreach (ConfiguracaoDerivacaoFato derivacao in _regrasDerivacao)
+        {
+            universo.Add(derivacao.CodigoFato);
+        }
+
+        foreach (FatoColetado fato in _fatosColetados)
+        {
+            foreach (string citado in fato.FatosCitados)
+            {
+                if (!universo.Contains(citado))
+                {
+                    return FatoCitadoAusente("a pré-condição do fato", fato.FatoCodigo, citado);
+                }
+            }
+        }
+
+        foreach (ConfiguracaoDerivacaoFato derivacao in _regrasDerivacao)
+        {
+            foreach (RegraDerivacaoConfigurada regra in derivacao.Regras)
+            {
+                foreach (CondicaoRegraDerivacao condicao in regra.Condicoes)
+                {
+                    if (!universo.Contains(condicao.Fato))
+                    {
+                        return FatoCitadoAusente("a regra de derivação do fato", derivacao.CodigoFato, condicao.Fato);
+                    }
+                }
+            }
+        }
+
+        return null;
+    }
+
+    private static DomainError FatoCitadoAusente(string onde, string dono, string citado) =>
+        new(
+            FatoColetadoErrorCodes.PrecondicaoCitaFatoNaoColetado,
+            $"{char.ToUpperInvariant(onde[0])}{onde[1..]} '{dono}' cita '{citado}', que este processo não coleta nem deriva.");
 
     /// <summary>
     /// O grafo de dependência conjunto (campos, fatos, exigências e as quatro arestas, §6) tem

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Domain/Entities/ProcessoSeletivo.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Domain/Entities/ProcessoSeletivo.cs
@@ -1360,7 +1360,29 @@ public sealed class ProcessoSeletivo : SoftDeletableEntity
             return coerencia;
         }
 
-        return PendenciaDaReferenciaTemporalFatos();
+        if (PendenciaDaReferenciaTemporalFatos() is { } referenciaTemporal)
+        {
+            return referenciaTemporal;
+        }
+
+        return PendenciaDoGrafoConjunto();
+    }
+
+    /// <summary>
+    /// O grafo de dependência conjunto (campos, fatos, exigências e as quatro arestas, §6) tem
+    /// de ser um DAG para ser congelável: a ordem topológica total que o snapshot congela (RN08)
+    /// não existe se houver ciclo. A construção do grafo (<see cref="ConstruirGrafoDependencia"/>)
+    /// já detecta o ciclo — aqui ela vira gate de publicação, antes de canonicalizar.
+    /// </summary>
+    /// <remarks>
+    /// O grafo ignora deliberadamente uma referência a fato ausente (ele projeta o que existe),
+    /// então este gate <b>não</b> prova sozinho que todo fato citado existe — essa é uma recusa
+    /// à parte (§7.3). Aqui só se garante a aciclicidade.
+    /// </remarks>
+    private DomainError? PendenciaDoGrafoConjunto()
+    {
+        Result<GrafoDependenciaConjunta> grafo = ConstruirGrafoDependencia();
+        return grafo.IsFailure ? grafo.Error : null;
     }
 
     /// <summary>

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Domain/Entities/ProcessoSeletivo.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Domain/Entities/ProcessoSeletivo.cs
@@ -1048,12 +1048,20 @@ public sealed class ProcessoSeletivo : SoftDeletableEntity
         {
             foreach (string citado in fato.FatosCitados)
             {
-                // Citar um fato NÃO coletado é permitido: pode ser um fato DERIVADO, que não tem
-                // Ordem de coleta e por isso não é checável aqui isoladamente (§7.3a). A garantia
-                // de que todo fato citado existe — em coletados ∪ derivados — e de que não há
-                // ciclo vem do grafo conjunto, no gate de pré-canonicalização. Aqui só resta a
-                // anterioridade ENTRE coletados, que é a única com Ordem para comparar.
-                if (porCodigo.TryGetValue(citado, out FatoColetado? anterior) && anterior.Ordem >= fato.Ordem)
+                // A pré-condição de um campo só cita fato COLETADO — não um derivado. O resolvedor
+                // de estado dos fatos (runtime) percorre apenas os fatos coletados por Ordem e não
+                // aciona o motor de derivação; uma pré-condição que citasse um fato derivado
+                // avaliaria indeterminada para sempre, e o campo nunca ficaria respondível. Enquanto
+                // a coleta não for dirigida pelo grafo conjunto (§6, dependente do portador do
+                // estado de coleta, ainda inexistente), a citação fica restrita ao que se coleta.
+                if (!porCodigo.TryGetValue(citado, out FatoColetado? anterior))
+                {
+                    return new DomainError(
+                        FatoColetadoErrorCodes.PrecondicaoCitaFatoNaoColetado,
+                        $"A pré-condição do fato '{fato.FatoCodigo}' cita '{citado}', que este processo não coleta.");
+                }
+
+                if (anterior.Ordem >= fato.Ordem)
                 {
                     return new DomainError(
                         FatoColetadoErrorCodes.PrecondicaoCitaFatoPosterior,
@@ -1372,17 +1380,17 @@ public sealed class ProcessoSeletivo : SoftDeletableEntity
     }
 
     /// <summary>
-    /// Todo fato citado — na pré-condição de um campo ou na condição de uma regra de derivação —
-    /// tem de existir no processo, como fato coletado ou derivado (§7.3). O grafo conjunto ignora
-    /// de propósito uma referência ausente (projeta só o que existe), então esta é a recusa que
-    /// prova a completude do vocabulário citado, antes que a aciclicidade e a ordem topológica
-    /// sejam congeladas — e é o substituto do gate isolado de <c>DefinirFatosColetados</c>, que
-    /// relaxou para deixar uma pré-condição citar um fato derivado (§7.3a).
+    /// A condição de uma regra de derivação tem de citar um fato que exista no processo — coletado
+    /// ou derivado (§7.3). O motor de derivação resolve os derivados em ordem, então um derivado
+    /// que dependa de outro é resolúvel; o que ele não sabe fazer é resolver um fato que o processo
+    /// não configura. O grafo conjunto ignora de propósito uma referência ausente (projeta só o
+    /// que existe), então é esta recusa que prova a completude do vocabulário citado, antes que a
+    /// aciclicidade e a ordem topológica sejam congeladas (RN08).
     /// </summary>
     /// <remarks>
-    /// O gatilho de exigência cita fato pelo mesmo vocabulário e caberia aqui; a checagem da sua
-    /// completude fica para o mesmo passo em que a exigência passa a exigir os seus fatos
-    /// coletados (fora desta fatia).
+    /// A pré-condição de campo já é barrada na definição (<see cref="ValidarGrafoDeFatos"/>): ela
+    /// só cita coletado, porque o resolvedor de runtime não aciona o motor de derivação. O gatilho
+    /// de exigência cita pelo mesmo vocabulário e caberá aqui quando passar a exigir os seus fatos.
     /// </remarks>
     private DomainError? PendenciaDeFatosCitados()
     {
@@ -1397,17 +1405,6 @@ public sealed class ProcessoSeletivo : SoftDeletableEntity
             universo.Add(derivacao.CodigoFato);
         }
 
-        foreach (FatoColetado fato in _fatosColetados)
-        {
-            foreach (string citado in fato.FatosCitados)
-            {
-                if (!universo.Contains(citado))
-                {
-                    return FatoCitadoAusente("a pré-condição do fato", fato.FatoCodigo, citado);
-                }
-            }
-        }
-
         foreach (ConfiguracaoDerivacaoFato derivacao in _regrasDerivacao)
         {
             foreach (RegraDerivacaoConfigurada regra in derivacao.Regras)
@@ -1416,7 +1413,10 @@ public sealed class ProcessoSeletivo : SoftDeletableEntity
                 {
                     if (!universo.Contains(condicao.Fato))
                     {
-                        return FatoCitadoAusente("a regra de derivação do fato", derivacao.CodigoFato, condicao.Fato);
+                        return new DomainError(
+                            FatoColetadoErrorCodes.PrecondicaoCitaFatoNaoColetado,
+                            $"A regra de derivação do fato '{derivacao.CodigoFato}' cita '{condicao.Fato}', "
+                            + "que este processo não coleta nem deriva.");
                     }
                 }
             }
@@ -1424,11 +1424,6 @@ public sealed class ProcessoSeletivo : SoftDeletableEntity
 
         return null;
     }
-
-    private static DomainError FatoCitadoAusente(string onde, string dono, string citado) =>
-        new(
-            FatoColetadoErrorCodes.PrecondicaoCitaFatoNaoColetado,
-            $"{char.ToUpperInvariant(onde[0])}{onde[1..]} '{dono}' cita '{citado}', que este processo não coleta nem deriva.");
 
     /// <summary>
     /// O grafo de dependência conjunto (campos, fatos, exigências e as quatro arestas, §6) tem

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Domain/ValueObjects/IdCanonico.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Domain/ValueObjects/IdCanonico.cs
@@ -1,0 +1,128 @@
+namespace Unifesspa.UniPlus.Selecao.Domain.ValueObjects;
+
+using System.Globalization;
+using System.Text;
+
+using Unifesspa.UniPlus.Selecao.Domain.Enums;
+
+/// <summary>
+/// A identidade <b>canônica</b> de um nó do grafo de dependência para fins de congelamento
+/// (Story #928, §7.1): <c>tipoDeNo/escopo/codigo</c>, em que o escopo é o processo seletivo que
+/// contém o nó.
+/// </summary>
+/// <remarks>
+/// <para>
+/// A identidade de <b>runtime</b> de um nó (<see cref="NoGrafoDependencia"/>) é o par
+/// <c>(Classe, Codigo)</c> — basta para a detecção de ciclo e a ordem <b>dentro de um
+/// processo</b>. A identidade <b>canônica</b> acrescenta o escopo: o mesmo código de fato em
+/// dois processos distintos são nós distintos, e o hash RN08 não pode confundi-los. Campo e
+/// fato do mesmo código continuam distintos pelo <c>tipoDeNo</c>.
+/// </para>
+/// <para>
+/// A gramática é <b>fechada</b> e o <c>/</c> é reservado: nenhum componente pode contê-lo, sob
+/// pena de a identidade de dois nós diferentes colidir por remontagem ambígua. Os componentes
+/// são ASCII estrutural — os códigos do vocabulário são <c>UPPER_SNAKE</c> e as identidades de
+/// exigência são GUID em hex, ambos subconjuntos de ASCII imprimível. A ordenação é por
+/// <b>bytes UTF-8</b>, não por <see cref="StringComparer.Ordinal"/>: coincidem enquanto tudo é
+/// ASCII, mas a chave total do envelope depende da ordem de bytes, e é essa que se declara.
+/// </para>
+/// </remarks>
+public sealed class IdCanonico : IComparable<IdCanonico>, IEquatable<IdCanonico>
+{
+    private const char Delimitador = '/';
+    private const string LiteralEscopoProcesso = "PROCESSO";
+
+    private readonly byte[] _bytes;
+
+    private IdCanonico(string valor, byte[] bytes)
+    {
+        Valor = valor;
+        _bytes = bytes;
+    }
+
+    /// <summary>A forma textual canônica — <c>tipoDeNo/PROCESSO/&lt;id&gt;/codigo</c>.</summary>
+    public string Valor { get; }
+
+    /// <summary>Os bytes UTF-8 de <see cref="Valor"/>, a base da ordenação e da igualdade.</summary>
+    public ReadOnlySpan<byte> Bytes => _bytes;
+
+    /// <summary>
+    /// Compõe a identidade canônica de um nó do grafo de um processo. <paramref name="codigo"/>
+    /// é o código do fato (campo/fato) ou a identidade da exigência (GUID em hex) — já validado
+    /// a montante; aqui só se garante a gramática da identidade.
+    /// </summary>
+    public static IdCanonico De(ClasseNoGrafo classe, Guid processoId, string codigo)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(codigo);
+
+        string tipoDeNo = TipoDeNo(classe);
+        string codigoCanonico = codigo.Normalize(NormalizationForm.FormC);
+
+        ExigirComponente(tipoDeNo, nameof(classe));
+        ExigirComponente(codigoCanonico, nameof(codigo));
+
+        string valor = string.Join(
+            Delimitador,
+            tipoDeNo,
+            LiteralEscopoProcesso,
+            processoId.ToString("N", CultureInfo.InvariantCulture),
+            codigoCanonico);
+
+        return new IdCanonico(valor, Encoding.UTF8.GetBytes(valor));
+    }
+
+    /// <summary>O token de <c>tipoDeNo</c> de cada classe — parte da gramática congelada.</summary>
+    private static string TipoDeNo(ClasseNoGrafo classe) => classe switch
+    {
+        ClasseNoGrafo.Campo => "CAMPO",
+        ClasseNoGrafo.Fato => "FATO",
+        ClasseNoGrafo.Exigencia => "EXIGENCIA",
+        _ => throw new ArgumentOutOfRangeException(nameof(classe), classe, "Classe de nó do grafo desconhecida."),
+    };
+
+    private static void ExigirComponente(string componente, string nomeParametro)
+    {
+        foreach (char c in componente)
+        {
+            if (c is < '!' or > '~' || c == Delimitador)
+            {
+                throw new ArgumentException(
+                    $"O componente '{componente}' da identidade canônica só admite ASCII imprimível sem o delimitador " +
+                    $"'{Delimitador}' — encontrado o caractere U+{(int)c:X4}.",
+                    nomeParametro);
+            }
+        }
+    }
+
+    public int CompareTo(IdCanonico? other) =>
+        other is null ? 1 : _bytes.AsSpan().SequenceCompareTo(other._bytes);
+
+    public bool Equals(IdCanonico? other) =>
+        other is not null && _bytes.AsSpan().SequenceEqual(other._bytes);
+
+    public override bool Equals(object? obj) => obj is IdCanonico outro && Equals(outro);
+
+    public override int GetHashCode() => string.GetHashCode(Valor, StringComparison.Ordinal);
+
+    public override string ToString() => Valor;
+
+    public static bool operator ==(IdCanonico? esquerda, IdCanonico? direita) =>
+        esquerda is null ? direita is null : esquerda.Equals(direita);
+
+    public static bool operator !=(IdCanonico? esquerda, IdCanonico? direita) => !(esquerda == direita);
+
+    public static bool operator <(IdCanonico? esquerda, IdCanonico? direita) =>
+        Comparar(esquerda, direita) < 0;
+
+    public static bool operator <=(IdCanonico? esquerda, IdCanonico? direita) =>
+        Comparar(esquerda, direita) <= 0;
+
+    public static bool operator >(IdCanonico? esquerda, IdCanonico? direita) =>
+        Comparar(esquerda, direita) > 0;
+
+    public static bool operator >=(IdCanonico? esquerda, IdCanonico? direita) =>
+        Comparar(esquerda, direita) >= 0;
+
+    private static int Comparar(IdCanonico? esquerda, IdCanonico? direita) =>
+        esquerda is null ? (direita is null ? 0 : -1) : esquerda.CompareTo(direita);
+}

--- a/tests/Unifesspa.UniPlus.Selecao.Domain.UnitTests/Entities/ProcessoSeletivoFatosColetadosTests.cs
+++ b/tests/Unifesspa.UniPlus.Selecao.Domain.UnitTests/Entities/ProcessoSeletivoFatosColetadosTests.cs
@@ -89,23 +89,21 @@ public sealed class ProcessoSeletivoFatosColetadosTests
     }
 
     /// <summary>
-    /// Uma pré-condição pode citar um fato <b>derivado</b>, que não tem Ordem de coleta e por
-    /// isso não é checável na definição isolada (§7.3a): a definição relaxou. A garantia de que
-    /// o fato citado existe — em coletados ∪ derivados — passou para o gate de pré-canonicalização.
-    /// Aqui o fato citado (<c>PCD</c>) não é coletado nem derivado, então a definição aceita e a
-    /// recusa aflora ao publicar.
+    /// Uma pré-condição de campo só cita fato <b>coletado</b>, nunca derivado: o resolvedor de
+    /// estado dos fatos percorre só os coletados e não aciona o motor de derivação, de modo que
+    /// uma pré-condição sobre um derivado avaliaria indeterminada para sempre. A recusa é na
+    /// definição, antes de o campo virar configuração.
     /// </summary>
-    [Fact(DisplayName = "Pré-condição que cita fato inexistente passa na definição, mas é recusada no gate de pré-canonicalização")]
-    public void CitaFatoInexistente_RecusadoNoGateDePublicacao()
+    [Fact(DisplayName = "Pré-condição que cita fato não coletado pelo processo é recusada")]
+    public void CitaFatoNaoColetado_Recusado()
     {
         ProcessoSeletivo processo = NovoProcesso();
 
-        processo.DefinirFatosColetados([Fato("CONCORRER_PCD", 0, "PCD")]).IsSuccess.Should().BeTrue(
-            "a definição isolada não tem os fatos derivados em mãos para checar a existência da citação");
+        Result resultado = processo.DefinirFatosColetados(
+            [Fato("CONCORRER_PCD", 0, "PCD")]);
 
-        processo.PendenciaPreCanonicalizacao().Should().NotBeNull();
-        processo.PendenciaPreCanonicalizacao()!.Code
-            .Should().Be(FatoColetadoErrorCodes.PrecondicaoCitaFatoNaoColetado);
+        resultado.IsFailure.Should().BeTrue("o gate ficaria preso a um fato que este processo nunca vai resolver");
+        resultado.Error!.Code.Should().Be(FatoColetadoErrorCodes.PrecondicaoCitaFatoNaoColetado);
     }
 
     [Fact(DisplayName = "Fato citando a si mesmo é recusado na criação, antes de chegar ao grafo")]

--- a/tests/Unifesspa.UniPlus.Selecao.Domain.UnitTests/Entities/ProcessoSeletivoFatosColetadosTests.cs
+++ b/tests/Unifesspa.UniPlus.Selecao.Domain.UnitTests/Entities/ProcessoSeletivoFatosColetadosTests.cs
@@ -88,16 +88,24 @@ public sealed class ProcessoSeletivoFatosColetadosTests
         resultado.Error.Message.Should().Contain("A → B → A");
     }
 
-    [Fact(DisplayName = "Pré-condição que cita fato não coletado pelo processo é recusada")]
-    public void CitaFatoNaoColetado_Recusado()
+    /// <summary>
+    /// Uma pré-condição pode citar um fato <b>derivado</b>, que não tem Ordem de coleta e por
+    /// isso não é checável na definição isolada (§7.3a): a definição relaxou. A garantia de que
+    /// o fato citado existe — em coletados ∪ derivados — passou para o gate de pré-canonicalização.
+    /// Aqui o fato citado (<c>PCD</c>) não é coletado nem derivado, então a definição aceita e a
+    /// recusa aflora ao publicar.
+    /// </summary>
+    [Fact(DisplayName = "Pré-condição que cita fato inexistente passa na definição, mas é recusada no gate de pré-canonicalização")]
+    public void CitaFatoInexistente_RecusadoNoGateDePublicacao()
     {
         ProcessoSeletivo processo = NovoProcesso();
 
-        Result resultado = processo.DefinirFatosColetados(
-            [Fato("CONCORRER_PCD", 0, "PCD")]);
+        processo.DefinirFatosColetados([Fato("CONCORRER_PCD", 0, "PCD")]).IsSuccess.Should().BeTrue(
+            "a definição isolada não tem os fatos derivados em mãos para checar a existência da citação");
 
-        resultado.IsFailure.Should().BeTrue("o gate ficaria preso a um fato que este processo nunca vai resolver");
-        resultado.Error!.Code.Should().Be(FatoColetadoErrorCodes.PrecondicaoCitaFatoNaoColetado);
+        processo.PendenciaPreCanonicalizacao().Should().NotBeNull();
+        processo.PendenciaPreCanonicalizacao()!.Code
+            .Should().Be(FatoColetadoErrorCodes.PrecondicaoCitaFatoNaoColetado);
     }
 
     [Fact(DisplayName = "Fato citando a si mesmo é recusado na criação, antes de chegar ao grafo")]

--- a/tests/Unifesspa.UniPlus.Selecao.Domain.UnitTests/Entities/ProcessoSeletivoRegrasDerivacaoTests.cs
+++ b/tests/Unifesspa.UniPlus.Selecao.Domain.UnitTests/Entities/ProcessoSeletivoRegrasDerivacaoTests.cs
@@ -63,6 +63,21 @@ public sealed class ProcessoSeletivoRegrasDerivacaoTests
             .Should().Be(GrafoDependenciaConjuntaErrorCodes.GrafoConjuntoComCiclo);
     }
 
+    [Fact(DisplayName = "Regra de derivação que cita fato inexistente é recusada no gate de pré-canonicalização")]
+    public void DerivacaoCitaFatoInexistente_RecusadaNoGateDePublicacao()
+    {
+        ProcessoSeletivo processo = NovoProcesso();
+
+        ConfiguracaoDerivacaoFato d1 = ConfiguracaoDerivacaoFato.Criar("D1", [Regra(0, "X", ("BOGUS", true))]).Value!;
+
+        processo.DefinirRegrasDerivacao([d1]).IsSuccess.Should().BeTrue(
+            "a definição isolada só valida forma e unicidade — não conhece o universo de fatos do processo");
+
+        processo.PendenciaPreCanonicalizacao().Should().NotBeNull();
+        processo.PendenciaPreCanonicalizacao()!.Code
+            .Should().Be(FatoColetadoErrorCodes.PrecondicaoCitaFatoNaoColetado);
+    }
+
     [Fact(DisplayName = "Define e reidrata a configuração de derivação em rascunho")]
     public void Definir_EmRascunho_Aceita()
     {

--- a/tests/Unifesspa.UniPlus.Selecao.Domain.UnitTests/Entities/ProcessoSeletivoRegrasDerivacaoTests.cs
+++ b/tests/Unifesspa.UniPlus.Selecao.Domain.UnitTests/Entities/ProcessoSeletivoRegrasDerivacaoTests.cs
@@ -40,6 +40,29 @@ public sealed class ProcessoSeletivoRegrasDerivacaoTests
             Regra(2, "LI_PCD", ("CONCORRER_PCD", true), ("EGRESSO_ESCOLA_PUBLICA", true)),
         ]).Value!;
 
+    /// <summary>
+    /// Um ciclo de derivação (D1 depende de D2, D2 depende de D1) atravessa a validação isolada
+    /// de <see cref="ProcessoSeletivo.DefinirRegrasDerivacao"/> — que só barra código duplicado.
+    /// A aciclicidade do grafo conjunto (§7) é condição para congelar a ordem topológica (RN08),
+    /// e o gate de pré-canonicalização a exige antes de publicar. O ciclo entre classes/regras
+    /// que nenhuma factory isolada pega é exatamente o que o grafo conjunto existe para recusar.
+    /// </summary>
+    [Fact(DisplayName = "Ciclo de derivação passa pela definição isolada mas é recusado no gate de pré-canonicalização")]
+    public void CicloDeDerivacao_RecusadoNoGateDePublicacao()
+    {
+        ProcessoSeletivo processo = NovoProcesso();
+
+        ConfiguracaoDerivacaoFato d1 = ConfiguracaoDerivacaoFato.Criar("D1", [Regra(0, "X", ("D2", true))]).Value!;
+        ConfiguracaoDerivacaoFato d2 = ConfiguracaoDerivacaoFato.Criar("D2", [Regra(0, "Y", ("D1", true))]).Value!;
+
+        processo.DefinirRegrasDerivacao([d1, d2]).IsSuccess.Should().BeTrue(
+            "a definição isolada só barra código duplicado — o ciclo cruza duas configurações e passa aqui");
+
+        processo.PendenciaPreCanonicalizacao().Should().NotBeNull();
+        processo.PendenciaPreCanonicalizacao()!.Code
+            .Should().Be(GrafoDependenciaConjuntaErrorCodes.GrafoConjuntoComCiclo);
+    }
+
     [Fact(DisplayName = "Define e reidrata a configuração de derivação em rascunho")]
     public void Definir_EmRascunho_Aceita()
     {

--- a/tests/Unifesspa.UniPlus.Selecao.Domain.UnitTests/ValueObjects/IdCanonicoTests.cs
+++ b/tests/Unifesspa.UniPlus.Selecao.Domain.UnitTests/ValueObjects/IdCanonicoTests.cs
@@ -1,0 +1,93 @@
+namespace Unifesspa.UniPlus.Selecao.Domain.UnitTests.ValueObjects;
+
+using System.Text;
+
+using AwesomeAssertions;
+
+using Unifesspa.UniPlus.Selecao.Domain.Enums;
+using Unifesspa.UniPlus.Selecao.Domain.ValueObjects;
+
+using Xunit;
+
+public sealed class IdCanonicoTests
+{
+    private static readonly Guid ProcessoA = new("11111111-1111-4111-8111-111111111111");
+    private static readonly Guid ProcessoB = new("22222222-2222-4222-8222-222222222222");
+
+    [Fact(DisplayName = "IdCanonico — compõe tipoDeNo/PROCESSO/<id-N>/codigo")]
+    public void Compoe_AFormaCanonica()
+    {
+        IdCanonico.De(ClasseNoGrafo.Fato, ProcessoA, "COR_RACA").Valor
+            .Should().Be("FATO/PROCESSO/11111111111141118111111111111111/COR_RACA");
+    }
+
+    [Fact(DisplayName = "IdCanonico — campo e fato do mesmo código são identidades distintas")]
+    public void CampoEFato_MesmoCodigo_SaoDistintos()
+    {
+        IdCanonico campo = IdCanonico.De(ClasseNoGrafo.Campo, ProcessoA, "QUILOMBOLA");
+        IdCanonico fato = IdCanonico.De(ClasseNoGrafo.Fato, ProcessoA, "QUILOMBOLA");
+
+        campo.Should().NotBe(fato);
+        campo.Valor.Should().StartWith("CAMPO/");
+        fato.Valor.Should().StartWith("FATO/");
+    }
+
+    [Fact(DisplayName = "IdCanonico — o mesmo código em processos distintos são identidades distintas")]
+    public void MesmoCodigo_ProcessosDistintos_SaoDistintos()
+    {
+        IdCanonico.De(ClasseNoGrafo.Fato, ProcessoA, "PCD")
+            .Should().NotBe(IdCanonico.De(ClasseNoGrafo.Fato, ProcessoB, "PCD"));
+    }
+
+    [Fact(DisplayName = "IdCanonico — duas composições iguais são iguais e têm o mesmo hash")]
+    public void MesmaComposicao_Igual()
+    {
+        IdCanonico a = IdCanonico.De(ClasseNoGrafo.Exigencia, ProcessoA, "0f9a");
+        IdCanonico b = IdCanonico.De(ClasseNoGrafo.Exigencia, ProcessoA, "0f9a");
+
+        a.Should().Be(b);
+        a.GetHashCode().Should().Be(b.GetHashCode());
+    }
+
+    [Fact(DisplayName = "IdCanonico — a ordenação é por bytes UTF-8 (aqui, ASCII, coincide com ordinal)")]
+    public void Ordena_PorBytes()
+    {
+        IdCanonico a = IdCanonico.De(ClasseNoGrafo.Fato, ProcessoA, "AAA");
+        IdCanonico b = IdCanonico.De(ClasseNoGrafo.Fato, ProcessoA, "AAB");
+
+        a.CompareTo(b).Should().BeNegative();
+        b.CompareTo(a).Should().BePositive();
+        a.CompareTo(a).Should().Be(0);
+
+        Encoding.UTF8.GetBytes(a.Valor).Should().Equal(a.Bytes.ToArray());
+    }
+
+    [Theory(DisplayName = "IdCanonico — o delimitador '/' no código é recusado (remontagem ambígua)")]
+    [InlineData("COR/RACA")]
+    [InlineData("/PCD")]
+    [InlineData("PCD/")]
+    public void Delimitador_NoCodigo_Recusado(string codigo)
+    {
+        Action criar = () => IdCanonico.De(ClasseNoGrafo.Fato, ProcessoA, codigo);
+
+        criar.Should().Throw<ArgumentException>();
+    }
+
+    [Theory(DisplayName = "IdCanonico — código não-ASCII ou de controle é recusado")]
+    [InlineData("CÓDIGO")]
+    [InlineData("COR RACA")]
+    public void NaoAsciiOuControle_Recusado(string codigo)
+    {
+        Action criar = () => IdCanonico.De(ClasseNoGrafo.Fato, ProcessoA, codigo);
+
+        criar.Should().Throw<ArgumentException>();
+    }
+
+    [Fact(DisplayName = "IdCanonico — código vazio é recusado")]
+    public void Vazio_Recusado()
+    {
+        Action criar = () => IdCanonico.De(ClasseNoGrafo.Fato, ProcessoA, "  ");
+
+        criar.Should().Throw<ArgumentException>();
+    }
+}


### PR DESCRIPTION
## O que muda

Primeira fatia do §7 (determinismo e congelamento conjunto, RN08) da change `coleta-de-fatos-e-derivacao`: a **identidade canônica de nó** (fundação) e duas **recusas de publicação** que faltavam.

## Como

- **`IdCanonico`** (§7.1) — a identidade de runtime de um nó do grafo é o par `(Classe, Codigo)`, que basta dentro de um processo. O congelamento precisa de mais: o mesmo código de fato em dois processos são nós distintos. `IdCanonico` acrescenta o escopo do processo — `tipoDeNo/PROCESSO/<id>/codigo` — com gramática fechada (o delimitador `/` é reservado; nenhum componente pode contê-lo) e ordenação por bytes UTF-8, que é a que a chave total do envelope declarará. É a base que a fatia de congelamento vai consumir.
- **Recusa de ciclo no grafo conjunto** (§7.3) — um ciclo que cruza configurações independentes (duas regras de derivação que dependem uma da outra; um campo cuja pré-condição fecha volta por um fato derivado) atravessa cada validação isolada. A ordem topológica total que o snapshot congela não existe se houver ciclo, então a construção do grafo (§6), que já detecta o ciclo, vira gate de pré-canonicalização.
- **Recusa de fato citado inexistente + relaxamento §7.3a** — a pré-condição de um campo pode citar um fato **derivado**, que não tem ordem de coleta; a validação isolada da coleta relaxa (deixa de recusar citação a não-coletado, checa só a anterioridade entre coletados). A garantia de que todo fato citado (pré-condição, regra de derivação) existe em coletados ∪ derivados passa para o gate de pré-canonicalização — o grafo conjunto ignora de propósito uma referência ausente, então é esta recusa que prova a completude do vocabulário citado.

## Provas

- `IdCanonicoTests`: composição, distinção campo/fato e por processo, gramática fechada (delimitador/não-ASCII/vazio recusados), ordenação por bytes.
- Gates: ciclo de derivação e fato citado inexistente passam pela definição isolada mas são recusados no gate de pré-canonicalização (a recusa migrou da definição para o publish, junto do relaxamento).
- Suíte inteira verde; `dotnet format --verify-no-changes` limpo.

O gatilho de exigência cita pelo mesmo vocabulário e caberá no mesmo gate quando passar a exigir os seus fatos coletados (fora desta fatia). O congelamento do grafo/fatos/regras no envelope é a próxima fatia.

Refs #928
