### PR TITLE
feat(selecao): recusa modalidade contribuída fora do domínio ofertado ao publicar

### DIFF
--- a/src/selecao/Unifesspa.UniPlus.Selecao.Domain/Entities/ProcessoSeletivo.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Domain/Entities/ProcessoSeletivo.cs
@@ -9,6 +9,7 @@ using Events;
 using Unifesspa.UniPlus.Kernel.Domain.Entities;
 using Unifesspa.UniPlus.Kernel.Extensions;
 using Unifesspa.UniPlus.Kernel.Results;
+using Unifesspa.UniPlus.Selecao.Domain.Services;
 using Unifesspa.UniPlus.Selecao.Domain.ValueObjects;
 
 /// <summary>
@@ -1376,7 +1377,47 @@ public sealed class ProcessoSeletivo : SoftDeletableEntity
             return fatoCitado;
         }
 
+        if (PendenciaDoDominioDeContribuicao() is { } contribuicaoForaDoDominio)
+        {
+            return contribuicaoForaDoDominio;
+        }
+
         return PendenciaDoGrafoConjunto();
+    }
+
+    /// <summary>
+    /// O código que a derivação de <c>MODALIDADE</c> contribui tem de pertencer ao domínio congelado
+    /// daquele processo — o conjunto de modalidades ofertadas (Story #928, §7.2). Um código fora dele
+    /// é recusado com erro nomeado, <b>sem tradução de alias</b>: <c>V</c>, por exemplo, é rótulo de
+    /// exibição de <c>AC_PCD</c> no edital, nunca um código de entrada. A canonicidade é avaliada
+    /// contra o domínio da configuração, não contra o conjunto federal global.
+    /// </summary>
+    /// <remarks>
+    /// Reconstruir o VO da regra contra o domínio (<see cref="ConfiguracaoDerivacaoFato.ParaRegrasDerivacao"/>)
+    /// é o contrato que faz a recusa: o VO valida que todo <c>contribui</c> pertence ao domínio, e
+    /// devolve o mesmo erro nomeado que o decodificador do envelope aplica na reidratação — publish e
+    /// decode barram o mesmo código desconhecido.
+    /// </remarks>
+    private DomainError? PendenciaDoDominioDeContribuicao()
+    {
+        IReadOnlyCollection<string> modalidadesOfertadas =
+            [.. _distribuicaoVagas.SelectMany(static d => d.Modalidades).Select(static m => m.Codigo).Distinct(StringComparer.Ordinal)];
+
+        foreach (ConfiguracaoDerivacaoFato config in _regrasDerivacao)
+        {
+            if (!string.Equals(config.CodigoFato, RegrasDerivacaoModalidadeLei12711.CodigoFato, StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            Result<RegrasDerivacaoFato> regras = config.ParaRegrasDerivacao(modalidadesOfertadas);
+            if (regras.IsFailure)
+            {
+                return regras.Error;
+            }
+        }
+
+        return null;
     }
 
     /// <summary>

--- a/tests/Unifesspa.UniPlus.Selecao.Domain.UnitTests/Entities/ProcessoSeletivoRegrasDerivacaoTests.cs
+++ b/tests/Unifesspa.UniPlus.Selecao.Domain.UnitTests/Entities/ProcessoSeletivoRegrasDerivacaoTests.cs
@@ -40,6 +40,40 @@ public sealed class ProcessoSeletivoRegrasDerivacaoTests
             Regra(2, "LI_PCD", ("CONCORRER_PCD", true), ("EGRESSO_ESCOLA_PUBLICA", true)),
         ]).Value!;
 
+    /// <summary>Oferta uma distribuição mínima cujas modalidades são o domínio congelado de contribuição.</summary>
+    private static void OfertarModalidades(ProcessoSeletivo processo, params string[] codigos)
+    {
+        List<ModalidadeSelecionada> modalidades =
+        [
+            .. codigos.Select(static codigo => ModalidadeSelecionada.Criar(
+                modalidadeOrigemId: Guid.CreateVersion7(),
+                codigo: codigo,
+                descricao: null,
+                naturezaLegal: NaturezaLegalModalidade.Ampla,
+                composicaoVagas: ComposicaoVagasModalidade.ResidualDoVo,
+                composicaoOrigemCodigo: null,
+                regraRemanejamento: RegraRemanejamentoModalidade.Nenhuma,
+                remanejamentoDestino: null,
+                remanejamentoPar: null,
+                remanejamentoFallback: null,
+                criteriosCumulativos: [],
+                acaoQuandoIndeferido: null,
+                baseLegal: "Res. Unifesspa 532/2021",
+                quantidadeDeclarada: 10).Value!),
+        ];
+
+        ConfiguracaoDistribuicaoVagas config = ConfiguracaoDistribuicaoVagas.Criar(
+            ofertaCursoOrigemId: Guid.CreateVersion7(),
+            voBase: 40,
+            pr: 1m,
+            regraDistribuicao: ReferenciaRegra.Criar(RegraDistribuicaoVagasCodigo.Institucional, "v1", new string('a', 64)).Value!,
+            regraAjuste: null,
+            referenciaDemografica: null,
+            modalidades: modalidades).Value!;
+
+        processo.DefinirDistribuicaoVagas([config], PrecondicaoIfMatch.Ausente).IsSuccess.Should().BeTrue();
+    }
+
     /// <summary>
     /// Um ciclo de derivação (D1 depende de D2, D2 depende de D1) atravessa a validação isolada
     /// de <see cref="ProcessoSeletivo.DefinirRegrasDerivacao"/> — que só barra código duplicado.
@@ -61,6 +95,35 @@ public sealed class ProcessoSeletivoRegrasDerivacaoTests
         processo.PendenciaPreCanonicalizacao().Should().NotBeNull();
         processo.PendenciaPreCanonicalizacao()!.Code
             .Should().Be(GrafoDependenciaConjuntaErrorCodes.GrafoConjuntoComCiclo);
+    }
+
+    [Fact(DisplayName = "MODALIDADE que contribui código fora das modalidades ofertadas é recusada no gate de pré-canonicalização")]
+    public void ContribuiForaDoDominioDoProcesso_RecusadoNoGateDePublicacao()
+    {
+        ProcessoSeletivo processo = NovoProcesso();
+        OfertarModalidades(processo, "AC");
+
+        // "V" é rótulo de exibição de AC_PCD no edital, nunca código — e não está entre as
+        // modalidades ofertadas por este processo. Contribuí-lo é recusado, sem tradução de alias.
+        processo.DefinirRegrasDerivacao([ConfiguracaoDerivacaoFato.Criar("MODALIDADE", [Ancora(0, "V")]).Value!])
+            .IsSuccess.Should().BeTrue("a definição isolada não conhece o domínio de modalidades ofertadas");
+
+        processo.PendenciaPreCanonicalizacao().Should().NotBeNull();
+        processo.PendenciaPreCanonicalizacao()!.Code
+            .Should().Be(RegrasDerivacaoFatoErrorCodes.ContribuiForaDoDominio);
+    }
+
+    [Fact(DisplayName = "MODALIDADE que contribui apenas códigos ofertados passa o gate de pré-canonicalização")]
+    public void ContribuiDentroDoDominioDoProcesso_PassaNoGateDePublicacao()
+    {
+        ProcessoSeletivo processo = NovoProcesso();
+        OfertarModalidades(processo, "AC");
+
+        processo.DefinirRegrasDerivacao([ConfiguracaoDerivacaoFato.Criar("MODALIDADE", [Ancora(0, "AC")]).Value!])
+            .IsSuccess.Should().BeTrue();
+
+        processo.PendenciaPreCanonicalizacao().Should().BeNull(
+            "AC está entre as modalidades ofertadas — o gate de domínio de contribuição não barra");
     }
 
     [Fact(DisplayName = "Regra de derivação que cita fato inexistente é recusada no gate de pré-canonicalização")]


### PR DESCRIPTION
## Objetivo

Fecha a recusa de publicação da Story #928, §7.2: uma regra de derivação de `MODALIDADE` que contribui um código **fora do domínio congelado do processo** (o conjunto de modalidades ofertadas) é recusada com erro nomeado, **sem tradução de alias**.

## O que muda

- Novo gate de domínio `ProcessoSeletivo.PendenciaDoDominioDeContribuicao`, encadeado em `PendenciaPreCanonicalizacao` (após a recusa de citação de fato, antes da aciclicidade do grafo conjunto).
- Para a derivação de `MODALIDADE`, reconstrói o value object da regra contra o domínio de modalidades ofertadas (`ConfiguracaoDerivacaoFato.ParaRegrasDerivacao`) — o contrato que valida `contribui ∈ domínio`. Devolve `RegrasDerivacaoFato.ContribuiForaDoDominio`, o **mesmo** erro que o decodificador do envelope já aplica na reidratação (§7.4): publish e decode barram o mesmo código desconhecido.
- `V` é rótulo de exibição de `AC_PCD` no edital (vive na `Descricao` da modalidade cadastrada), nunca um código de entrada — e não está entre as modalidades ofertadas, então contribuí-lo é recusado.

## Testes

- `ContribuiForaDoDominioDoProcesso_RecusadoNoGateDePublicacao` — MODALIDADE contribui `V` (não ofertado) → `PendenciaPreCanonicalizacao` recusa com `ContribuiForaDoDominio`.
- `ContribuiDentroDoDominioDoProcesso_PassaNoGateDePublicacao` — controle: contribui apenas `AC` (ofertado) → gate passa.
- Suíte completa verde; `dotnet format` limpo.

## Contexto

A canonicidade é avaliada contra o domínio da configuração, não contra o conjunto federal global — coerente com o cenário do spec "Domínio de modalidade é o do processo, não o federal". A simetria com o decodificador do §7.4 elimina a assimetria em que o decode era mais estrito que o publish.

Refs #928