### PR TITLE
feat(selecao): endpoint de definição de fatos coletados em rascunho

### DIFF
--- a/contracts/openapi.selecao.json
+++ b/contracts/openapi.selecao.json
@@ -2305,6 +2305,107 @@
         "x-uniplus-idempotent": true
       }
     },
+    "/api/selecao/processos-seletivos/{id}/fatos-coletados": {
+      "put": {
+        "tags": [
+          "ProcessoSeletivo"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "Idempotency-Key",
+            "in": "header",
+            "description": "Chave opaca (1-255 ASCII printable, sem \u0027,\u0027 ou \u0027;\u0027) para retry seguro do comando. Replay com mesma key \u002B mesmo body retorna response cacheada (ADR-0027).",
+            "required": true,
+            "schema": {
+              "maxLength": 255,
+              "minLength": 1,
+              "pattern": "^[\\x21-\\x2B\\x2D-\\x3A\\x3C-\\x7E]\u002B$",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/FatoColetadoInput"
+                }
+              }
+            },
+            "text/json": {
+              "schema": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/FatoColetadoInput"
+                }
+              }
+            },
+            "application/*\u002Bjson": {
+              "schema": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/FatoColetadoInput"
+                }
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "No Content"
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Requisi\u00E7\u00E3o concorrente com a mesma Idempotency-Key ainda em processamento (uniplus.idempotency.processing_conflict). Repetir depois \u2014 a opera\u00E7\u00E3o anterior ainda n\u00E3o concluiu."
+          },
+          "413": {
+            "description": "Corpo acima do limite dos endpoints idempotentes (uniplus.idempotency.body_muito_grande). O limite \u00E9 do filtro, n\u00E3o do servidor."
+          }
+        },
+        "x-uniplus-idempotent": true
+      }
+    },
     "/api/selecao/processos-seletivos/{id}/publicacao": {
       "post": {
         "tags": [
@@ -3631,6 +3732,25 @@
           }
         }
       },
+      "CondicaoPrecondicaoInput": {
+        "required": [
+          "fato",
+          "operador",
+          "valor"
+        ],
+        "type": "object",
+        "properties": {
+          "fato": {
+            "type": "string"
+          },
+          "operador": {
+            "type": "string"
+          },
+          "valor": {
+            "$ref": "#/components/schemas/JsonElement"
+          }
+        }
+      },
       "ConfiguracaoBonusRegionalDto": {
         "required": [
           "id",
@@ -4801,6 +4921,39 @@
                 "$ref": "#/components/schemas/RegraRecursoFaseInput"
               }
             ]
+          }
+        }
+      },
+      "FatoColetadoInput": {
+        "required": [
+          "fatoCodigo",
+          "ordem",
+          "precondicao"
+        ],
+        "type": "object",
+        "properties": {
+          "fatoCodigo": {
+            "type": "string"
+          },
+          "ordem": {
+            "pattern": "^-?(?:0|[1-9]\\d*)$",
+            "type": [
+              "integer",
+              "string"
+            ],
+            "format": "int32"
+          },
+          "precondicao": {
+            "type": [
+              "null",
+              "array"
+            ],
+            "items": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/CondicaoPrecondicaoInput"
+              }
+            }
           }
         }
       },

--- a/src/selecao/Unifesspa.UniPlus.Selecao.API/Controllers/ProcessoSeletivoController.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.API/Controllers/ProcessoSeletivoController.cs
@@ -404,6 +404,31 @@ public sealed class ProcessoSeletivoController : ControllerBase
     }
 
     /// <summary>
+    /// Substitui integralmente os fatos que o processo coleta do candidato, com a sua ordem de
+    /// coleta e a pré-condição opcional que decide se o campo produtor é apresentado (Story
+    /// #984). Só é coletável um fato declarado, respondido em campo de inscrição — derivados e
+    /// computados são recusados. Escopo desta Story: edição só em rascunho (pré-publicação); um
+    /// processo publicado é recusado com <c>422</c>. Sem <c>If-Match</c>: em rascunho não há
+    /// sessão editorial nem ETag — a resposta é <c>204</c> sem ETag (a edição sob retificação é
+    /// entregue junto do congelamento conjunto do grafo).
+    /// </summary>
+    [HttpPut("{id:guid}/fatos-coletados")]
+    [RequiresIdempotencyKey]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status422UnprocessableEntity)]
+    public async Task<IActionResult> DefinirFatosColetados(
+        Guid id,
+        [FromBody] IReadOnlyList<FatoColetadoInput> fatos,
+        CancellationToken cancellationToken)
+    {
+        Result<MutacaoAceita> resultado = await _commandBus.Send(
+            new DefinirFatosColetadosCommand(id, fatos), cancellationToken);
+        return ResponderMutacao(resultado);
+    }
+
+    /// <summary>
     /// Publica o processo (RN08): valida a conformidade, congela a versão 1 da
     /// configuração (append-only) e transita o status para Publicado, tudo na mesma
     /// transação — junto da requisição durável que registra o ato em Publicações

--- a/src/selecao/Unifesspa.UniPlus.Selecao.API/Errors/SelecaoDomainErrorRegistration.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.API/Errors/SelecaoDomainErrorRegistration.cs
@@ -221,6 +221,11 @@ internal sealed class SelecaoDomainErrorRegistration : IDomainErrorRegistration
         new("FatoColetado.PrecondicaoCitaFatoPosterior", new DomainErrorMapping(StatusCodes.Status422UnprocessableEntity, "uniplus.selecao.fato_coletado.precondicao_cita_fato_posterior", "A pré-condição cita um fato posterior na ordem de coleta")),
         new("FatoColetado.GrafoComCiclo", new DomainErrorMapping(StatusCodes.Status422UnprocessableEntity, "uniplus.selecao.fato_coletado.grafo_com_ciclo", "As pré-condições dos fatos formam um ciclo")),
         new("CondicaoPrecondicaoFato.ClausulaInvalida", new DomainErrorMapping(StatusCodes.Status422UnprocessableEntity, "uniplus.selecao.condicao_precondicao_fato.clausula_invalida", "O ordinal da cláusula da pré-condição não pode ser negativo")),
+        // Coletabilidade de fato (Story #984) — semântica cross-módulo resolvida na Application:
+        // um fato coletado tem de existir no vocabulário e ser declarado com binding de campo de
+        // inscrição (derivado/computado não é coletável).
+        new("FatoColetado.FatoDesconhecido", new DomainErrorMapping(StatusCodes.Status422UnprocessableEntity, "uniplus.selecao.fato_coletado.fato_desconhecido", "O fato coletado não pertence ao vocabulário de fatos do candidato")),
+        new("FatoColetado.FatoNaoColetavel", new DomainErrorMapping(StatusCodes.Status422UnprocessableEntity, "uniplus.selecao.fato_coletado.fato_nao_coletavel", "O fato não é coletável — só um fato declarado respondido em campo de inscrição pode ser coletado")),
         // Regra de derivação de fato (Story #927). Todas as recusas são de configuração (422): regra
         // mal formada, ou tentativa de editá-la após a publicação enquanto o congelamento conjunto
         // (#928) ainda não existe. Os códigos usam constantes e escapam do fitness test — registrados

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Application/Commands/ProcessosSeletivos/DefinirFatosColetadosCommand.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Application/Commands/ProcessosSeletivos/DefinirFatosColetadosCommand.cs
@@ -1,0 +1,39 @@
+namespace Unifesspa.UniPlus.Selecao.Application.Commands.ProcessosSeletivos;
+
+using System.Text.Json;
+
+using Kernel.Results;
+
+using Unifesspa.UniPlus.Application.Abstractions.Messaging;
+
+/// <summary>
+/// Uma condição da pré-condição de um fato coletado — a tripla
+/// <c>{ Fato, Operador, Valor }</c> na forma flat do wire de comando. Idêntica em forma à
+/// condição de gatilho documental: o <see cref="Operador"/> é o código canônico UPPER_SNAKE
+/// (<c>IGUAL</c>, <c>EM</c>, …) e o <see cref="Valor"/> é o valor JSON já tipado (string,
+/// booleano, número ou array para <c>EM</c>/<c>NAO_EM</c>).
+/// </summary>
+public sealed record CondicaoPrecondicaoInput(string Fato, string Operador, JsonElement Valor);
+
+/// <summary>
+/// Um fato que o processo coleta do candidato, com a sua posição na ordem de coleta e a
+/// pré-condição opcional que decide se o campo produtor é apresentado. A
+/// <see cref="Precondicao"/> é um predicado na forma normal disjuntiva — a lista externa é o
+/// <b>OU</b> de cláusulas, cada cláusula interna é o <b>E</b> de condições. Ausência de
+/// pré-condição é representada por <see langword="null"/>, nunca por uma lista vazia (fato sem
+/// gate é coletado sempre; um predicado sem cláusula avaliaria falso, que é o oposto).
+/// </summary>
+public sealed record FatoColetadoInput(
+    string FatoCodigo,
+    int Ordem,
+    IReadOnlyList<IReadOnlyList<CondicaoPrecondicaoInput>>? Precondicao);
+
+/// <summary>
+/// Substitui integralmente os fatos que o processo coleta do candidato (Story #984). Escopo
+/// desta Story: edição só em rascunho (pré-publicação) — a edição sob sessão de retificação é
+/// entregue junto do congelamento conjunto do grafo. Por isso o comando não carrega
+/// precondição de concorrência: em rascunho não há sessão editorial nem ETag.
+/// </summary>
+public sealed record DefinirFatosColetadosCommand(
+    Guid ProcessoSeletivoId,
+    IReadOnlyList<FatoColetadoInput> Fatos) : ICommand<Result<MutacaoAceita>>;

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Application/Commands/ProcessosSeletivos/DefinirFatosColetadosCommandHandler.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Application/Commands/ProcessosSeletivos/DefinirFatosColetadosCommandHandler.cs
@@ -1,0 +1,279 @@
+namespace Unifesspa.UniPlus.Selecao.Application.Commands.ProcessosSeletivos;
+
+using Abstractions;
+
+using Domain.Entities;
+using Domain.Enums;
+using Domain.Interfaces;
+using Domain.Services;
+using Domain.ValueObjects;
+
+using Kernel.Results;
+
+using Unifesspa.UniPlus.Configuracao.Contracts;
+
+/// <summary>
+/// Handler do <see cref="DefinirFatosColetadosCommand"/> (Story #984): substitui integralmente
+/// a coleta de fatos de um processo em rascunho. A validação de <b>coletabilidade</b> (só se
+/// coleta fato <c>Origem = DECLARADO</c> com binding de campo de inscrição) e a validação
+/// <b>semântica</b> das pré-condições (operador × domínio × valor do fato citado, contra a
+/// oferta do próprio processo para os domínios dinâmicos) são resolvidas aqui, na Application,
+/// que tem acesso ao vocabulário cross-módulo (<see cref="IFatoCandidatoReader"/>, ADR-0056).
+/// A validação <b>estrutural</b> do grafo (ordem única, pré-condição cita fato coletado e
+/// anterior, aciclicidade) e o guard de rascunho são do agregado
+/// (<see cref="ProcessoSeletivo.DefinirFatosColetados"/>).
+/// </summary>
+public static class DefinirFatosColetadosCommandHandler
+{
+    public static async Task<Result<MutacaoAceita>> Handle(
+        DefinirFatosColetadosCommand command,
+        IProcessoSeletivoRepository processoSeletivoRepository,
+        IFatoCandidatoReader fatoCandidatoReader,
+        ISelecaoUnitOfWork unitOfWork,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(command);
+        ArgumentNullException.ThrowIfNull(processoSeletivoRepository);
+        ArgumentNullException.ThrowIfNull(fatoCandidatoReader);
+        ArgumentNullException.ThrowIfNull(unitOfWork);
+
+        ProcessoSeletivo? processo = await processoSeletivoRepository
+            .ObterParaMutacaoAsync(command.ProcessoSeletivoId, cancellationToken)
+            .ConfigureAwait(false);
+        if (processo is null)
+        {
+            return Result<MutacaoAceita>.Failure(new DomainError(
+                "ProcessoSeletivo.NaoEncontrado",
+                $"Processo Seletivo {command.ProcessoSeletivoId} não encontrado."));
+        }
+
+        // Guard de rascunho ANTES da resolução do vocabulário cross-módulo: um processo já
+        // publicado é recusado sem pagar o I/O do reader nem caçar um fato desconhecido que o
+        // cliente não errou. O mesmo guard continua dentro de DefinirFatosColetados.
+        if (processo.EdicaoDeGrafoDeFatosBloqueada() is { } bloqueio)
+        {
+            return Result<MutacaoAceita>.Failure(bloqueio);
+        }
+
+        (IReadOnlyDictionary<string, FatoCandidatoView> catalogo,
+            IReadOnlyDictionary<string, DescritorFatoCandidato> vocabulario) =
+            await ResolverVocabularioAsync(fatoCandidatoReader, cancellationToken).ConfigureAwait(false);
+
+        // O domínio dos fatos categóricos de escopo-processo (CONDICAO_ATENDIMENTO, …) vem da
+        // oferta do PRÓPRIO processo — uma pré-condição que os cite valida contra ela, nunca
+        // contra um catálogo global.
+        IReadOnlyDictionary<string, IReadOnlySet<string>> dominiosDinamicos = ResolverDominiosDinamicos(processo);
+
+        List<FatoColetado> fatos = [];
+        foreach (FatoColetadoInput input in command.Fatos)
+        {
+            Result<FatoColetado> fatoResult = ResolverFato(input, catalogo, vocabulario, dominiosDinamicos);
+            if (fatoResult.IsFailure)
+            {
+                return Result<MutacaoAceita>.Failure(fatoResult.Error!);
+            }
+
+            fatos.Add(fatoResult.Value!);
+        }
+
+        Result result = processo.DefinirFatosColetados(fatos);
+        if (result.IsFailure)
+        {
+            return Result<MutacaoAceita>.Failure(result.Error!);
+        }
+
+        // Agregado tracked: a substituição da coleção (Clear + filhos novos com Guid v7) é
+        // persistida por change detection no SaveChanges — não chamar DbSet.Update.
+        await unitOfWork.SalvarAlteracoesAsync(cancellationToken).ConfigureAwait(false);
+
+        // Rascunho não tem sessão editorial: ETagDaSessaoEditorial é nulo e a resposta é 204
+        // sem ETag. O tipo de retorno já prepara a Story da edição sob retificação, que passará
+        // a emitir a tag da revisão.
+        return Result<MutacaoAceita>.Success(new MutacaoAceita(processo.ETagDaSessaoEditorial));
+    }
+
+    private static Result<FatoColetado> ResolverFato(
+        FatoColetadoInput input,
+        IReadOnlyDictionary<string, FatoCandidatoView> catalogo,
+        IReadOnlyDictionary<string, DescritorFatoCandidato> vocabulario,
+        IReadOnlyDictionary<string, IReadOnlySet<string>> dominiosDinamicos)
+    {
+        // Coletabilidade: o fato existe no vocabulário e é DECLARADO com binding de campo de
+        // inscrição. Um derivado (MODALIDADE, binding REGRA_DERIVACAO) ou um computado
+        // (RENDA_PER_CAPITA, binding ATRIBUTO_CANDIDATO) não é coletável — o candidato não o
+        // responde num campo.
+        if (!catalogo.TryGetValue(input.FatoCodigo, out FatoCandidatoView? view))
+        {
+            return Result<FatoColetado>.Failure(new DomainError(
+                ColetabilidadeDeFato.FatoDesconhecido,
+                $"O fato '{input.FatoCodigo}' não pertence ao vocabulário de fatos do candidato."));
+        }
+
+        if (!ColetabilidadeDeFato.EhColetavel(view))
+        {
+            return Result<FatoColetado>.Failure(new DomainError(
+                ColetabilidadeDeFato.FatoNaoColetavel,
+                $"O fato '{input.FatoCodigo}' não é coletável — só um fato declarado, respondido em campo de "
+                + "inscrição, pode ser coletado (derivados e computados não)."));
+        }
+
+        Result<IReadOnlyList<CondicaoPrecondicaoFato>?> precondicoesResult =
+            ResolverPrecondicao(input.Precondicao, vocabulario, dominiosDinamicos);
+        if (precondicoesResult.IsFailure)
+        {
+            return Result<FatoColetado>.Failure(precondicoesResult.Error!);
+        }
+
+        return FatoColetado.Criar(input.FatoCodigo, input.Ordem, precondicoesResult.Value);
+    }
+
+    /// <summary>
+    /// Monta e valida a pré-condição de um fato. Primeiro a <b>forma</b> de cada condição
+    /// (<see cref="CondicaoDnf.Criar"/>), depois a <b>semântica</b> do predicado inteiro
+    /// (<see cref="PredicadoDnfValidador"/>) — fato citado no vocabulário, operador × domínio,
+    /// valor × domínio (estático ou dinâmico). A estrutura do grafo (o fato citado é coletado e
+    /// anterior) é do agregado, em <see cref="ProcessoSeletivo.DefinirFatosColetados"/>.
+    /// </summary>
+    private static Result<IReadOnlyList<CondicaoPrecondicaoFato>?> ResolverPrecondicao(
+        IReadOnlyList<IReadOnlyList<CondicaoPrecondicaoInput>>? precondicao,
+        IReadOnlyDictionary<string, DescritorFatoCandidato> vocabulario,
+        IReadOnlyDictionary<string, IReadOnlySet<string>> dominiosDinamicos)
+    {
+        if (precondicao is null)
+        {
+            return Result<IReadOnlyList<CondicaoPrecondicaoFato>?>.Success(null);
+        }
+
+        List<(int Clausula, CondicaoDnf Condicao)> linhas = [];
+        List<CondicaoPrecondicaoFato> condicoes = [];
+        for (int clausula = 0; clausula < precondicao.Count; clausula++)
+        {
+            foreach (CondicaoPrecondicaoInput condicaoInput in precondicao[clausula])
+            {
+                // Defesa em profundidade: uma condição nula (JSON `[[null]]`) já é barrada pelo
+                // validator (400), mas nunca deve virar NullReferenceException/500 aqui.
+                if (condicaoInput is null)
+                {
+                    return Result<IReadOnlyList<CondicaoPrecondicaoFato>?>.Failure(new DomainError(
+                        CondicaoPrecondicaoFatoErrorCodes.ClausulaInvalida,
+                        "A pré-condição contém uma condição nula."));
+                }
+
+                Operador operador = OperadorCodigo.FromCodigo(condicaoInput.Operador);
+
+                Result<CondicaoPrecondicaoFato> condicaoResult =
+                    CondicaoPrecondicaoFato.Criar(clausula, condicaoInput.Fato, operador, condicaoInput.Valor);
+                if (condicaoResult.IsFailure)
+                {
+                    return Result<IReadOnlyList<CondicaoPrecondicaoFato>?>.Failure(condicaoResult.Error!);
+                }
+
+                condicoes.Add(condicaoResult.Value!);
+                linhas.Add((clausula, CondicaoDnf.Criar(condicaoInput.Fato, operador, condicaoInput.Valor).Value!));
+            }
+        }
+
+        Result<PredicadoDnf> predicadoResult = PredicadoDnf.CriarDeCondicoesAgrupadas(linhas);
+        if (predicadoResult.IsFailure)
+        {
+            return Result<IReadOnlyList<CondicaoPrecondicaoFato>?>.Failure(predicadoResult.Error!);
+        }
+
+        Result validacao = PredicadoDnfValidador.Validar(predicadoResult.Value!, vocabulario, null, dominiosDinamicos);
+        return validacao.IsFailure
+            ? Result<IReadOnlyList<CondicaoPrecondicaoFato>?>.Failure(validacao.Error!)
+            : Result<IReadOnlyList<CondicaoPrecondicaoFato>?>.Success(condicoes);
+    }
+
+    /// <summary>
+    /// Resolve o vocabulário fechado de fatos do candidato numa única passada do reader
+    /// cross-módulo: o catálogo cru por código (para a coletabilidade) e a projeção
+    /// <see cref="DescritorFatoCandidato"/> (para o validador de predicado), incluindo os
+    /// categóricos de escopo-processo como <see cref="TipoDominioFato.CategoricoDinamico"/>.
+    /// </summary>
+    private static async Task<(
+        IReadOnlyDictionary<string, FatoCandidatoView> Catalogo,
+        IReadOnlyDictionary<string, DescritorFatoCandidato> Vocabulario)> ResolverVocabularioAsync(
+        IFatoCandidatoReader fatoCandidatoReader, CancellationToken cancellationToken)
+    {
+        IReadOnlyList<FatoCandidatoView> fatos = await fatoCandidatoReader
+            .ListarAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        Dictionary<string, FatoCandidatoView> catalogo = new(StringComparer.Ordinal);
+        Dictionary<string, DescritorFatoCandidato> vocabulario = new(StringComparer.Ordinal);
+        foreach (FatoCandidatoView fato in fatos)
+        {
+            catalogo[fato.Codigo] = fato;
+
+            TipoDominioFato? tipoDominio = fato switch
+            {
+                { Dominio: "BOOLEANO" } => TipoDominioFato.Booleano,
+                { Dominio: "NUMERICO" } => TipoDominioFato.Numerico,
+                { Dominio: "CATEGORICO", ValoresDominio.Count: > 0 } => TipoDominioFato.CategoricoEstatico,
+                { Dominio: "CATEGORICO", ValoresDominio: null } => TipoDominioFato.CategoricoDinamico,
+                _ => null,
+            };
+
+            if (tipoDominio is not { } tipo)
+            {
+                continue;
+            }
+
+            Result<DescritorFatoCandidato> descritorResult = DescritorFatoCandidato.Criar(fato.Codigo, tipo, fato.ValoresDominio);
+            if (descritorResult.IsSuccess)
+            {
+                vocabulario[fato.Codigo] = descritorResult.Value!;
+            }
+        }
+
+        return (catalogo, vocabulario);
+    }
+
+    /// <summary>
+    /// Domínio dinâmico dos fatos categóricos de escopo-processo (CONDICAO_ATENDIMENTO,
+    /// TIPO_DEFICIENCIA): o conjunto de valores que o PRÓPRIO processo oferece, para que uma
+    /// pré-condição que os cite seja validada contra a oferta e não contra um catálogo global.
+    /// </summary>
+    private static Dictionary<string, IReadOnlySet<string>> ResolverDominiosDinamicos(ProcessoSeletivo processo)
+    {
+        HashSet<string> condicoesAtendimento = [.. (processo.OfertaAtendimento?.Condicoes ?? [])
+            .Select(static c => c.CondicaoCodigo)];
+
+        HashSet<string> tiposDeficiencia = [.. (processo.OfertaAtendimento?.TiposDeficiencia ?? [])
+            .Select(static t => t.TipoDeficienciaNome)];
+
+        return new Dictionary<string, IReadOnlySet<string>>(StringComparer.Ordinal)
+        {
+            ["CONDICAO_ATENDIMENTO"] = condicoesAtendimento,
+            ["TIPO_DEFICIENCIA"] = tiposDeficiencia,
+        };
+    }
+}
+
+/// <summary>
+/// Política de coletabilidade de um fato do candidato (Story #984). Só é coletável — respondido
+/// pelo candidato num campo do formulário de inscrição — o fato de <c>Origem = DECLARADO</c>
+/// cujo binding aponta para um campo de inscrição (<c>CAMPO_INSCRICAO:{campo}</c>). Um fato
+/// derivado (<c>REGRA_DERIVACAO:…</c>) ou computado de atributo (<c>ATRIBUTO_CANDIDATO:…</c>)
+/// não é respondido diretamente e não pode ser coletado. Enquanto <c>CAMPO_INSCRICAO</c> for o
+/// único binding coletável, este é o critério; um novo binding coletável estende esta política,
+/// não os call sites.
+/// </summary>
+internal static class ColetabilidadeDeFato
+{
+    public const string FatoDesconhecido = "FatoColetado.FatoDesconhecido";
+    public const string FatoNaoColetavel = "FatoColetado.FatoNaoColetavel";
+
+    private const string OrigemDeclarado = "DECLARADO";
+    private const string PrefixoBindingCampoInscricao = "CAMPO_INSCRICAO:";
+
+    public static bool EhColetavel(FatoCandidatoView fato)
+    {
+        ArgumentNullException.ThrowIfNull(fato);
+
+        return string.Equals(fato.Origem, OrigemDeclarado, StringComparison.Ordinal)
+            && fato.Binding.StartsWith(PrefixoBindingCampoInscricao, StringComparison.Ordinal)
+            && fato.Binding.Length > PrefixoBindingCampoInscricao.Length;
+    }
+}

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Application/Validators/ProcessosSeletivos/DefinirFatosColetadosCommandValidator.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Application/Validators/ProcessosSeletivos/DefinirFatosColetadosCommandValidator.cs
@@ -1,0 +1,47 @@
+namespace Unifesspa.UniPlus.Selecao.Application.Validators.ProcessosSeletivos;
+
+using Commands.ProcessosSeletivos;
+
+using FluentValidation;
+
+public sealed class DefinirFatosColetadosCommandValidator : AbstractValidator<DefinirFatosColetadosCommand>
+{
+    public DefinirFatosColetadosCommandValidator()
+    {
+        RuleFor(x => x.ProcessoSeletivoId)
+            .NotEmpty()
+            .WithMessage("ProcessoSeletivoId é obrigatório.");
+
+        // Lista obrigatória, mas pode ser vazia — vazia zera a coleta do processo. Sem esta
+        // regra um payload nulo chegaria ao handler e estouraria no foreach em vez de 400.
+        RuleFor(x => x.Fatos)
+            .NotNull()
+            .WithMessage("Lista de fatos coletados é obrigatória (pode ser vazia).");
+
+        RuleForEach(x => x.Fatos)
+            .NotNull()
+            .WithMessage("Item de fato coletado não pode ser nulo.");
+
+        RuleForEach(x => x.Fatos).ChildRules(fato =>
+        {
+            fato.RuleFor(f => f.FatoCodigo)
+                .NotEmpty()
+                .WithMessage("O código do fato coletado é obrigatório.");
+
+            fato.RuleFor(f => f.Ordem)
+                .GreaterThanOrEqualTo(0)
+                .WithMessage("A ordem de coleta não pode ser negativa.");
+
+            // Ausência de pré-condição é null, nunca []. Uma lista externa vazia, uma cláusula
+            // interna vazia ou uma condição nula deixariam a semântica DNF ambígua (um predicado
+            // sem cláusula, ou uma cláusula sem condição, avaliaria falso — o oposto de "sem
+            // pré-condição") ou fariam o handler desreferenciar um item nulo.
+            fato.RuleFor(f => f.Precondicao)
+                .Must(precondicao => precondicao is null
+                    || (precondicao.Count > 0 && precondicao.All(static clausula =>
+                        clausula is { Count: > 0 } && clausula.All(static condicao => condicao is not null))))
+                .WithMessage("A pré-condição, quando presente, não pode ser uma lista vazia, conter cláusulas "
+                    + "vazias ou condições nulas — a ausência de pré-condição é representada por null.");
+        });
+    }
+}

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Domain/Entities/ProcessoSeletivo.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Domain/Entities/ProcessoSeletivo.cs
@@ -932,16 +932,28 @@ public sealed class ProcessoSeletivo : SoftDeletableEntity
     /// envelope, é entregue na story do congelamento conjunto (#928).
     /// </para>
     /// </remarks>
+    /// <summary>
+    /// Guard não-mutante da edição do grafo de coleta: devolve o erro de "só em rascunho" quando
+    /// o processo já foi publicado, ou <see langword="null"/> quando a edição é permitida. Existe
+    /// para que a Application possa recusar a operação <b>antes</b> de resolver o vocabulário
+    /// cross-módulo e validar o corpo — o mesmo guard continua dentro de
+    /// <see cref="DefinirFatosColetados"/>, esta antecipação dá a ordem, não a garantia.
+    /// </summary>
+    public DomainError? EdicaoDeGrafoDeFatosBloqueada() =>
+        Status != StatusProcesso.Rascunho
+            ? new DomainError(
+                "ProcessoSeletivo.GrafoDeFatosSomenteEmRascunho",
+                "O grafo de coleta de fatos só pode ser definido antes da primeira publicação — "
+                + "a edição sob retificação depende do congelamento conjunto do grafo (#928).")
+            : null;
+
     public Result DefinirFatosColetados(IReadOnlyList<FatoColetado> fatosColetados)
     {
         ArgumentNullException.ThrowIfNull(fatosColetados);
 
-        if (Status != StatusProcesso.Rascunho)
+        if (EdicaoDeGrafoDeFatosBloqueada() is { } bloqueio)
         {
-            return Result.Failure(new DomainError(
-                "ProcessoSeletivo.GrafoDeFatosSomenteEmRascunho",
-                "O grafo de coleta de fatos só pode ser definido antes da primeira publicação — "
-                + "a edição sob retificação depende do congelamento conjunto do grafo (#928)."));
+            return Result.Failure(bloqueio);
         }
 
         if (ValidarGrafoDeFatos(fatosColetados) is { } erro)

--- a/tests/Unifesspa.UniPlus.Selecao.Application.UnitTests/Commands/DefinirFatosColetadosCommandHandlerTests.cs
+++ b/tests/Unifesspa.UniPlus.Selecao.Application.UnitTests/Commands/DefinirFatosColetadosCommandHandlerTests.cs
@@ -1,0 +1,171 @@
+namespace Unifesspa.UniPlus.Selecao.Application.UnitTests.Commands;
+
+using System.Text.Json;
+
+using AwesomeAssertions;
+
+using NSubstitute;
+
+using Unifesspa.UniPlus.Configuracao.Contracts;
+using Unifesspa.UniPlus.Kernel.Results;
+using Unifesspa.UniPlus.Selecao.Application.Abstractions;
+using Unifesspa.UniPlus.Selecao.Application.Commands.ProcessosSeletivos;
+using Unifesspa.UniPlus.Selecao.Domain.Entities;
+using Unifesspa.UniPlus.Selecao.Domain.Enums;
+using Unifesspa.UniPlus.Selecao.Domain.Interfaces;
+
+/// <summary>
+/// Cobertura do <see cref="DefinirFatosColetadosCommandHandler"/> (Story #984): a coletabilidade
+/// (só fato declarado com binding de campo de inscrição), a validação semântica das
+/// pré-condições contra o vocabulário fechado, e a delegação da estrutura do grafo ao agregado.
+/// </summary>
+public sealed class DefinirFatosColetadosCommandHandlerTests
+{
+    private sealed record Mocks(
+        IProcessoSeletivoRepository Repository,
+        IFatoCandidatoReader FatoCandidatoReader,
+        ISelecaoUnitOfWork UnitOfWork);
+
+    private static Mocks NovosMocks(ProcessoSeletivo? processo, Guid processoId)
+    {
+        IProcessoSeletivoRepository repository = Substitute.For<IProcessoSeletivoRepository>();
+        repository.ObterParaMutacaoAsync(processoId, Arg.Any<CancellationToken>()).Returns(processo);
+
+        Mocks mocks = new(repository, Substitute.For<IFatoCandidatoReader>(), Substitute.For<ISelecaoUnitOfWork>());
+        mocks.FatoCandidatoReader.ListarAsync(Arg.Any<CancellationToken>()).Returns(VocabularioSeed());
+        return mocks;
+    }
+
+    private static Task<Result<MutacaoAceita>> HandleAsync(Mocks mocks, DefinirFatosColetadosCommand command) =>
+        DefinirFatosColetadosCommandHandler.Handle(
+            command, mocks.Repository, mocks.FatoCandidatoReader, mocks.UnitOfWork, CancellationToken.None);
+
+    private static IReadOnlyList<FatoCandidatoView> VocabularioSeed() =>
+    [
+        new(Guid.CreateVersion7(), "COR_RACA", "Cor ou raça", null, "CATEGORICO", "DECLARADO", "ESCALAR",
+            ["BRANCA", "PRETA", "PARDA", "AMARELA", "INDIGENA", "NAO_INFORMADO"], "INSCRICAO", "CAMPO_INSCRICAO:COR_RACA", null),
+        new(Guid.CreateVersion7(), "BAIXA_RENDA", "Baixa renda", null, "BOOLEANO", "DECLARADO", "ESCALAR",
+            null, "INSCRICAO", "CAMPO_INSCRICAO:BAIXA_RENDA", null),
+        new(Guid.CreateVersion7(), "MODALIDADE", "Modalidade", null, "CATEGORICO", "DERIVADO", "MULTIVALORADO",
+            null, "INSCRICAO", "REGRA_DERIVACAO:MODALIDADE", null),
+        new(Guid.CreateVersion7(), "RENDA_PER_CAPITA", "Renda per capita", null, "NUMERICO", "DERIVADO", "ESCALAR",
+            null, "INSCRICAO", "ATRIBUTO_CANDIDATO:RENDA_PER_CAPITA", null),
+    ];
+
+    private static ProcessoSeletivo ProcessoEmRascunho() =>
+        ProcessoSeletivo.Criar("PS Fatos", TipoProcesso.SiSU, OrigemCandidatos.ImportacaoExterna);
+
+    private static CondicaoPrecondicaoInput Condicao(string fato, string operador, object valor) =>
+        new(fato, operador, JsonSerializer.SerializeToElement(valor));
+
+    [Fact(DisplayName = "Processo inexistente retorna ProcessoSeletivo.NaoEncontrado sem tocar no reader")]
+    public async Task Handle_ProcessoInexistente_RetornaNaoEncontrado()
+    {
+        Guid processoId = Guid.CreateVersion7();
+        Mocks mocks = NovosMocks(processo: null, processoId);
+        DefinirFatosColetadosCommand command = new(processoId, []);
+
+        Result<MutacaoAceita> resultado = await HandleAsync(mocks, command);
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be("ProcessoSeletivo.NaoEncontrado");
+    }
+
+    [Fact(DisplayName = "Coleta com pré-condição válida é aceita, persistida, e devolve 204 sem ETag em rascunho")]
+    public async Task Handle_ColetaValida_DefineEPersiste()
+    {
+        ProcessoSeletivo processo = ProcessoEmRascunho();
+        Mocks mocks = NovosMocks(processo, processo.Id);
+
+        DefinirFatosColetadosCommand command = new(processo.Id,
+        [
+            new FatoColetadoInput("COR_RACA", 0, null),
+            new FatoColetadoInput("BAIXA_RENDA", 1, [[Condicao("COR_RACA", "IGUAL", "PRETA")]]),
+        ]);
+
+        Result<MutacaoAceita> resultado = await HandleAsync(mocks, command);
+
+        resultado.IsSuccess.Should().BeTrue();
+        resultado.Value!.ETag.Should().BeNull("em rascunho não há sessão editorial nem ETag");
+        processo.FatosColetados.Select(f => f.FatoCodigo).Should().BeEquivalentTo(["COR_RACA", "BAIXA_RENDA"]);
+        await mocks.UnitOfWork.Received(1).SalvarAlteracoesAsync(Arg.Any<CancellationToken>());
+    }
+
+    [Fact(DisplayName = "Coletar um fato derivado (MODALIDADE) é recusado como não coletável")]
+    public async Task Handle_FatoDerivado_RetornaNaoColetavel()
+    {
+        ProcessoSeletivo processo = ProcessoEmRascunho();
+        Mocks mocks = NovosMocks(processo, processo.Id);
+        DefinirFatosColetadosCommand command = new(processo.Id, [new FatoColetadoInput("MODALIDADE", 0, null)]);
+
+        Result<MutacaoAceita> resultado = await HandleAsync(mocks, command);
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be("FatoColetado.FatoNaoColetavel");
+        await mocks.UnitOfWork.DidNotReceive().SalvarAlteracoesAsync(Arg.Any<CancellationToken>());
+    }
+
+    [Fact(DisplayName = "Coletar um fato computado de atributo (RENDA_PER_CAPITA) é recusado como não coletável")]
+    public async Task Handle_FatoComputado_RetornaNaoColetavel()
+    {
+        ProcessoSeletivo processo = ProcessoEmRascunho();
+        Mocks mocks = NovosMocks(processo, processo.Id);
+        DefinirFatosColetadosCommand command = new(processo.Id, [new FatoColetadoInput("RENDA_PER_CAPITA", 0, null)]);
+
+        Result<MutacaoAceita> resultado = await HandleAsync(mocks, command);
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be("FatoColetado.FatoNaoColetavel");
+    }
+
+    [Fact(DisplayName = "Fato fora do vocabulário é recusado como desconhecido, sem tradução")]
+    public async Task Handle_FatoForaDoVocabulario_RetornaDesconhecido()
+    {
+        ProcessoSeletivo processo = ProcessoEmRascunho();
+        Mocks mocks = NovosMocks(processo, processo.Id);
+        DefinirFatosColetadosCommand command = new(processo.Id, [new FatoColetadoInput("V", 0, null)]);
+
+        Result<MutacaoAceita> resultado = await HandleAsync(mocks, command);
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be("FatoColetado.FatoDesconhecido");
+    }
+
+    [Fact(DisplayName = "Pré-condição com operador incompatível com o domínio do fato citado é recusada")]
+    public async Task Handle_OperadorIncompativel_RetornaErroSemantico()
+    {
+        ProcessoSeletivo processo = ProcessoEmRascunho();
+        Mocks mocks = NovosMocks(processo, processo.Id);
+
+        // COR_RACA é categórico: MAIOR_IGUAL não se aplica.
+        DefinirFatosColetadosCommand command = new(processo.Id,
+        [
+            new FatoColetadoInput("COR_RACA", 0, null),
+            new FatoColetadoInput("BAIXA_RENDA", 1, [[Condicao("COR_RACA", "MAIOR_IGUAL", "PRETA")]]),
+        ]);
+
+        Result<MutacaoAceita> resultado = await HandleAsync(mocks, command);
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be("PredicadoDnf.OperadorIncompativelComDominio");
+    }
+
+    [Fact(DisplayName = "Pré-condição que cita fato posterior na ordem é recusada pela estrutura do grafo (domínio)")]
+    public async Task Handle_CitaFatoPosterior_RetornaErroDoDominio()
+    {
+        ProcessoSeletivo processo = ProcessoEmRascunho();
+        Mocks mocks = NovosMocks(processo, processo.Id);
+
+        // BAIXA_RENDA na ordem 0 cita COR_RACA (ordem 1, posterior).
+        DefinirFatosColetadosCommand command = new(processo.Id,
+        [
+            new FatoColetadoInput("BAIXA_RENDA", 0, [[Condicao("COR_RACA", "IGUAL", "PRETA")]]),
+            new FatoColetadoInput("COR_RACA", 1, null),
+        ]);
+
+        Result<MutacaoAceita> resultado = await HandleAsync(mocks, command);
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be("FatoColetado.PrecondicaoCitaFatoPosterior");
+    }
+}

--- a/tests/Unifesspa.UniPlus.Selecao.Application.UnitTests/Validators/DefinirFatosColetadosCommandValidatorTests.cs
+++ b/tests/Unifesspa.UniPlus.Selecao.Application.UnitTests/Validators/DefinirFatosColetadosCommandValidatorTests.cs
@@ -1,0 +1,103 @@
+namespace Unifesspa.UniPlus.Selecao.Application.UnitTests.Validators;
+
+using System.Text.Json;
+
+using AwesomeAssertions;
+
+using FluentValidation.Results;
+
+using Unifesspa.UniPlus.Selecao.Application.Commands.ProcessosSeletivos;
+using Unifesspa.UniPlus.Selecao.Application.Validators.ProcessosSeletivos;
+
+public sealed class DefinirFatosColetadosCommandValidatorTests
+{
+    private static readonly DefinirFatosColetadosCommandValidator Validator = new();
+
+    private static CondicaoPrecondicaoInput Condicao(string fato) =>
+        new(fato, "IGUAL", JsonSerializer.SerializeToElement("PRETA"));
+
+    [Fact(DisplayName = "Passa com lista de fatos vazia — zera a coleta")]
+    public void Aceita_ListaVazia()
+    {
+        ValidationResult result = Validator.Validate(new DefinirFatosColetadosCommand(Guid.CreateVersion7(), []));
+
+        result.IsValid.Should().BeTrue();
+    }
+
+    [Fact(DisplayName = "Passa com fato sem pré-condição (null)")]
+    public void Aceita_FatoSemPrecondicao()
+    {
+        ValidationResult result = Validator.Validate(new DefinirFatosColetadosCommand(
+            Guid.CreateVersion7(), [new FatoColetadoInput("COR_RACA", 0, null)]));
+
+        result.IsValid.Should().BeTrue();
+    }
+
+    [Fact(DisplayName = "Falha quando a lista de fatos é nula (payload malformado)")]
+    public void Rejeita_FatosNulo()
+    {
+        ValidationResult result = Validator.Validate(new DefinirFatosColetadosCommand(Guid.CreateVersion7(), null!));
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.PropertyName == "Fatos");
+    }
+
+    [Fact(DisplayName = "Falha quando o código do fato é vazio")]
+    public void Rejeita_FatoCodigoVazio()
+    {
+        ValidationResult result = Validator.Validate(new DefinirFatosColetadosCommand(
+            Guid.CreateVersion7(), [new FatoColetadoInput("", 0, null)]));
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.PropertyName == "Fatos[0].FatoCodigo");
+    }
+
+    [Fact(DisplayName = "Falha quando a ordem é negativa")]
+    public void Rejeita_OrdemNegativa()
+    {
+        ValidationResult result = Validator.Validate(new DefinirFatosColetadosCommand(
+            Guid.CreateVersion7(), [new FatoColetadoInput("COR_RACA", -1, null)]));
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.PropertyName == "Fatos[0].Ordem");
+    }
+
+    [Fact(DisplayName = "Falha quando a pré-condição presente é uma lista externa vazia (ausência é null)")]
+    public void Rejeita_PrecondicaoListaExternaVazia()
+    {
+        ValidationResult result = Validator.Validate(new DefinirFatosColetadosCommand(
+            Guid.CreateVersion7(), [new FatoColetadoInput("BAIXA_RENDA", 0, [])]));
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.PropertyName == "Fatos[0].Precondicao");
+    }
+
+    [Fact(DisplayName = "Falha quando a pré-condição tem uma cláusula interna vazia")]
+    public void Rejeita_PrecondicaoClausulaVazia()
+    {
+        ValidationResult result = Validator.Validate(new DefinirFatosColetadosCommand(
+            Guid.CreateVersion7(), [new FatoColetadoInput("BAIXA_RENDA", 0, [[]])]));
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.PropertyName == "Fatos[0].Precondicao");
+    }
+
+    [Fact(DisplayName = "Falha quando a pré-condição tem uma condição nula ([[null]])")]
+    public void Rejeita_PrecondicaoCondicaoNula()
+    {
+        ValidationResult result = Validator.Validate(new DefinirFatosColetadosCommand(
+            Guid.CreateVersion7(), [new FatoColetadoInput("BAIXA_RENDA", 0, [[null!]])]));
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.PropertyName == "Fatos[0].Precondicao");
+    }
+
+    [Fact(DisplayName = "Passa com pré-condição bem-formada (uma cláusula, uma condição)")]
+    public void Aceita_PrecondicaoBemFormada()
+    {
+        ValidationResult result = Validator.Validate(new DefinirFatosColetadosCommand(
+            Guid.CreateVersion7(), [new FatoColetadoInput("BAIXA_RENDA", 0, [[Condicao("COR_RACA")]])]));
+
+        result.IsValid.Should().BeTrue();
+    }
+}

--- a/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/Outbox/Cascading/DefinirFatosColetadosEndpointTests.cs
+++ b/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/Outbox/Cascading/DefinirFatosColetadosEndpointTests.cs
@@ -1,0 +1,225 @@
+namespace Unifesspa.UniPlus.Selecao.IntegrationTests.Outbox.Cascading;
+
+using System.Globalization;
+using System.Net;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+
+using AwesomeAssertions;
+
+using Domain.Entities;
+
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+
+using Unifesspa.UniPlus.IntegrationTests.Fixtures.Authentication;
+using Unifesspa.UniPlus.Selecao.Infrastructure.Persistence;
+
+/// <summary>
+/// O endpoint <c>PUT /processos-seletivos/{id}/fatos-coletados</c> (Story #984), fim a fim
+/// pelo HTTP. Prova o que só o ciclo real prova: a coletabilidade e o vocabulário resolvidos
+/// contra o seed cross-módulo de Configuração, o guard de rascunho num processo publicado, a
+/// idempotência do replay e a autorização herdada do controller.
+/// </summary>
+[Collection(CascadingCollection.Name)]
+[Trait("Category", "OutboxCapability")]
+[Trait("Category", "OutboxCascading")]
+public sealed class DefinirFatosColetadosEndpointTests
+{
+    private readonly CascadingFixture _fixture;
+
+    public DefinirFatosColetadosEndpointTests(CascadingFixture fixture) => _fixture = fixture;
+
+    [Fact(DisplayName = "Coleta válida em rascunho é aceita com 204 sem ETag e persiste os fatos")]
+    public async Task Rascunho_ColetaValida_204SemEtag()
+    {
+        Contexto ctx = await SemearRascunhoAsync(nameof(Rascunho_ColetaValida_204SemEtag));
+
+        object[] corpo =
+        [
+            new { fatoCodigo = "COR_RACA", ordem = 0, precondicao = (object?)null },
+            new
+            {
+                fatoCodigo = "BAIXA_RENDA",
+                ordem = 1,
+                precondicao = new[] { new[] { new { fato = "COR_RACA", operador = "IGUAL", valor = "PRETA" } } },
+            },
+        ];
+
+        HttpResponseMessage resposta = await ctx.PutFatosAsync(corpo);
+
+        resposta.StatusCode.Should().Be(HttpStatusCode.NoContent);
+        resposta.Headers.ETag.Should().BeNull("em rascunho não há sessão editorial nem ETag");
+
+        await using AsyncServiceScope scope = ctx.Api.Services.CreateAsyncScope();
+        SelecaoDbContext db = scope.ServiceProvider.GetRequiredService<SelecaoDbContext>();
+        List<FatoColetado> fatos = await db.Set<FatoColetado>().AsNoTracking()
+            .Where(f => f.ProcessoSeletivoId == ctx.ProcessoId).ToListAsync();
+        fatos.Select(f => f.FatoCodigo).Should().BeEquivalentTo(["COR_RACA", "BAIXA_RENDA"]);
+    }
+
+    [Fact(DisplayName = "Fato fora do vocabulário é recusado com 422 sem tradução")]
+    public async Task Rascunho_FatoDesconhecido_422()
+    {
+        Contexto ctx = await SemearRascunhoAsync(nameof(Rascunho_FatoDesconhecido_422));
+
+        HttpResponseMessage resposta = await ctx.PutFatosAsync(
+            [new { fatoCodigo = "V", ordem = 0, precondicao = (object?)null }]);
+
+        resposta.StatusCode.Should().Be(HttpStatusCode.UnprocessableEntity);
+    }
+
+    [Fact(DisplayName = "Coletar um fato derivado (MODALIDADE) é recusado com 422")]
+    public async Task Rascunho_FatoDerivado_422()
+    {
+        Contexto ctx = await SemearRascunhoAsync(nameof(Rascunho_FatoDerivado_422));
+
+        HttpResponseMessage resposta = await ctx.PutFatosAsync(
+            [new { fatoCodigo = "MODALIDADE", ordem = 0, precondicao = (object?)null }]);
+
+        resposta.StatusCode.Should().Be(HttpStatusCode.UnprocessableEntity);
+    }
+
+    [Fact(DisplayName = "Redefinir a coleta de um processo publicado é recusado com 422 (só em rascunho)")]
+    public async Task Publicado_Recusa_422()
+    {
+        Contexto ctx = await SemearRascunhoAsync(nameof(Publicado_Recusa_422));
+        await ctx.PublicarAsync();
+
+        HttpResponseMessage resposta = await ctx.PutFatosAsync(
+            [new { fatoCodigo = "COR_RACA", ordem = 0, precondicao = (object?)null }]);
+
+        resposta.StatusCode.Should().Be(HttpStatusCode.UnprocessableEntity);
+    }
+
+    [Fact(DisplayName = "Replay com a mesma Idempotency-Key e o mesmo corpo devolve o mesmo 204")]
+    public async Task Rascunho_ReplayIdempotente_204()
+    {
+        Contexto ctx = await SemearRascunhoAsync(nameof(Rascunho_ReplayIdempotente_204));
+        object[] corpo = [new { fatoCodigo = "COR_RACA", ordem = 0, precondicao = (object?)null }];
+        string chave = MakeIdempotencyKey();
+
+        (await ctx.PutFatosAsync(corpo, idempotencyKey: chave)).StatusCode.Should().Be(HttpStatusCode.NoContent);
+        HttpResponseMessage replay = await ctx.PutFatosAsync(corpo, idempotencyKey: chave);
+
+        replay.StatusCode.Should().Be(HttpStatusCode.NoContent);
+        replay.Headers.Contains("Idempotency-Replayed").Should().BeTrue();
+    }
+
+    [Fact(DisplayName = "Sem autenticação é 401")]
+    public async Task SemAutenticacao_401()
+    {
+        Contexto ctx = await SemearRascunhoAsync(nameof(SemAutenticacao_401));
+
+        HttpResponseMessage resposta = await ctx.PutFatosAsync(
+            [new { fatoCodigo = "COR_RACA", ordem = 0, precondicao = (object?)null }], autenticar: Autenticacao.Nenhuma);
+
+        resposta.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+
+    [Fact(DisplayName = "Autenticado sem o papel plataforma-admin é 403")]
+    public async Task SemPapel_403()
+    {
+        Contexto ctx = await SemearRascunhoAsync(nameof(SemPapel_403));
+
+        HttpResponseMessage resposta = await ctx.PutFatosAsync(
+            [new { fatoCodigo = "COR_RACA", ordem = 0, precondicao = (object?)null }], autenticar: Autenticacao.PapelErrado);
+
+        resposta.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+    }
+
+    private enum Autenticacao
+    {
+        PlataformaAdmin,
+        PapelErrado,
+        Nenhuma,
+    }
+
+    private sealed record Contexto(CascadingApiFactory Api, HttpClient Client, Guid ProcessoId, Guid DocumentoId)
+    {
+        public async Task<HttpResponseMessage> PutFatosAsync(
+            IReadOnlyList<object> corpo, string? idempotencyKey = null, Autenticacao autenticar = Autenticacao.PlataformaAdmin)
+        {
+            using HttpRequestMessage request = new(
+                HttpMethod.Put,
+                new Uri($"/api/selecao/processos-seletivos/{ProcessoId}/fatos-coletados", UriKind.Relative))
+            {
+                Content = JsonContent.Create(corpo),
+            };
+            Autenticar(request, autenticar);
+            request.Headers.TryAddWithoutValidation("Idempotency-Key", idempotencyKey ?? MakeIdempotencyKey());
+            return await Client.SendAsync(request).ConfigureAwait(false);
+        }
+
+        public async Task PublicarAsync()
+        {
+            using HttpRequestMessage publicar = new(
+                HttpMethod.Post,
+                new Uri($"/api/selecao/processos-seletivos/{ProcessoId}/publicacao", UriKind.Relative))
+            {
+                Content = JsonContent.Create(new
+                {
+                    numero = "001/2026",
+                    periodoInscricaoInicio = Hoje(),
+                    periodoInscricaoFim = HojeMais(30),
+                    documentoEditalId = DocumentoId,
+                    ato = new
+                    {
+                        orgao = "CEPS",
+                        serie = "EDITAL",
+                        ano = 2026,
+                        dataPublicacao = Hoje(),
+                        assinante = "Diretor do CEPS",
+                        tipoAtoCodigo = "EDITAL_ABERTURA",
+                    },
+                }),
+            };
+            Autenticar(publicar, Autenticacao.PlataformaAdmin);
+            publicar.Headers.TryAddWithoutValidation("Idempotency-Key", MakeIdempotencyKey());
+            HttpResponseMessage resposta = await Client.SendAsync(publicar).ConfigureAwait(false);
+            resposta.StatusCode.Should().Be(HttpStatusCode.NoContent, "o cenário depende de um certame publicado");
+        }
+    }
+
+    private async Task<Contexto> SemearRascunhoAsync(string nome)
+    {
+        CascadingApiFactory api = _fixture.Factory;
+        await TiposDeAtoSeeder.SemearAsync(api.Services);
+        HttpClient client = api.CreateClient();
+
+        Guid processoId;
+        Guid documentoId;
+        await using (AsyncServiceScope scope = api.Services.CreateAsyncScope())
+        {
+            SelecaoDbContext db = scope.ServiceProvider.GetRequiredService<SelecaoDbContext>();
+            (ProcessoSeletivo processo, DocumentoEdital documento) = await ProcessoSeletivoPublicavelSeeder
+                .SemearAsync(db, $"{nome} {Guid.CreateVersion7()}");
+            processoId = processo.Id;
+            documentoId = documento.Id;
+        }
+
+        return new Contexto(api, client, processoId, documentoId);
+    }
+
+    private static void Autenticar(HttpRequestMessage request, Autenticacao autenticacao)
+    {
+        if (autenticacao == Autenticacao.Nenhuma)
+        {
+            return;
+        }
+
+        request.Headers.Authorization = new AuthenticationHeaderValue(
+            TestAuthHandler.AuthorizationScheme, TestAuthHandler.TokenValue);
+        request.Headers.TryAddWithoutValidation(
+            TestAuthHandler.RolesHeader,
+            autenticacao == Autenticacao.PlataformaAdmin ? "plataforma-admin" : "consulta-publica");
+    }
+
+    private static string Hoje() =>
+        DateOnly.FromDateTime(DateTime.UtcNow).ToString("yyyy-MM-dd", CultureInfo.InvariantCulture);
+
+    private static string HojeMais(int dias) =>
+        DateOnly.FromDateTime(DateTime.UtcNow.AddDays(dias)).ToString("yyyy-MM-dd", CultureInfo.InvariantCulture);
+
+    private static string MakeIdempotencyKey() => Guid.CreateVersion7().ToString("N");
+}


### PR DESCRIPTION
## Objetivo

Expõe via HTTP a configuração de **fatos coletados** de um processo seletivo — a primeira fatia da superfície de coleta/derivação (Feature #983, Story #984). Até aqui o grafo de coleta só era exercitável pelo domínio, em teste; este PR liga o endpoint que o configura.

`PUT api/selecao/processos-seletivos/{id}/fatos-coletados` substitui integralmente os fatos que o processo coleta do candidato, com a ordem de coleta e a pré-condição opcional (predicado DNF) que decide se o campo produtor é apresentado.

## Escopo

- **Rascunho apenas.** Processo publicado é recusado com `422`; em rascunho não há sessão editorial nem ETag, e o sucesso é `204` sem ETag. A edição sob retificação (concorrência otimista) vem junto do congelamento conjunto do grafo, numa Story própria.
- **Coletabilidade:** só é coletável um fato `DECLARADO` respondido em campo de inscrição — derivados (ex.: `MODALIDADE`) e computados de atributo (ex.: `RENDA_PER_CAPITA`) são recusados.
- **Semântica da pré-condição:** operador × domínio × valor do fato citado, validados contra o vocabulário fechado cross-módulo (ADR-0056), inclusive contra a oferta do próprio processo para os domínios dinâmicos (CONDICAO_ATENDIMENTO).
- **Estrutura do grafo** (ordem única, cita fato coletado e anterior, aciclicidade) permanece no agregado.

## Notas de implementação

- DTO de entrada (`FatoColetadoInput`/`CondicaoPrecondicaoInput`) na Application, co-locado ao command (padrão `EtapaProcessoInput`).
- Guard de rascunho ganhou um acesso não-mutante no agregado, para recusar a operação antes de resolver o vocabulário cross-módulo.
- Baseline OpenAPI regerada no próprio PR (drift-check) com os dois novos schemas de entrada.
- Os códigos de erro de fato já estavam registrados; adicionados só os dois de coletabilidade.

## Testes

- Unit do validator (forma; rejeita pré-condição vazia/cláusula vazia/condição nula) e do handler (coletabilidade, semântica, delegação ao domínio).
- Integração HTTP (rascunho 204 sem ETag; 422 vocabulário/derivado; 422 em publicado; replay idempotente; 401/403).
- Suíte completa verde; `dotnet format` limpo.

Refs #984, #924