### PR TITLE
feat(selecao): endpoint de definição de regras de derivação em rascunho

### DIFF
--- a/contracts/openapi.selecao.json
+++ b/contracts/openapi.selecao.json
@@ -2406,6 +2406,107 @@
         "x-uniplus-idempotent": true
       }
     },
+    "/api/selecao/processos-seletivos/{id}/regras-derivacao": {
+      "put": {
+        "tags": [
+          "ProcessoSeletivo"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "Idempotency-Key",
+            "in": "header",
+            "description": "Chave opaca (1-255 ASCII printable, sem \u0027,\u0027 ou \u0027;\u0027) para retry seguro do comando. Replay com mesma key \u002B mesmo body retorna response cacheada (ADR-0027).",
+            "required": true,
+            "schema": {
+              "maxLength": 255,
+              "minLength": 1,
+              "pattern": "^[\\x21-\\x2B\\x2D-\\x3A\\x3C-\\x7E]\u002B$",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/ConfiguracaoDerivacaoInput"
+                }
+              }
+            },
+            "text/json": {
+              "schema": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/ConfiguracaoDerivacaoInput"
+                }
+              }
+            },
+            "application/*\u002Bjson": {
+              "schema": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/ConfiguracaoDerivacaoInput"
+                }
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "No Content"
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Requisi\u00E7\u00E3o concorrente com a mesma Idempotency-Key ainda em processamento (uniplus.idempotency.processing_conflict). Repetir depois \u2014 a opera\u00E7\u00E3o anterior ainda n\u00E3o concluiu."
+          },
+          "413": {
+            "description": "Corpo acima do limite dos endpoints idempotentes (uniplus.idempotency.body_muito_grande). O limite \u00E9 do filtro, n\u00E3o do servidor."
+          }
+        },
+        "x-uniplus-idempotent": true
+      }
+    },
     "/api/selecao/processos-seletivos/{id}/publicacao": {
       "post": {
         "tags": [
@@ -3671,6 +3772,25 @@
         ],
         "type": "string"
       },
+      "CondicaoDerivacaoInput": {
+        "required": [
+          "fato",
+          "operador",
+          "valor"
+        ],
+        "type": "object",
+        "properties": {
+          "fato": {
+            "type": "string"
+          },
+          "operador": {
+            "type": "string"
+          },
+          "valor": {
+            "$ref": "#/components/schemas/JsonElement"
+          }
+        }
+      },
       "CondicaoGatilhoDto": {
         "required": [
           "id",
@@ -3858,6 +3978,24 @@
           },
           "concorrenciaDuplaAplicavel": {
             "type": "boolean"
+          }
+        }
+      },
+      "ConfiguracaoDerivacaoInput": {
+        "required": [
+          "codigoFato",
+          "regras"
+        ],
+        "type": "object",
+        "properties": {
+          "codigoFato": {
+            "type": "string"
+          },
+          "regras": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/RegraDerivacaoInput"
+            }
           }
         }
       },
@@ -6237,6 +6375,39 @@
           },
           "hash": {
             "type": "string"
+          }
+        }
+      },
+      "RegraDerivacaoInput": {
+        "required": [
+          "ordem",
+          "contribui",
+          "quando"
+        ],
+        "type": "object",
+        "properties": {
+          "ordem": {
+            "pattern": "^-?(?:0|[1-9]\\d*)$",
+            "type": [
+              "integer",
+              "string"
+            ],
+            "format": "int32"
+          },
+          "contribui": {
+            "type": "string"
+          },
+          "quando": {
+            "type": [
+              "null",
+              "array"
+            ],
+            "items": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/CondicaoDerivacaoInput"
+              }
+            }
           }
         }
       },

--- a/src/selecao/Unifesspa.UniPlus.Selecao.API/Controllers/ProcessoSeletivoController.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.API/Controllers/ProcessoSeletivoController.cs
@@ -429,6 +429,32 @@ public sealed class ProcessoSeletivoController : ControllerBase
     }
 
     /// <summary>
+    /// Substitui integralmente as regras que derivam os fatos derivados do processo — hoje a
+    /// modalidade de concorrência (Story #985). Cada configuração traz o fato derivado e a lista de
+    /// regras <c>{ ordem, contribui, quando? }</c>; a regra incondicional (âncora) tem <c>quando</c>
+    /// nulo. Só um fato derivado com binding de regra de derivação é alvo válido — para a
+    /// modalidade, cada código contribuído tem de ser uma das modalidades ofertadas pelo processo.
+    /// Escopo desta Story: edição só em rascunho (pré-publicação); um processo publicado é recusado
+    /// com <c>422</c>. Sem <c>If-Match</c>: em rascunho não há sessão editorial nem ETag — a
+    /// resposta é <c>204</c> sem ETag.
+    /// </summary>
+    [HttpPut("{id:guid}/regras-derivacao")]
+    [RequiresIdempotencyKey]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status422UnprocessableEntity)]
+    public async Task<IActionResult> DefinirRegrasDerivacao(
+        Guid id,
+        [FromBody] IReadOnlyList<ConfiguracaoDerivacaoInput> configuracoes,
+        CancellationToken cancellationToken)
+    {
+        Result<MutacaoAceita> resultado = await _commandBus.Send(
+            new DefinirRegrasDerivacaoCommand(id, configuracoes), cancellationToken);
+        return ResponderMutacao(resultado);
+    }
+
+    /// <summary>
     /// Publica o processo (RN08): valida a conformidade, congela a versão 1 da
     /// configuração (append-only) e transita o status para Publicado, tudo na mesma
     /// transação — junto da requisição durável que registra o ato em Publicações

--- a/src/selecao/Unifesspa.UniPlus.Selecao.API/Errors/SelecaoDomainErrorRegistration.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.API/Errors/SelecaoDomainErrorRegistration.cs
@@ -231,6 +231,10 @@ internal sealed class SelecaoDomainErrorRegistration : IDomainErrorRegistration
         // (#928) ainda não existe. Os códigos usam constantes e escapam do fitness test — registrados
         // à mão para não caírem em 500 quando o endpoint de configuração da regra existir.
         new("ProcessoSeletivo.RegrasDerivacaoSomenteEmRascunho", new DomainErrorMapping(StatusCodes.Status422UnprocessableEntity, "uniplus.selecao.processo_seletivo.regras_derivacao_somente_em_rascunho", "As regras de derivação só são editáveis antes da primeira publicação")),
+        // Alvo de derivação (Story #985) — semântica cross-módulo resolvida na Application: o fato
+        // configurado tem de existir e ser derivado com binding de regra de derivação.
+        new("ConfiguracaoDerivacaoFato.FatoDesconhecido", new DomainErrorMapping(StatusCodes.Status422UnprocessableEntity, "uniplus.selecao.configuracao_derivacao_fato.fato_desconhecido", "O fato derivado não pertence ao vocabulário de fatos do candidato")),
+        new("ConfiguracaoDerivacaoFato.FatoNaoDerivavel", new DomainErrorMapping(StatusCodes.Status422UnprocessableEntity, "uniplus.selecao.configuracao_derivacao_fato.fato_nao_derivavel", "O fato não é um alvo de derivação — só um fato derivado com binding de regra de derivação pode ter regras configuradas")),
         new("ConfiguracaoDerivacaoFato.CodigoFatoObrigatorio", new DomainErrorMapping(StatusCodes.Status422UnprocessableEntity, "uniplus.selecao.configuracao_derivacao_fato.codigo_fato_obrigatorio", "O código do fato derivado é obrigatório")),
         new("ConfiguracaoDerivacaoFato.SemRegras", new DomainErrorMapping(StatusCodes.Status422UnprocessableEntity, "uniplus.selecao.configuracao_derivacao_fato.sem_regras", "A derivação de um fato precisa de ao menos uma regra")),
         new("ConfiguracaoDerivacaoFato.OrdemRegraDuplicada", new DomainErrorMapping(StatusCodes.Status422UnprocessableEntity, "uniplus.selecao.configuracao_derivacao_fato.ordem_regra_duplicada", "Duas regras da mesma derivação têm a mesma ordem")),

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Application/Commands/ProcessosSeletivos/DefinirRegrasDerivacaoCommand.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Application/Commands/ProcessosSeletivos/DefinirRegrasDerivacaoCommand.cs
@@ -1,0 +1,44 @@
+namespace Unifesspa.UniPlus.Selecao.Application.Commands.ProcessosSeletivos;
+
+using System.Text.Json;
+
+using Kernel.Results;
+
+using Unifesspa.UniPlus.Application.Abstractions.Messaging;
+
+/// <summary>
+/// Uma condição do predicado <c>quando</c> de uma regra de derivação — a tripla
+/// <c>{ Fato, Operador, Valor }</c> na forma flat do wire. O <see cref="Operador"/> é o código
+/// canônico UPPER_SNAKE e o <see cref="Valor"/> é o valor JSON já tipado.
+/// </summary>
+public sealed record CondicaoDerivacaoInput(string Fato, string Operador, JsonElement Valor);
+
+/// <summary>
+/// Uma regra de derivação: quando o predicado <see cref="Quando"/> é verdadeiro, a regra contribui
+/// o código <see cref="Contribui"/> para o conjunto derivado. O <see cref="Quando"/> é um predicado
+/// na forma normal disjuntiva — a lista externa é o <b>OU</b> de cláusulas, cada cláusula interna é
+/// o <b>E</b> de condições. A regra <b>âncora</b> (incondicional, sempre verdadeira) é representada
+/// por <see cref="Quando"/> <see langword="null"/> — nunca por uma lista vazia.
+/// </summary>
+public sealed record RegraDerivacaoInput(
+    int Ordem,
+    string Contribui,
+    IReadOnlyList<IReadOnlyList<CondicaoDerivacaoInput>>? Quando);
+
+/// <summary>
+/// A configuração de derivação de um fato: o código do fato derivado e a lista de regras que o
+/// resolvem.
+/// </summary>
+public sealed record ConfiguracaoDerivacaoInput(
+    string CodigoFato,
+    IReadOnlyList<RegraDerivacaoInput> Regras);
+
+/// <summary>
+/// Substitui integralmente as regras que derivam os fatos derivados do processo (Story #985).
+/// Escopo desta Story: edição só em rascunho (pré-publicação) — a edição sob sessão de retificação
+/// é entregue junto do congelamento conjunto da configuração. Por isso o comando não carrega
+/// precondição de concorrência: em rascunho não há sessão editorial nem ETag.
+/// </summary>
+public sealed record DefinirRegrasDerivacaoCommand(
+    Guid ProcessoSeletivoId,
+    IReadOnlyList<ConfiguracaoDerivacaoInput> Configuracoes) : ICommand<Result<MutacaoAceita>>;

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Application/Commands/ProcessosSeletivos/DefinirRegrasDerivacaoCommandHandler.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Application/Commands/ProcessosSeletivos/DefinirRegrasDerivacaoCommandHandler.cs
@@ -1,0 +1,304 @@
+namespace Unifesspa.UniPlus.Selecao.Application.Commands.ProcessosSeletivos;
+
+using Abstractions;
+
+using Domain.Entities;
+using Domain.Enums;
+using Domain.Interfaces;
+using Domain.Services;
+using Domain.ValueObjects;
+
+using Kernel.Results;
+
+using Unifesspa.UniPlus.Configuracao.Contracts;
+
+/// <summary>
+/// Handler do <see cref="DefinirRegrasDerivacaoCommand"/> (Story #985): substitui integralmente as
+/// regras de derivação de um processo em rascunho. Resolve na Application (que tem acesso ao
+/// vocabulário cross-módulo, ADR-0056) a semântica que o domínio não alcança: o fato alvo é
+/// <b>derivado com binding de regra de derivação</b>; cada condição <c>quando</c> valida operador ×
+/// domínio × valor do fato citado, contra a oferta do próprio processo para os domínios dinâmicos;
+/// todo fato citado está disponível na configuração final (coletado ou derivado no processo); e o
+/// código contribuído pertence ao domínio do fato — para <c>MODALIDADE</c>, ao conjunto de
+/// modalidades ofertadas. A validação estrutural (código de fato único) e o guard de rascunho são
+/// do agregado (<see cref="ProcessoSeletivo.DefinirRegrasDerivacao"/>).
+/// </summary>
+public static class DefinirRegrasDerivacaoCommandHandler
+{
+    public static async Task<Result<MutacaoAceita>> Handle(
+        DefinirRegrasDerivacaoCommand command,
+        IProcessoSeletivoRepository processoSeletivoRepository,
+        IFatoCandidatoReader fatoCandidatoReader,
+        ISelecaoUnitOfWork unitOfWork,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(command);
+        ArgumentNullException.ThrowIfNull(processoSeletivoRepository);
+        ArgumentNullException.ThrowIfNull(fatoCandidatoReader);
+        ArgumentNullException.ThrowIfNull(unitOfWork);
+
+        ProcessoSeletivo? processo = await processoSeletivoRepository
+            .ObterParaMutacaoAsync(command.ProcessoSeletivoId, cancellationToken)
+            .ConfigureAwait(false);
+        if (processo is null)
+        {
+            return Result<MutacaoAceita>.Failure(new DomainError(
+                "ProcessoSeletivo.NaoEncontrado",
+                $"Processo Seletivo {command.ProcessoSeletivoId} não encontrado."));
+        }
+
+        // Guard de rascunho ANTES da resolução do vocabulário cross-módulo.
+        if (processo.EdicaoDeRegrasDerivacaoBloqueada() is { } bloqueio)
+        {
+            return Result<MutacaoAceita>.Failure(bloqueio);
+        }
+
+        (IReadOnlyDictionary<string, FatoCandidatoView> catalogo,
+            IReadOnlyDictionary<string, DescritorFatoCandidato> vocabulario) =
+            await ResolverVocabularioAsync(fatoCandidatoReader, cancellationToken).ConfigureAwait(false);
+
+        Dictionary<string, IReadOnlySet<string>> dominiosDinamicos = ResolverDominiosDinamicos(processo);
+        IReadOnlyCollection<string> modalidadesOfertadas =
+            [.. dominiosDinamicos[RegrasDerivacaoModalidadeLei12711.CodigoFato]];
+
+        // Universo dos fatos disponíveis na configuração final: os coletados pelo processo mais os
+        // derivados definidos neste mesmo comando (a substituição é integral). Uma condição só pode
+        // citar um fato deste universo — coerente com a recusa de fato citado inexistente do publish.
+        HashSet<string> universo = new(StringComparer.Ordinal);
+        foreach (FatoColetado fato in processo.FatosColetados)
+        {
+            universo.Add(fato.FatoCodigo);
+        }
+
+        foreach (ConfiguracaoDerivacaoInput configInput in command.Configuracoes)
+        {
+            universo.Add(configInput.CodigoFato);
+        }
+
+        List<ConfiguracaoDerivacaoFato> configuracoes = [];
+        foreach (ConfiguracaoDerivacaoInput configInput in command.Configuracoes)
+        {
+            Result<ConfiguracaoDerivacaoFato> configResult =
+                ResolverConfiguracao(configInput, catalogo, vocabulario, universo, dominiosDinamicos, modalidadesOfertadas);
+            if (configResult.IsFailure)
+            {
+                return Result<MutacaoAceita>.Failure(configResult.Error!);
+            }
+
+            configuracoes.Add(configResult.Value!);
+        }
+
+        Result result = processo.DefinirRegrasDerivacao(configuracoes);
+        if (result.IsFailure)
+        {
+            return Result<MutacaoAceita>.Failure(result.Error!);
+        }
+
+        await unitOfWork.SalvarAlteracoesAsync(cancellationToken).ConfigureAwait(false);
+
+        return Result<MutacaoAceita>.Success(new MutacaoAceita(processo.ETagDaSessaoEditorial));
+    }
+
+    private static Result<ConfiguracaoDerivacaoFato> ResolverConfiguracao(
+        ConfiguracaoDerivacaoInput configInput,
+        IReadOnlyDictionary<string, FatoCandidatoView> catalogo,
+        IReadOnlyDictionary<string, DescritorFatoCandidato> vocabulario,
+        IReadOnlySet<string> universo,
+        IReadOnlyDictionary<string, IReadOnlySet<string>> dominiosDinamicos,
+        IReadOnlyCollection<string> modalidadesOfertadas)
+    {
+        // Alvo: o fato tem de existir e ser derivado com o binding da própria regra de derivação
+        // (REGRA_DERIVACAO:{codigo}). Um fato declarado, ou derivado por outro mecanismo, não tem
+        // regras configuráveis. No vocabulário atual, MODALIDADE é o único alvo válido.
+        if (!catalogo.TryGetValue(configInput.CodigoFato, out FatoCandidatoView? view))
+        {
+            return Result<ConfiguracaoDerivacaoFato>.Failure(new DomainError(
+                DerivabilidadeDeFato.FatoDesconhecido,
+                $"O fato '{configInput.CodigoFato}' não pertence ao vocabulário de fatos do candidato."));
+        }
+
+        if (!DerivabilidadeDeFato.EhAlvoDeDerivacao(view))
+        {
+            return Result<ConfiguracaoDerivacaoFato>.Failure(new DomainError(
+                DerivabilidadeDeFato.FatoNaoDerivavel,
+                $"O fato '{configInput.CodigoFato}' não é um alvo de derivação — só um fato derivado com binding de "
+                + "regra de derivação pode ter regras configuradas."));
+        }
+
+        List<RegraDerivacaoConfigurada> regras = [];
+        foreach (RegraDerivacaoInput regraInput in configInput.Regras)
+        {
+            Result<RegraDerivacaoConfigurada> regraResult =
+                ResolverRegra(regraInput, vocabulario, universo, dominiosDinamicos);
+            if (regraResult.IsFailure)
+            {
+                return Result<ConfiguracaoDerivacaoFato>.Failure(regraResult.Error!);
+            }
+
+            regras.Add(regraResult.Value!);
+        }
+
+        Result<ConfiguracaoDerivacaoFato> configResult = ConfiguracaoDerivacaoFato.Criar(configInput.CodigoFato, regras);
+        if (configResult.IsFailure)
+        {
+            return configResult;
+        }
+
+        // Domínio de contribuição: só MODALIDADE tem domínio validável nesta Story — cada código
+        // contribuído tem de ser uma das modalidades ofertadas pelo processo (mesmo domínio e mesmo
+        // erro do gate de publicação). Um segundo fato derivado com binding de regra, quando existir
+        // no seed, estende esta validação; até lá, a estrutura das regras já foi conferida.
+        if (string.Equals(configInput.CodigoFato, RegrasDerivacaoModalidadeLei12711.CodigoFato, StringComparison.Ordinal))
+        {
+            Result<RegrasDerivacaoFato> dominioResult = configResult.Value!.ParaRegrasDerivacao(modalidadesOfertadas);
+            if (dominioResult.IsFailure)
+            {
+                return Result<ConfiguracaoDerivacaoFato>.Failure(dominioResult.Error!);
+            }
+        }
+
+        return configResult;
+    }
+
+    /// <summary>
+    /// Monta e valida uma regra. A regra <b>âncora</b> (sem condições, sempre verdadeira) tem
+    /// <c>Quando</c> nulo. Cada condição valida a forma (<see cref="CondicaoDnf.Criar"/>) e, no
+    /// conjunto, a semântica do predicado (<see cref="PredicadoDnfValidador"/>) — fato citado no
+    /// vocabulário, disponível na configuração final, operador × domínio, valor × domínio.
+    /// </summary>
+    private static Result<RegraDerivacaoConfigurada> ResolverRegra(
+        RegraDerivacaoInput regraInput,
+        IReadOnlyDictionary<string, DescritorFatoCandidato> vocabulario,
+        IReadOnlySet<string> universo,
+        IReadOnlyDictionary<string, IReadOnlySet<string>> dominiosDinamicos)
+    {
+        List<(int Clausula, CondicaoDnf Condicao)> linhas = [];
+        List<CondicaoRegraDerivacao> condicoes = [];
+        IReadOnlyList<IReadOnlyList<CondicaoDerivacaoInput>> quando = regraInput.Quando ?? [];
+        for (int clausula = 0; clausula < quando.Count; clausula++)
+        {
+            foreach (CondicaoDerivacaoInput condicaoInput in quando[clausula])
+            {
+                // Defesa em profundidade: uma condição nula (JSON `[[null]]`) já é barrada pelo
+                // validator (400), mas nunca deve virar NullReferenceException/500 aqui.
+                if (condicaoInput is null)
+                {
+                    return Result<RegraDerivacaoConfigurada>.Failure(new DomainError(
+                        CondicaoRegraDerivacaoErrorCodes.ClausulaInvalida,
+                        "O predicado da regra contém uma condição nula."));
+                }
+
+                Operador operador = OperadorCodigo.FromCodigo(condicaoInput.Operador);
+
+                Result<CondicaoRegraDerivacao> condicaoResult =
+                    CondicaoRegraDerivacao.Criar(clausula, condicaoInput.Fato, operador, condicaoInput.Valor);
+                if (condicaoResult.IsFailure)
+                {
+                    return Result<RegraDerivacaoConfigurada>.Failure(condicaoResult.Error!);
+                }
+
+                condicoes.Add(condicaoResult.Value!);
+                linhas.Add((clausula, CondicaoDnf.Criar(condicaoInput.Fato, operador, condicaoInput.Valor).Value!));
+            }
+        }
+
+        if (linhas.Count > 0)
+        {
+            Result<PredicadoDnf> predicadoResult = PredicadoDnf.CriarDeCondicoesAgrupadas(linhas);
+            if (predicadoResult.IsFailure)
+            {
+                return Result<RegraDerivacaoConfigurada>.Failure(predicadoResult.Error!);
+            }
+
+            Result validacao = PredicadoDnfValidador.Validar(predicadoResult.Value!, vocabulario, universo, dominiosDinamicos);
+            if (validacao.IsFailure)
+            {
+                return Result<RegraDerivacaoConfigurada>.Failure(validacao.Error!);
+            }
+        }
+
+        return RegraDerivacaoConfigurada.Criar(regraInput.Ordem, regraInput.Contribui, condicoes);
+    }
+
+    private static async Task<(
+        IReadOnlyDictionary<string, FatoCandidatoView> Catalogo,
+        IReadOnlyDictionary<string, DescritorFatoCandidato> Vocabulario)> ResolverVocabularioAsync(
+        IFatoCandidatoReader fatoCandidatoReader, CancellationToken cancellationToken)
+    {
+        IReadOnlyList<FatoCandidatoView> fatos = await fatoCandidatoReader
+            .ListarAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        Dictionary<string, FatoCandidatoView> catalogo = new(StringComparer.Ordinal);
+        Dictionary<string, DescritorFatoCandidato> vocabulario = new(StringComparer.Ordinal);
+        foreach (FatoCandidatoView fato in fatos)
+        {
+            catalogo[fato.Codigo] = fato;
+
+            TipoDominioFato? tipoDominio = fato switch
+            {
+                { Dominio: "BOOLEANO" } => TipoDominioFato.Booleano,
+                { Dominio: "NUMERICO" } => TipoDominioFato.Numerico,
+                { Dominio: "CATEGORICO", ValoresDominio.Count: > 0 } => TipoDominioFato.CategoricoEstatico,
+                { Dominio: "CATEGORICO", ValoresDominio: null } => TipoDominioFato.CategoricoDinamico,
+                _ => null,
+            };
+
+            if (tipoDominio is not { } tipo)
+            {
+                continue;
+            }
+
+            Result<DescritorFatoCandidato> descritorResult = DescritorFatoCandidato.Criar(fato.Codigo, tipo, fato.ValoresDominio);
+            if (descritorResult.IsSuccess)
+            {
+                vocabulario[fato.Codigo] = descritorResult.Value!;
+            }
+        }
+
+        return (catalogo, vocabulario);
+    }
+
+    private static Dictionary<string, IReadOnlySet<string>> ResolverDominiosDinamicos(ProcessoSeletivo processo)
+    {
+        HashSet<string> modalidades = [.. processo.DistribuicaoVagas
+            .SelectMany(static d => d.Modalidades)
+            .Select(static m => m.Codigo)];
+
+        HashSet<string> condicoesAtendimento = [.. (processo.OfertaAtendimento?.Condicoes ?? [])
+            .Select(static c => c.CondicaoCodigo)];
+
+        HashSet<string> tiposDeficiencia = [.. (processo.OfertaAtendimento?.TiposDeficiencia ?? [])
+            .Select(static t => t.TipoDeficienciaNome)];
+
+        return new Dictionary<string, IReadOnlySet<string>>(StringComparer.Ordinal)
+        {
+            [RegrasDerivacaoModalidadeLei12711.CodigoFato] = modalidades,
+            ["CONDICAO_ATENDIMENTO"] = condicoesAtendimento,
+            ["TIPO_DEFICIENCIA"] = tiposDeficiencia,
+        };
+    }
+}
+
+/// <summary>
+/// Política de derivabilidade de um fato (Story #985). Só pode ter regras de derivação configuradas
+/// o fato de <c>Origem = DERIVADO</c> cujo binding é o da própria regra de derivação
+/// (<c>REGRA_DERIVACAO:{codigo}</c>). Um fato declarado, ou derivado por outro mecanismo (ex.:
+/// computado de atributo do candidato), não é alvo de configuração de regras.
+/// </summary>
+internal static class DerivabilidadeDeFato
+{
+    public const string FatoDesconhecido = "ConfiguracaoDerivacaoFato.FatoDesconhecido";
+    public const string FatoNaoDerivavel = "ConfiguracaoDerivacaoFato.FatoNaoDerivavel";
+
+    private const string OrigemDerivado = "DERIVADO";
+    private const string PrefixoBindingRegraDerivacao = "REGRA_DERIVACAO:";
+
+    public static bool EhAlvoDeDerivacao(FatoCandidatoView fato)
+    {
+        ArgumentNullException.ThrowIfNull(fato);
+
+        return string.Equals(fato.Origem, OrigemDerivado, StringComparison.Ordinal)
+            && string.Equals(fato.Binding, PrefixoBindingRegraDerivacao + fato.Codigo, StringComparison.Ordinal);
+    }
+}

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Application/Validators/ProcessosSeletivos/DefinirRegrasDerivacaoCommandValidator.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Application/Validators/ProcessosSeletivos/DefinirRegrasDerivacaoCommandValidator.cs
@@ -1,0 +1,60 @@
+namespace Unifesspa.UniPlus.Selecao.Application.Validators.ProcessosSeletivos;
+
+using Commands.ProcessosSeletivos;
+
+using FluentValidation;
+
+public sealed class DefinirRegrasDerivacaoCommandValidator : AbstractValidator<DefinirRegrasDerivacaoCommand>
+{
+    public DefinirRegrasDerivacaoCommandValidator()
+    {
+        RuleFor(x => x.ProcessoSeletivoId)
+            .NotEmpty()
+            .WithMessage("ProcessoSeletivoId é obrigatório.");
+
+        // Lista obrigatória, mas pode ser vazia — vazia zera as regras de derivação do processo.
+        RuleFor(x => x.Configuracoes)
+            .NotNull()
+            .WithMessage("Lista de configurações de derivação é obrigatória (pode ser vazia).");
+
+        RuleForEach(x => x.Configuracoes)
+            .NotNull()
+            .WithMessage("Item de configuração de derivação não pode ser nulo.");
+
+        RuleForEach(x => x.Configuracoes).ChildRules(config =>
+        {
+            config.RuleFor(c => c.CodigoFato)
+                .NotEmpty()
+                .WithMessage("O código do fato derivado é obrigatório.");
+
+            config.RuleFor(c => c.Regras)
+                .NotEmpty()
+                .WithMessage("A derivação de um fato precisa de ao menos uma regra.");
+
+            config.RuleForEach(c => c.Regras)
+                .NotNull()
+                .WithMessage("Item de regra de derivação não pode ser nulo.");
+
+            config.RuleForEach(c => c.Regras).ChildRules(regra =>
+            {
+                regra.RuleFor(r => r.Ordem)
+                    .GreaterThanOrEqualTo(0)
+                    .WithMessage("A ordem da regra não pode ser negativa.");
+
+                regra.RuleFor(r => r.Contribui)
+                    .NotEmpty()
+                    .WithMessage("Uma regra de derivação precisa contribuir um código.");
+
+                // Regra âncora (incondicional) tem Quando null. Uma lista externa vazia, uma
+                // cláusula interna vazia ou uma condição nula deixariam a semântica DNF ambígua ou
+                // fariam o handler desreferenciar um item nulo — a âncora é representada por null.
+                regra.RuleFor(r => r.Quando)
+                    .Must(quando => quando is null
+                        || (quando.Count > 0 && quando.All(static clausula =>
+                            clausula is { Count: > 0 } && clausula.All(static condicao => condicao is not null))))
+                    .WithMessage("O predicado 'quando', quando presente, não pode ser uma lista vazia, conter "
+                        + "cláusulas vazias ou condições nulas — uma regra incondicional (âncora) tem 'quando' null.");
+            });
+        });
+    }
+}

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Domain/Entities/ProcessoSeletivo.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Domain/Entities/ProcessoSeletivo.cs
@@ -982,16 +982,28 @@ public sealed class ProcessoSeletivo : SoftDeletableEntity
     /// com binding de regra; fatos citados e código contribuído no vocabulário e no domínio) depende
     /// de dados cross-módulo e é do comando na Application.
     /// </remarks>
+    /// <summary>
+    /// Guard não-mutante da edição das regras de derivação: devolve o erro de "só em rascunho"
+    /// quando o processo já foi publicado, ou <see langword="null"/> quando a edição é permitida.
+    /// Existe para que a Application possa recusar a operação <b>antes</b> de resolver o vocabulário
+    /// cross-módulo e validar o corpo — o mesmo guard continua dentro de
+    /// <see cref="DefinirRegrasDerivacao"/>, esta antecipação dá a ordem, não a garantia.
+    /// </summary>
+    public DomainError? EdicaoDeRegrasDerivacaoBloqueada() =>
+        Status != StatusProcesso.Rascunho
+            ? new DomainError(
+                "ProcessoSeletivo.RegrasDerivacaoSomenteEmRascunho",
+                "As regras de derivação só podem ser definidas antes da primeira publicação — "
+                + "a edição sob retificação depende do congelamento conjunto da configuração (#928).")
+            : null;
+
     public Result DefinirRegrasDerivacao(IReadOnlyList<ConfiguracaoDerivacaoFato> regrasDerivacao)
     {
         ArgumentNullException.ThrowIfNull(regrasDerivacao);
 
-        if (Status != StatusProcesso.Rascunho)
+        if (EdicaoDeRegrasDerivacaoBloqueada() is { } bloqueio)
         {
-            return Result.Failure(new DomainError(
-                "ProcessoSeletivo.RegrasDerivacaoSomenteEmRascunho",
-                "As regras de derivação só podem ser definidas antes da primeira publicação — "
-                + "a edição sob retificação depende do congelamento conjunto da configuração (#928)."));
+            return Result.Failure(bloqueio);
         }
 
         HashSet<string> codigos = new(StringComparer.Ordinal);

--- a/tests/Unifesspa.UniPlus.Selecao.Application.UnitTests/Commands/DefinirRegrasDerivacaoCommandHandlerTests.cs
+++ b/tests/Unifesspa.UniPlus.Selecao.Application.UnitTests/Commands/DefinirRegrasDerivacaoCommandHandlerTests.cs
@@ -1,0 +1,211 @@
+namespace Unifesspa.UniPlus.Selecao.Application.UnitTests.Commands;
+
+using System.Text.Json;
+
+using AwesomeAssertions;
+
+using NSubstitute;
+
+using Unifesspa.UniPlus.Configuracao.Contracts;
+using Unifesspa.UniPlus.Kernel.Results;
+using Unifesspa.UniPlus.Selecao.Application.Abstractions;
+using Unifesspa.UniPlus.Selecao.Application.Commands.ProcessosSeletivos;
+using Unifesspa.UniPlus.Selecao.Domain.Entities;
+using Unifesspa.UniPlus.Selecao.Domain.Enums;
+using Unifesspa.UniPlus.Selecao.Domain.Interfaces;
+using Unifesspa.UniPlus.Selecao.Domain.ValueObjects;
+
+/// <summary>
+/// Cobertura do <see cref="DefinirRegrasDerivacaoCommandHandler"/> (Story #985): o alvo derivado
+/// com binding de regra, a semântica das condições <c>quando</c> contra o vocabulário e a oferta do
+/// processo, o domínio de contribuição de MODALIDADE, e a delegação estrutural ao agregado.
+/// </summary>
+public sealed class DefinirRegrasDerivacaoCommandHandlerTests
+{
+    private const string HashFixo = "ab01234567ab01234567ab01234567ab01234567ab01234567ab01234567ab01";
+
+    private sealed record Mocks(
+        IProcessoSeletivoRepository Repository,
+        IFatoCandidatoReader FatoCandidatoReader,
+        ISelecaoUnitOfWork UnitOfWork);
+
+    private static Mocks NovosMocks(ProcessoSeletivo? processo, Guid processoId)
+    {
+        IProcessoSeletivoRepository repository = Substitute.For<IProcessoSeletivoRepository>();
+        repository.ObterParaMutacaoAsync(processoId, Arg.Any<CancellationToken>()).Returns(processo);
+
+        Mocks mocks = new(repository, Substitute.For<IFatoCandidatoReader>(), Substitute.For<ISelecaoUnitOfWork>());
+        mocks.FatoCandidatoReader.ListarAsync(Arg.Any<CancellationToken>()).Returns(VocabularioSeed());
+        return mocks;
+    }
+
+    private static Task<Result<MutacaoAceita>> HandleAsync(Mocks mocks, DefinirRegrasDerivacaoCommand command) =>
+        DefinirRegrasDerivacaoCommandHandler.Handle(
+            command, mocks.Repository, mocks.FatoCandidatoReader, mocks.UnitOfWork, CancellationToken.None);
+
+    private static IReadOnlyList<FatoCandidatoView> VocabularioSeed() =>
+    [
+        new(Guid.CreateVersion7(), "COR_RACA", "Cor ou raça", null, "CATEGORICO", "DECLARADO", "ESCALAR",
+            ["BRANCA", "PRETA", "PARDA", "AMARELA", "INDIGENA", "NAO_INFORMADO"], "INSCRICAO", "CAMPO_INSCRICAO:COR_RACA", null),
+        new(Guid.CreateVersion7(), "BAIXA_RENDA", "Baixa renda", null, "BOOLEANO", "DECLARADO", "ESCALAR",
+            null, "INSCRICAO", "CAMPO_INSCRICAO:BAIXA_RENDA", null),
+        new(Guid.CreateVersion7(), "MODALIDADE", "Modalidade", null, "CATEGORICO", "DERIVADO", "MULTIVALORADO",
+            null, "INSCRICAO", "REGRA_DERIVACAO:MODALIDADE", null),
+    ];
+
+    private static ProcessoSeletivo ProcessoBase() =>
+        ProcessoSeletivo.Criar("PS Regras", TipoProcesso.SiSU, OrigemCandidatos.InscricaoPropria);
+
+    /// <summary>Processo em rascunho que oferta a modalidade AC e coleta COR_RACA — o mínimo para uma derivação de MODALIDADE válida.</summary>
+    private static ProcessoSeletivo ProcessoComModalidadeAcEColeta()
+    {
+        ProcessoSeletivo processo = ProcessoBase();
+
+        processo.DefinirFatosColetados([FatoColetado.Criar("COR_RACA", 0, null).Value!])
+            .IsSuccess.Should().BeTrue();
+
+        ReferenciaRegra regraDistribuicao = ReferenciaRegra.Criar(
+            RegraDistribuicaoVagasCodigo.Institucional, "v1", HashFixo).Value!;
+        ModalidadeSelecionada ac = ModalidadeSelecionada.Criar(
+            modalidadeOrigemId: Guid.CreateVersion7(),
+            codigo: "AC",
+            descricao: "Ampla concorrência",
+            naturezaLegal: NaturezaLegalModalidade.Ampla,
+            composicaoVagas: ComposicaoVagasModalidade.ResidualDoVo,
+            composicaoOrigemCodigo: null,
+            regraRemanejamento: RegraRemanejamentoModalidade.Nenhuma,
+            remanejamentoDestino: null,
+            remanejamentoPar: null,
+            remanejamentoFallback: null,
+            criteriosCumulativos: [],
+            acaoQuandoIndeferido: null,
+            baseLegal: "Res. Unifesspa 532/2021",
+            quantidadeDeclarada: 40).Value!;
+        ConfiguracaoDistribuicaoVagas distribuicao = ConfiguracaoDistribuicaoVagas.Criar(
+            ofertaCursoOrigemId: Guid.CreateVersion7(),
+            voBase: 40,
+            pr: 1m,
+            regraDistribuicao: regraDistribuicao,
+            regraAjuste: null,
+            referenciaDemografica: null,
+            modalidades: [ac]).Value!;
+        processo.DefinirDistribuicaoVagas([distribuicao], PrecondicaoIfMatch.Ausente).IsSuccess.Should().BeTrue();
+
+        return processo;
+    }
+
+    private static CondicaoDerivacaoInput Condicao(string fato, string operador, object valor) =>
+        new(fato, operador, JsonSerializer.SerializeToElement(valor));
+
+    private static ConfiguracaoDerivacaoInput ConfigModalidade(params RegraDerivacaoInput[] regras) =>
+        new("MODALIDADE", regras);
+
+    [Fact(DisplayName = "Processo inexistente retorna ProcessoSeletivo.NaoEncontrado")]
+    public async Task Handle_ProcessoInexistente_RetornaNaoEncontrado()
+    {
+        Guid processoId = Guid.CreateVersion7();
+        Mocks mocks = NovosMocks(processo: null, processoId);
+
+        Result<MutacaoAceita> resultado = await HandleAsync(mocks, new DefinirRegrasDerivacaoCommand(processoId, []));
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be("ProcessoSeletivo.NaoEncontrado");
+    }
+
+    [Fact(DisplayName = "Derivação de MODALIDADE válida (âncora + condicional) é aceita e persistida")]
+    public async Task Handle_DerivacaoValida_DefineEPersiste()
+    {
+        ProcessoSeletivo processo = ProcessoComModalidadeAcEColeta();
+        Mocks mocks = NovosMocks(processo, processo.Id);
+
+        DefinirRegrasDerivacaoCommand command = new(processo.Id,
+        [
+            ConfigModalidade(
+                new RegraDerivacaoInput(0, "AC", null),
+                new RegraDerivacaoInput(1, "AC", [[Condicao("COR_RACA", "IGUAL", "PRETA")]])),
+        ]);
+
+        Result<MutacaoAceita> resultado = await HandleAsync(mocks, command);
+
+        resultado.IsSuccess.Should().BeTrue(resultado.Error?.Message);
+        resultado.Value!.ETag.Should().BeNull("em rascunho não há sessão editorial nem ETag");
+        processo.RegrasDerivacao.Should().ContainSingle(c => c.CodigoFato == "MODALIDADE");
+        await mocks.UnitOfWork.Received(1).SalvarAlteracoesAsync(Arg.Any<CancellationToken>());
+    }
+
+    [Fact(DisplayName = "Fato alvo fora do vocabulário é recusado como desconhecido")]
+    public async Task Handle_AlvoDesconhecido_Retorna422()
+    {
+        ProcessoSeletivo processo = ProcessoBase();
+        Mocks mocks = NovosMocks(processo, processo.Id);
+        DefinirRegrasDerivacaoCommand command = new(processo.Id,
+            [new ConfiguracaoDerivacaoInput("BOGUS", [new RegraDerivacaoInput(0, "AC", null)])]);
+
+        Result<MutacaoAceita> resultado = await HandleAsync(mocks, command);
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be("ConfiguracaoDerivacaoFato.FatoDesconhecido");
+    }
+
+    [Fact(DisplayName = "Fato alvo declarado (não derivável) é recusado")]
+    public async Task Handle_AlvoDeclarado_RetornaNaoDerivavel()
+    {
+        ProcessoSeletivo processo = ProcessoBase();
+        Mocks mocks = NovosMocks(processo, processo.Id);
+        DefinirRegrasDerivacaoCommand command = new(processo.Id,
+            [new ConfiguracaoDerivacaoInput("COR_RACA", [new RegraDerivacaoInput(0, "PRETA", null)])]);
+
+        Result<MutacaoAceita> resultado = await HandleAsync(mocks, command);
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be("ConfiguracaoDerivacaoFato.FatoNaoDerivavel");
+    }
+
+    [Fact(DisplayName = "Contribui fora das modalidades ofertadas é recusado com ContribuiForaDoDominio")]
+    public async Task Handle_ContribuiForaDoDominio_Recusa()
+    {
+        ProcessoSeletivo processo = ProcessoComModalidadeAcEColeta();
+        Mocks mocks = NovosMocks(processo, processo.Id);
+
+        // "V" não é uma modalidade ofertada (só AC é).
+        DefinirRegrasDerivacaoCommand command = new(processo.Id,
+            [ConfigModalidade(new RegraDerivacaoInput(0, "V", null))]);
+
+        Result<MutacaoAceita> resultado = await HandleAsync(mocks, command);
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be("RegrasDerivacaoFato.ContribuiForaDoDominio");
+    }
+
+    [Fact(DisplayName = "Condição 'quando' que cita fato não disponível na configuração é recusada")]
+    public async Task Handle_QuandoCitaFatoIndisponivel_Recusa()
+    {
+        ProcessoSeletivo processo = ProcessoComModalidadeAcEColeta();
+        Mocks mocks = NovosMocks(processo, processo.Id);
+
+        // BAIXA_RENDA existe no vocabulário mas não é coletado nem derivado neste processo.
+        DefinirRegrasDerivacaoCommand command = new(processo.Id,
+            [ConfigModalidade(new RegraDerivacaoInput(0, "AC", [[Condicao("BAIXA_RENDA", "IGUAL", true)]]))]);
+
+        Result<MutacaoAceita> resultado = await HandleAsync(mocks, command);
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be("PredicadoDnf.FatoNaoColetadoPeloProcesso");
+    }
+
+    [Fact(DisplayName = "Condição 'quando' com operador incompatível com o domínio do fato citado é recusada")]
+    public async Task Handle_QuandoOperadorIncompativel_Recusa()
+    {
+        ProcessoSeletivo processo = ProcessoComModalidadeAcEColeta();
+        Mocks mocks = NovosMocks(processo, processo.Id);
+
+        // COR_RACA é categórico: MAIOR_IGUAL não se aplica.
+        DefinirRegrasDerivacaoCommand command = new(processo.Id,
+            [ConfigModalidade(new RegraDerivacaoInput(0, "AC", [[Condicao("COR_RACA", "MAIOR_IGUAL", "PRETA")]]))]);
+
+        Result<MutacaoAceita> resultado = await HandleAsync(mocks, command);
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be("PredicadoDnf.OperadorIncompativelComDominio");
+    }
+}

--- a/tests/Unifesspa.UniPlus.Selecao.Application.UnitTests/Validators/DefinirRegrasDerivacaoCommandValidatorTests.cs
+++ b/tests/Unifesspa.UniPlus.Selecao.Application.UnitTests/Validators/DefinirRegrasDerivacaoCommandValidatorTests.cs
@@ -1,0 +1,110 @@
+namespace Unifesspa.UniPlus.Selecao.Application.UnitTests.Validators;
+
+using System.Text.Json;
+
+using AwesomeAssertions;
+
+using FluentValidation.Results;
+
+using Unifesspa.UniPlus.Selecao.Application.Commands.ProcessosSeletivos;
+using Unifesspa.UniPlus.Selecao.Application.Validators.ProcessosSeletivos;
+
+public sealed class DefinirRegrasDerivacaoCommandValidatorTests
+{
+    private static readonly DefinirRegrasDerivacaoCommandValidator Validator = new();
+
+    private static CondicaoDerivacaoInput Condicao() =>
+        new("COR_RACA", "IGUAL", JsonSerializer.SerializeToElement("PRETA"));
+
+    private static DefinirRegrasDerivacaoCommand Comando(params RegraDerivacaoInput[] regras) =>
+        new(Guid.CreateVersion7(), [new ConfiguracaoDerivacaoInput("MODALIDADE", regras)]);
+
+    [Fact(DisplayName = "Passa com lista de configurações vazia — zera as regras")]
+    public void Aceita_ListaVazia()
+    {
+        ValidationResult result = Validator.Validate(new DefinirRegrasDerivacaoCommand(Guid.CreateVersion7(), []));
+
+        result.IsValid.Should().BeTrue();
+    }
+
+    [Fact(DisplayName = "Passa com regra âncora (Quando null)")]
+    public void Aceita_RegraAncora()
+    {
+        ValidationResult result = Validator.Validate(Comando(new RegraDerivacaoInput(0, "AC", null)));
+
+        result.IsValid.Should().BeTrue();
+    }
+
+    [Fact(DisplayName = "Passa com regra condicional bem-formada")]
+    public void Aceita_RegraCondicional()
+    {
+        ValidationResult result = Validator.Validate(Comando(new RegraDerivacaoInput(0, "AC", [[Condicao()]])));
+
+        result.IsValid.Should().BeTrue();
+    }
+
+    [Fact(DisplayName = "Falha quando a lista de configurações é nula")]
+    public void Rejeita_ConfiguracoesNulo()
+    {
+        ValidationResult result = Validator.Validate(new DefinirRegrasDerivacaoCommand(Guid.CreateVersion7(), null!));
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.PropertyName == "Configuracoes");
+    }
+
+    [Fact(DisplayName = "Falha quando o código do fato é vazio")]
+    public void Rejeita_CodigoFatoVazio()
+    {
+        ValidationResult result = Validator.Validate(new DefinirRegrasDerivacaoCommand(
+            Guid.CreateVersion7(), [new ConfiguracaoDerivacaoInput("", [new RegraDerivacaoInput(0, "AC", null)])]));
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.PropertyName == "Configuracoes[0].CodigoFato");
+    }
+
+    [Fact(DisplayName = "Falha quando a configuração não tem regra alguma")]
+    public void Rejeita_SemRegras()
+    {
+        ValidationResult result = Validator.Validate(new DefinirRegrasDerivacaoCommand(
+            Guid.CreateVersion7(), [new ConfiguracaoDerivacaoInput("MODALIDADE", [])]));
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.PropertyName == "Configuracoes[0].Regras");
+    }
+
+    [Fact(DisplayName = "Falha quando a ordem da regra é negativa")]
+    public void Rejeita_OrdemNegativa()
+    {
+        ValidationResult result = Validator.Validate(Comando(new RegraDerivacaoInput(-1, "AC", null)));
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.PropertyName == "Configuracoes[0].Regras[0].Ordem");
+    }
+
+    [Fact(DisplayName = "Falha quando contribui é vazio")]
+    public void Rejeita_ContribuiVazio()
+    {
+        ValidationResult result = Validator.Validate(Comando(new RegraDerivacaoInput(0, "", null)));
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.PropertyName == "Configuracoes[0].Regras[0].Contribui");
+    }
+
+    [Fact(DisplayName = "Falha quando o 'quando' presente é uma lista externa vazia (âncora é null)")]
+    public void Rejeita_QuandoListaExternaVazia()
+    {
+        ValidationResult result = Validator.Validate(Comando(new RegraDerivacaoInput(0, "AC", [])));
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.PropertyName == "Configuracoes[0].Regras[0].Quando");
+    }
+
+    [Fact(DisplayName = "Falha quando o 'quando' tem uma condição nula ([[null]])")]
+    public void Rejeita_QuandoCondicaoNula()
+    {
+        ValidationResult result = Validator.Validate(Comando(new RegraDerivacaoInput(0, "AC", [[null!]])));
+
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.PropertyName == "Configuracoes[0].Regras[0].Quando");
+    }
+}

--- a/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/Outbox/Cascading/DefinirRegrasDerivacaoEndpointTests.cs
+++ b/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/Outbox/Cascading/DefinirRegrasDerivacaoEndpointTests.cs
@@ -22,6 +22,7 @@ using Unifesspa.UniPlus.Selecao.Infrastructure.Persistence;
 /// rascunho e a autorização.
 /// </summary>
 [Collection(CascadingCollection.Name)]
+[Trait("Category", "Integration")]
 [Trait("Category", "OutboxCapability")]
 [Trait("Category", "OutboxCascading")]
 public sealed class DefinirRegrasDerivacaoEndpointTests

--- a/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/Outbox/Cascading/DefinirRegrasDerivacaoEndpointTests.cs
+++ b/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/Outbox/Cascading/DefinirRegrasDerivacaoEndpointTests.cs
@@ -1,0 +1,276 @@
+namespace Unifesspa.UniPlus.Selecao.IntegrationTests.Outbox.Cascading;
+
+using System.Globalization;
+using System.Net;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+
+using AwesomeAssertions;
+
+using Domain.Entities;
+
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+
+using Unifesspa.UniPlus.IntegrationTests.Fixtures.Authentication;
+using Unifesspa.UniPlus.Selecao.Infrastructure.Persistence;
+
+/// <summary>
+/// O endpoint <c>PUT /processos-seletivos/{id}/regras-derivacao</c> (Story #985), fim a fim pelo
+/// HTTP. Prova o alvo derivado, a validação do <c>contribui</c> contra as modalidades ofertadas
+/// pelo processo, a composição com a coleta de fatos (a condição cita um fato coletado), o guard de
+/// rascunho e a autorização.
+/// </summary>
+[Collection(CascadingCollection.Name)]
+[Trait("Category", "OutboxCapability")]
+[Trait("Category", "OutboxCascading")]
+public sealed class DefinirRegrasDerivacaoEndpointTests
+{
+    private readonly CascadingFixture _fixture;
+
+    public DefinirRegrasDerivacaoEndpointTests(CascadingFixture fixture) => _fixture = fixture;
+
+    [Fact(DisplayName = "Derivação de MODALIDADE válida (âncora + condicional citando fato coletado) é aceita com 204 e persiste")]
+    public async Task Rascunho_DerivacaoValida_204()
+    {
+        Contexto ctx = await SemearRascunhoAsync(nameof(Rascunho_DerivacaoValida_204));
+
+        // A condição cita COR_RACA — precisa estar coletado no processo.
+        (await ctx.PutFatosAsync([new { fatoCodigo = "COR_RACA", ordem = 0, precondicao = (object?)null }]))
+            .StatusCode.Should().Be(HttpStatusCode.NoContent);
+
+        object[] corpo =
+        [
+            new
+            {
+                codigoFato = "MODALIDADE",
+                regras = new object[]
+                {
+                    new { ordem = 0, contribui = "AC", quando = (object?)null },
+                    new
+                    {
+                        ordem = 1,
+                        contribui = "AC",
+                        quando = new[] { new[] { new { fato = "COR_RACA", operador = "IGUAL", valor = "PRETA" } } },
+                    },
+                },
+            },
+        ];
+
+        HttpResponseMessage resposta = await ctx.PutRegrasAsync(corpo);
+
+        resposta.StatusCode.Should().Be(HttpStatusCode.NoContent);
+        resposta.Headers.ETag.Should().BeNull("em rascunho não há sessão editorial nem ETag");
+
+        await using AsyncServiceScope scope = ctx.Api.Services.CreateAsyncScope();
+        SelecaoDbContext db = scope.ServiceProvider.GetRequiredService<SelecaoDbContext>();
+        List<ConfiguracaoDerivacaoFato> configs = await db.Set<ConfiguracaoDerivacaoFato>().AsNoTracking()
+            .Where(c => c.ProcessoSeletivoId == ctx.ProcessoId).ToListAsync();
+        configs.Select(c => c.CodigoFato).Should().BeEquivalentTo(["MODALIDADE"]);
+    }
+
+    [Fact(DisplayName = "Contribui fora das modalidades ofertadas é recusado com 422")]
+    public async Task Rascunho_ContribuiForaDoDominio_422()
+    {
+        Contexto ctx = await SemearRascunhoAsync(nameof(Rascunho_ContribuiForaDoDominio_422));
+
+        object[] corpo =
+        [
+            new
+            {
+                codigoFato = "MODALIDADE",
+                regras = new object[] { new { ordem = 0, contribui = "V", quando = (object?)null } },
+            },
+        ];
+
+        HttpResponseMessage resposta = await ctx.PutRegrasAsync(corpo);
+
+        resposta.StatusCode.Should().Be(HttpStatusCode.UnprocessableEntity);
+    }
+
+    [Fact(DisplayName = "Alvo declarado (não derivável) é recusado com 422")]
+    public async Task Rascunho_AlvoNaoDerivavel_422()
+    {
+        Contexto ctx = await SemearRascunhoAsync(nameof(Rascunho_AlvoNaoDerivavel_422));
+
+        object[] corpo =
+        [
+            new
+            {
+                codigoFato = "COR_RACA",
+                regras = new object[] { new { ordem = 0, contribui = "PRETA", quando = (object?)null } },
+            },
+        ];
+
+        HttpResponseMessage resposta = await ctx.PutRegrasAsync(corpo);
+
+        resposta.StatusCode.Should().Be(HttpStatusCode.UnprocessableEntity);
+    }
+
+    [Fact(DisplayName = "Redefinir as regras de um processo publicado é recusado com 422 (só em rascunho)")]
+    public async Task Publicado_Recusa_422()
+    {
+        Contexto ctx = await SemearRascunhoAsync(nameof(Publicado_Recusa_422));
+        await ctx.PublicarAsync();
+
+        object[] corpo =
+        [
+            new
+            {
+                codigoFato = "MODALIDADE",
+                regras = new object[] { new { ordem = 0, contribui = "AC", quando = (object?)null } },
+            },
+        ];
+
+        HttpResponseMessage resposta = await ctx.PutRegrasAsync(corpo);
+
+        resposta.StatusCode.Should().Be(HttpStatusCode.UnprocessableEntity);
+    }
+
+    [Fact(DisplayName = "Replay com a mesma Idempotency-Key e o mesmo corpo devolve o mesmo 204")]
+    public async Task Rascunho_ReplayIdempotente_204()
+    {
+        Contexto ctx = await SemearRascunhoAsync(nameof(Rascunho_ReplayIdempotente_204));
+        object[] corpo =
+        [
+            new
+            {
+                codigoFato = "MODALIDADE",
+                regras = new object[] { new { ordem = 0, contribui = "AC", quando = (object?)null } },
+            },
+        ];
+        string chave = MakeIdempotencyKey();
+
+        (await ctx.PutRegrasAsync(corpo, idempotencyKey: chave)).StatusCode.Should().Be(HttpStatusCode.NoContent);
+        HttpResponseMessage replay = await ctx.PutRegrasAsync(corpo, idempotencyKey: chave);
+
+        replay.StatusCode.Should().Be(HttpStatusCode.NoContent);
+        replay.Headers.Contains("Idempotency-Replayed").Should().BeTrue();
+    }
+
+    [Fact(DisplayName = "Sem autenticação é 401")]
+    public async Task SemAutenticacao_401()
+    {
+        Contexto ctx = await SemearRascunhoAsync(nameof(SemAutenticacao_401));
+
+        HttpResponseMessage resposta = await ctx.PutRegrasAsync(
+            [new { codigoFato = "MODALIDADE", regras = new object[] { new { ordem = 0, contribui = "AC", quando = (object?)null } } }],
+            autenticar: Autenticacao.Nenhuma);
+
+        resposta.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+
+    [Fact(DisplayName = "Autenticado sem o papel plataforma-admin é 403")]
+    public async Task SemPapel_403()
+    {
+        Contexto ctx = await SemearRascunhoAsync(nameof(SemPapel_403));
+
+        HttpResponseMessage resposta = await ctx.PutRegrasAsync(
+            [new { codigoFato = "MODALIDADE", regras = new object[] { new { ordem = 0, contribui = "AC", quando = (object?)null } } }],
+            autenticar: Autenticacao.PapelErrado);
+
+        resposta.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+    }
+
+    private enum Autenticacao
+    {
+        PlataformaAdmin,
+        PapelErrado,
+        Nenhuma,
+    }
+
+    private sealed record Contexto(CascadingApiFactory Api, HttpClient Client, Guid ProcessoId, Guid DocumentoId)
+    {
+        public Task<HttpResponseMessage> PutFatosAsync(IReadOnlyList<object> corpo) =>
+            EnviarAsync(HttpMethod.Put, "fatos-coletados", corpo, MakeIdempotencyKey(), Autenticacao.PlataformaAdmin);
+
+        public Task<HttpResponseMessage> PutRegrasAsync(
+            IReadOnlyList<object> corpo, string? idempotencyKey = null, Autenticacao autenticar = Autenticacao.PlataformaAdmin) =>
+            EnviarAsync(HttpMethod.Put, "regras-derivacao", corpo, idempotencyKey ?? MakeIdempotencyKey(), autenticar);
+
+        private async Task<HttpResponseMessage> EnviarAsync(
+            HttpMethod metodo, string recurso, object corpo, string idempotencyKey, Autenticacao autenticar)
+        {
+            using HttpRequestMessage request = new(
+                metodo,
+                new Uri($"/api/selecao/processos-seletivos/{ProcessoId}/{recurso}", UriKind.Relative))
+            {
+                Content = JsonContent.Create(corpo),
+            };
+            Autenticar(request, autenticar);
+            request.Headers.TryAddWithoutValidation("Idempotency-Key", idempotencyKey);
+            return await Client.SendAsync(request).ConfigureAwait(false);
+        }
+
+        public async Task PublicarAsync()
+        {
+            using HttpRequestMessage publicar = new(
+                HttpMethod.Post,
+                new Uri($"/api/selecao/processos-seletivos/{ProcessoId}/publicacao", UriKind.Relative))
+            {
+                Content = JsonContent.Create(new
+                {
+                    numero = "001/2026",
+                    periodoInscricaoInicio = Hoje(),
+                    periodoInscricaoFim = HojeMais(30),
+                    documentoEditalId = DocumentoId,
+                    ato = new
+                    {
+                        orgao = "CEPS",
+                        serie = "EDITAL",
+                        ano = 2026,
+                        dataPublicacao = Hoje(),
+                        assinante = "Diretor do CEPS",
+                        tipoAtoCodigo = "EDITAL_ABERTURA",
+                    },
+                }),
+            };
+            Autenticar(publicar, Autenticacao.PlataformaAdmin);
+            publicar.Headers.TryAddWithoutValidation("Idempotency-Key", MakeIdempotencyKey());
+            HttpResponseMessage resposta = await Client.SendAsync(publicar).ConfigureAwait(false);
+            resposta.StatusCode.Should().Be(HttpStatusCode.NoContent, "o cenário depende de um certame publicado");
+        }
+    }
+
+    private async Task<Contexto> SemearRascunhoAsync(string nome)
+    {
+        CascadingApiFactory api = _fixture.Factory;
+        await TiposDeAtoSeeder.SemearAsync(api.Services);
+        HttpClient client = api.CreateClient();
+
+        Guid processoId;
+        Guid documentoId;
+        await using (AsyncServiceScope scope = api.Services.CreateAsyncScope())
+        {
+            SelecaoDbContext db = scope.ServiceProvider.GetRequiredService<SelecaoDbContext>();
+            (ProcessoSeletivo processo, DocumentoEdital documento) = await ProcessoSeletivoPublicavelSeeder
+                .SemearAsync(db, $"{nome} {Guid.CreateVersion7()}");
+            processoId = processo.Id;
+            documentoId = documento.Id;
+        }
+
+        return new Contexto(api, client, processoId, documentoId);
+    }
+
+    private static void Autenticar(HttpRequestMessage request, Autenticacao autenticacao)
+    {
+        if (autenticacao == Autenticacao.Nenhuma)
+        {
+            return;
+        }
+
+        request.Headers.Authorization = new AuthenticationHeaderValue(
+            TestAuthHandler.AuthorizationScheme, TestAuthHandler.TokenValue);
+        request.Headers.TryAddWithoutValidation(
+            TestAuthHandler.RolesHeader,
+            autenticacao == Autenticacao.PlataformaAdmin ? "plataforma-admin" : "consulta-publica");
+    }
+
+    private static string Hoje() =>
+        DateOnly.FromDateTime(DateTime.UtcNow).ToString("yyyy-MM-dd", CultureInfo.InvariantCulture);
+
+    private static string HojeMais(int dias) =>
+        DateOnly.FromDateTime(DateTime.UtcNow.AddDays(dias)).ToString("yyyy-MM-dd", CultureInfo.InvariantCulture);
+
+    private static string MakeIdempotencyKey() => Guid.CreateVersion7().ToString("N");
+}


### PR DESCRIPTION
## Objetivo

Expõe via HTTP a configuração das **regras de derivação** de um processo seletivo — a segunda fatia da superfície de coleta/derivação (Feature #983, Story #985). Complementa o endpoint de fatos coletados (#984): juntas, coleta e derivação são a superfície que configura o grafo, antes só exercitável em teste.

`PUT api/selecao/processos-seletivos/{id}/regras-derivacao` substitui integralmente as regras que derivam os fatos derivados do processo — hoje a modalidade de concorrência. Cada configuração traz o fato derivado e a lista de regras `{ ordem, contribui, quando? }`; a regra incondicional (âncora) tem `quando` nulo.

## Escopo

- **Rascunho apenas.** Processo publicado é recusado com `422`; sucesso é `204` sem ETag. A edição sob retificação vem junto do congelamento conjunto da configuração.

## Validação semântica (Application, vocabulário cross-módulo — ADR-0056)

- **Alvo derivado:** o `codigoFato` tem de ser um fato `DERIVADO` com binding `REGRA_DERIVACAO:{codigoFato}` — alvo declarado ou binding incompatível é recusado. No vocabulário atual, `MODALIDADE` é o único alvo válido.
- **`quando` pela matriz:** cada condição valida operador × domínio × valor do fato citado, inclusive contra a oferta do próprio processo para os domínios dinâmicos.
- **Fato citado disponível:** todo fato citado num `quando` está coletado ou derivado no próprio processo (universo = coletados ∪ derivados-no-comando), coerente com a recusa de fato citado inexistente do publish.
- **Domínio de contribuição:** para `MODALIDADE`, cada `contribui` pertence às modalidades ofertadas — mesmo domínio e mesmo erro (`RegrasDerivacaoFato.ContribuiForaDoDominio`) do gate de publicação e do decodificador.

A unicidade do código de fato e o guard de rascunho seguem no agregado (que ganhou um acesso não-mutante ao guard).

## Testes

- Unit do validator (forma; rejeita `quando` vazio/cláusula vazia/condição nula; sem regras) e do handler (alvo desconhecido/não-derivável, contribui fora do domínio, `quando` citando fato indisponível, operador incompatível, derivação válida persistida).
- Integração HTTP (derivação válida compondo com a coleta de fatos; 422 contribui/alvo; 422 em publicado; replay idempotente; 401/403).
- Baseline OpenAPI regerada; suíte completa verde; `dotnet format` limpo.

Refs #985, #924