### PR TITLE
feat(selecao): leitura tipada de fatos coletados e regras de derivação no GET

### DIFF
--- a/contracts/openapi.selecao.json
+++ b/contracts/openapi.selecao.json
@@ -3772,6 +3772,25 @@
         ],
         "type": "string"
       },
+      "CondicaoDerivacaoDto": {
+        "required": [
+          "fato",
+          "operador",
+          "valor"
+        ],
+        "type": "object",
+        "properties": {
+          "fato": {
+            "type": "string"
+          },
+          "operador": {
+            "type": "string"
+          },
+          "valor": {
+            "$ref": "#/components/schemas/JsonElement"
+          }
+        }
+      },
       "CondicaoDerivacaoInput": {
         "required": [
           "fato",
@@ -3849,6 +3868,25 @@
           },
           "valor": {
             "type": "string"
+          }
+        }
+      },
+      "CondicaoPrecondicaoDto": {
+        "required": [
+          "fato",
+          "operador",
+          "valor"
+        ],
+        "type": "object",
+        "properties": {
+          "fato": {
+            "type": "string"
+          },
+          "operador": {
+            "type": "string"
+          },
+          "valor": {
+            "$ref": "#/components/schemas/JsonElement"
           }
         }
       },
@@ -3978,6 +4016,24 @@
           },
           "concorrenciaDuplaAplicavel": {
             "type": "boolean"
+          }
+        }
+      },
+      "ConfiguracaoDerivacaoDto": {
+        "required": [
+          "codigoFato",
+          "regras"
+        ],
+        "type": "object",
+        "properties": {
+          "codigoFato": {
+            "type": "string"
+          },
+          "regras": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/RegraDerivacaoDto"
+            }
           }
         }
       },
@@ -5062,6 +5118,39 @@
           }
         }
       },
+      "FatoColetadoDto": {
+        "required": [
+          "fatoCodigo",
+          "ordem",
+          "precondicao"
+        ],
+        "type": "object",
+        "properties": {
+          "fatoCodigo": {
+            "type": "string"
+          },
+          "ordem": {
+            "pattern": "^-?(?:0|[1-9]\\d*)$",
+            "type": [
+              "integer",
+              "string"
+            ],
+            "format": "int32"
+          },
+          "precondicao": {
+            "type": [
+              "null",
+              "array"
+            ],
+            "items": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/CondicaoPrecondicaoDto"
+              }
+            }
+          }
+        }
+      },
       "FatoColetadoInput": {
         "required": [
           "fatoCodigo",
@@ -6013,6 +6102,8 @@
           "documentosExigidos",
           "raizesExigencia",
           "referenciaTemporalFatos",
+          "fatosColetados",
+          "regrasDerivacao",
           "criadoEm"
         ],
         "type": "object",
@@ -6108,6 +6199,18 @@
                 "$ref": "#/components/schemas/ReferenciaTemporalFatosDto"
               }
             ]
+          },
+          "fatosColetados": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/FatoColetadoDto"
+            }
+          },
+          "regrasDerivacao": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ConfiguracaoDerivacaoDto"
+            }
           },
           "criadoEm": {
             "type": "string",
@@ -6375,6 +6478,39 @@
           },
           "hash": {
             "type": "string"
+          }
+        }
+      },
+      "RegraDerivacaoDto": {
+        "required": [
+          "ordem",
+          "contribui",
+          "quando"
+        ],
+        "type": "object",
+        "properties": {
+          "ordem": {
+            "pattern": "^-?(?:0|[1-9]\\d*)$",
+            "type": [
+              "integer",
+              "string"
+            ],
+            "format": "int32"
+          },
+          "contribui": {
+            "type": "string"
+          },
+          "quando": {
+            "type": [
+              "null",
+              "array"
+            ],
+            "items": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/CondicaoDerivacaoDto"
+              }
+            }
           }
         }
       },

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Application/DTOs/ColetaDeFatosDto.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Application/DTOs/ColetaDeFatosDto.cs
@@ -1,0 +1,44 @@
+namespace Unifesspa.UniPlus.Selecao.Application.DTOs;
+
+using System.Text.Json;
+
+/// <summary>
+/// DTO de leitura de uma condição de pré-condição de fato coletado (Story #987). Mesma forma flat
+/// do wire de escrita (<c>CondicaoPrecondicaoInput</c>): fecha o round-trip GET→PUT sem
+/// transformação do cliente. O <see cref="Valor"/> é o valor JSON já tipado (string, booleano,
+/// número ou array), não um texto — o mesmo que a escrita recebe.
+/// </summary>
+public sealed record CondicaoPrecondicaoDto(string Fato, string Operador, JsonElement Valor);
+
+/// <summary>
+/// DTO de leitura de um fato coletado (Story #987). A <see cref="Precondicao"/> é o predicado na
+/// forma normal disjuntiva — o OU de cláusulas, cada cláusula o E de condições —, ou
+/// <see langword="null"/> quando o fato é coletado incondicionalmente (nunca uma lista vazia).
+/// </summary>
+public sealed record FatoColetadoDto(
+    string FatoCodigo,
+    int Ordem,
+    IReadOnlyList<IReadOnlyList<CondicaoPrecondicaoDto>>? Precondicao);
+
+/// <summary>
+/// DTO de leitura de uma condição do predicado <c>quando</c> de uma regra de derivação (Story
+/// #987). Mesma forma da escrita (<c>CondicaoDerivacaoInput</c>).
+/// </summary>
+public sealed record CondicaoDerivacaoDto(string Fato, string Operador, JsonElement Valor);
+
+/// <summary>
+/// DTO de leitura de uma regra de derivação (Story #987). A regra incondicional (âncora) tem
+/// <see cref="Quando"/> <see langword="null"/> — nunca uma lista vazia.
+/// </summary>
+public sealed record RegraDerivacaoDto(
+    int Ordem,
+    string Contribui,
+    IReadOnlyList<IReadOnlyList<CondicaoDerivacaoDto>>? Quando);
+
+/// <summary>
+/// DTO de leitura da configuração de derivação de um fato (Story #987): o fato derivado e a lista
+/// de regras que o resolvem.
+/// </summary>
+public sealed record ConfiguracaoDerivacaoDto(
+    string CodigoFato,
+    IReadOnlyList<RegraDerivacaoDto> Regras);

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Application/DTOs/ProcessoSeletivoDto.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Application/DTOs/ProcessoSeletivoDto.cs
@@ -23,6 +23,8 @@ public sealed record ProcessoSeletivoDto(
     IReadOnlyList<DocumentoExigidoDto> DocumentosExigidos,
     IReadOnlyList<NoExigenciaDto> RaizesExigencia,
     ReferenciaTemporalFatosDto? ReferenciaTemporalFatos,
+    IReadOnlyList<FatoColetadoDto> FatosColetados,
+    IReadOnlyList<ConfiguracaoDerivacaoDto> RegrasDerivacao,
     DateTimeOffset CriadoEm)
 {
     /// <summary>

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Application/Queries/ProcessosSeletivos/ObterProcessoSeletivoQueryHandler.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Application/Queries/ProcessosSeletivos/ObterProcessoSeletivoQueryHandler.cs
@@ -44,7 +44,52 @@ public static class ObterProcessoSeletivoQueryHandler
         [.. processo.DocumentosExigidos.OrderBy(d => d.Id).Select(ProjectDocumentoExigido)],
         [.. processo.RaizesDeExigencia.OrderBy(n => n.Ordem).ThenBy(n => n.Id).Select(ProjectNoExigencia)],
         ProjectReferenciaTemporalFatos(processo.ReferenciaTemporalFatos),
+        [.. processo.FatosColetados.OrderBy(f => f.Ordem).Select(ProjectFatoColetado)],
+        [.. processo.RegrasDerivacao.OrderBy(c => c.CodigoFato, StringComparer.Ordinal).Select(ProjectConfiguracaoDerivacao)],
         processo.CreatedAt);
+
+    private static FatoColetadoDto ProjectFatoColetado(FatoColetado fato) => new(
+        fato.FatoCodigo,
+        fato.Ordem,
+        ProjectPredicado(fato.Precondicoes, static c => (c.Clausula, c.Fato, c.Operador, c.Valor),
+            static (f, o, v) => new CondicaoPrecondicaoDto(f, o, v)));
+
+    private static ConfiguracaoDerivacaoDto ProjectConfiguracaoDerivacao(ConfiguracaoDerivacaoFato config) => new(
+        config.CodigoFato,
+        [.. config.Regras.OrderBy(r => r.Ordem).Select(ProjectRegraDerivacao)]);
+
+    private static RegraDerivacaoDto ProjectRegraDerivacao(RegraDerivacaoConfigurada regra) => new(
+        regra.Ordem,
+        regra.Contribui,
+        ProjectPredicado(regra.Condicoes, static c => (c.Clausula, c.Fato, c.Operador, c.Valor),
+            static (f, o, v) => new CondicaoDerivacaoDto(f, o, v)));
+
+    /// <summary>
+    /// Projeta um predicado relacional (linhas com ordinal de cláusula) na forma normal disjuntiva
+    /// tipada: agrupa por cláusula na ordem do ordinal, e dentro de cada cláusula ordena por
+    /// conteúdo (fato, operador, valor) para um round-trip determinístico. Ausência de condição é
+    /// <see langword="null"/>, nunca uma lista vazia — a projeção reflete o contrato de escrita.
+    /// </summary>
+    private static IReadOnlyList<IReadOnlyList<TCondicao>>? ProjectPredicado<TLinha, TCondicao>(
+        IReadOnlyCollection<TLinha> linhas,
+        Func<TLinha, (int Clausula, string Fato, Domain.Enums.Operador Operador, JsonElement Valor)> extrair,
+        Func<string, string, JsonElement, TCondicao> criar)
+    {
+        if (linhas.Count == 0)
+        {
+            return null;
+        }
+
+        return [.. linhas
+            .Select(extrair)
+            .GroupBy(static c => c.Clausula)
+            .OrderBy(static g => g.Key)
+            .Select(g => (IReadOnlyList<TCondicao>)[.. g
+                .OrderBy(static c => c.Fato, StringComparer.Ordinal)
+                .ThenBy(static c => c.Operador.ToCodigo(), StringComparer.Ordinal)
+                .ThenBy(static c => c.Valor.GetRawText(), StringComparer.Ordinal)
+                .Select(c => criar(c.Fato, c.Operador.ToCodigo(), c.Valor))])];
+    }
 
     // Achado Codex P2 (PR #896, issue #892): sem isto, um FIM_FASE/DATA_ESPECIFICA salvo
     // desaparecia do agregado GET, e o formulário de edição podia sobrescrevê-lo ou

--- a/tests/Unifesspa.UniPlus.Selecao.Application.UnitTests/Queries/ObterProcessoSeletivoQueryHandlerColetaDeFatosTests.cs
+++ b/tests/Unifesspa.UniPlus.Selecao.Application.UnitTests/Queries/ObterProcessoSeletivoQueryHandlerColetaDeFatosTests.cs
@@ -1,0 +1,107 @@
+namespace Unifesspa.UniPlus.Selecao.Application.UnitTests.Queries;
+
+using System.Text.Json;
+
+using AwesomeAssertions;
+
+using NSubstitute;
+
+using Unifesspa.UniPlus.Selecao.Application.DTOs;
+using Unifesspa.UniPlus.Selecao.Application.Queries.ProcessosSeletivos;
+using Unifesspa.UniPlus.Selecao.Domain.Entities;
+using Unifesspa.UniPlus.Selecao.Domain.Enums;
+using Unifesspa.UniPlus.Selecao.Domain.Interfaces;
+using Unifesspa.UniPlus.Selecao.Domain.ValueObjects;
+
+/// <summary>
+/// Cobertura de <see cref="ObterProcessoSeletivoQueryHandler.Handle"/> para a leitura tipada de
+/// fatos coletados e regras de derivação (Story #987): a ordenação determinística, o contrato
+/// "ausência é null, nunca []" e o round-trip do valor tipado.
+/// </summary>
+public sealed class ObterProcessoSeletivoQueryHandlerColetaDeFatosTests
+{
+    private static CondicaoPrecondicaoFato Precondicao(int clausula, string fato, Operador operador, object valor) =>
+        CondicaoPrecondicaoFato.Criar(clausula, fato, operador, JsonSerializer.SerializeToElement(valor)).Value!;
+
+    private static CondicaoRegraDerivacao CondicaoRegra(int clausula, string fato, Operador operador, object valor) =>
+        CondicaoRegraDerivacao.Criar(clausula, fato, operador, JsonSerializer.SerializeToElement(valor)).Value!;
+
+    private static async Task<ProcessoSeletivoDto> ProjetarAsync(ProcessoSeletivo processo)
+    {
+        IProcessoSeletivoRepository repository = Substitute.For<IProcessoSeletivoRepository>();
+        repository.ObterComConfiguracaoAsync(processo.Id, Arg.Any<CancellationToken>()).Returns(processo);
+
+        ProcessoSeletivoDto? dto = await ObterProcessoSeletivoQueryHandler.Handle(
+            new ObterProcessoSeletivoQuery(processo.Id), repository, CancellationToken.None);
+        dto.Should().NotBeNull();
+        return dto!;
+    }
+
+    [Fact(DisplayName = "Fatos coletados são ordenados por ordem; sem pré-condição projeta null, nunca []")]
+    public async Task Fatos_OrdenadosEPrecondicaoNullNuncaVazia()
+    {
+        ProcessoSeletivo processo = ProcessoSeletivo.Criar("PS Query", TipoProcesso.SiSU, OrigemCandidatos.InscricaoPropria);
+
+        // BAIXA_RENDA na ordem 0 (sem pré-condição); COR_RACA na ordem 1 com pré-condição citando o anterior.
+        FatoColetado baixaRenda = FatoColetado.Criar("BAIXA_RENDA", 0, null).Value!;
+        FatoColetado corRaca = FatoColetado.Criar("COR_RACA", 1,
+            [Precondicao(0, "BAIXA_RENDA", Operador.Igual, true)]).Value!;
+        // Passa fora de ordem de propósito — a projeção é quem ordena.
+        processo.DefinirFatosColetados([corRaca, baixaRenda]).IsSuccess.Should().BeTrue();
+
+        ProcessoSeletivoDto dto = await ProjetarAsync(processo);
+
+        dto.FatosColetados.Select(f => f.FatoCodigo).Should().ContainInOrder("BAIXA_RENDA", "COR_RACA");
+        dto.FatosColetados[0].Precondicao.Should().BeNull("fato sem pré-condição projeta null, nunca lista vazia");
+
+        IReadOnlyList<IReadOnlyList<CondicaoPrecondicaoDto>>? precondicao = dto.FatosColetados[1].Precondicao;
+        precondicao.Should().NotBeNull();
+        precondicao!.Should().ContainSingle().Which.Should().ContainSingle();
+        CondicaoPrecondicaoDto condicao = precondicao[0][0];
+        condicao.Fato.Should().Be("BAIXA_RENDA");
+        condicao.Operador.Should().Be("IGUAL");
+        condicao.Valor.GetBoolean().Should().BeTrue("o valor tipado faz round-trip como booleano JSON");
+    }
+
+    [Fact(DisplayName = "Regras de derivação: config por codigoFato, regras por ordem; âncora projeta quando null")]
+    public async Task Regras_OrdenadasEAncoraProjetaNull()
+    {
+        ProcessoSeletivo processo = ProcessoSeletivo.Criar("PS Query", TipoProcesso.SiSU, OrigemCandidatos.InscricaoPropria);
+
+        RegraDerivacaoConfigurada ancora = RegraDerivacaoConfigurada.Criar(0, "AC", null).Value!;
+        RegraDerivacaoConfigurada condicional = RegraDerivacaoConfigurada.Criar(1, "LB_PPI",
+            [CondicaoRegra(0, "COR_RACA", Operador.Igual, "PRETA")]).Value!;
+        // Regras fora de ordem — a projeção ordena por Ordem.
+        ConfiguracaoDerivacaoFato config = ConfiguracaoDerivacaoFato.Criar("MODALIDADE", [condicional, ancora]).Value!;
+        processo.DefinirRegrasDerivacao([config]).IsSuccess.Should().BeTrue();
+
+        ProcessoSeletivoDto dto = await ProjetarAsync(processo);
+
+        ConfiguracaoDerivacaoDto projetada = dto.RegrasDerivacao.Should().ContainSingle().Which;
+        projetada.CodigoFato.Should().Be("MODALIDADE");
+        projetada.Regras.Select(r => r.Ordem).Should().ContainInOrder(0, 1);
+
+        RegraDerivacaoDto regraAncora = projetada.Regras[0];
+        regraAncora.Contribui.Should().Be("AC");
+        regraAncora.Quando.Should().BeNull("a regra âncora incondicional projeta quando null, nunca lista vazia");
+
+        RegraDerivacaoDto regraCondicional = projetada.Regras[1];
+        regraCondicional.Contribui.Should().Be("LB_PPI");
+        regraCondicional.Quando.Should().NotBeNull();
+        CondicaoDerivacaoDto condicao = regraCondicional.Quando![0][0];
+        condicao.Fato.Should().Be("COR_RACA");
+        condicao.Operador.Should().Be("IGUAL");
+        condicao.Valor.GetString().Should().Be("PRETA");
+    }
+
+    [Fact(DisplayName = "Processo sem coleta nem derivação projeta listas vazias (não null)")]
+    public async Task SemColeta_ListasVazias()
+    {
+        ProcessoSeletivo processo = ProcessoSeletivo.Criar("PS Query", TipoProcesso.SiSU, OrigemCandidatos.InscricaoPropria);
+
+        ProcessoSeletivoDto dto = await ProjetarAsync(processo);
+
+        dto.FatosColetados.Should().BeEmpty();
+        dto.RegrasDerivacao.Should().BeEmpty();
+    }
+}

--- a/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/Outbox/Cascading/LeituraTipadaColetaEndpointTests.cs
+++ b/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/Outbox/Cascading/LeituraTipadaColetaEndpointTests.cs
@@ -1,0 +1,175 @@
+namespace Unifesspa.UniPlus.Selecao.IntegrationTests.Outbox.Cascading;
+
+using System.Net;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using System.Text.Json;
+
+using AwesomeAssertions;
+
+using Domain.Entities;
+
+using Microsoft.Extensions.DependencyInjection;
+
+using Unifesspa.UniPlus.IntegrationTests.Fixtures.Authentication;
+using Unifesspa.UniPlus.Selecao.Infrastructure.Persistence;
+
+/// <summary>
+/// A leitura tipada de fatos coletados e regras de derivação no <c>GET</c> do processo (Story
+/// #987), fim a fim: configura a coleta e a derivação pelos endpoints de escrita e confere que a
+/// consulta as devolve tipadas, com <c>precondicao</c>/<c>quando</c> ausente como <c>null</c> (nunca
+/// <c>[]</c>) e o valor tipado — round-trip com a forma de escrita.
+/// </summary>
+[Collection(CascadingCollection.Name)]
+[Trait("Category", "Integration")]
+[Trait("Category", "OutboxCapability")]
+[Trait("Category", "OutboxCascading")]
+public sealed class LeituraTipadaColetaEndpointTests
+{
+    private const string ProcessoMediaType = "application/vnd.uniplus.processo-seletivo.v1+json";
+
+    private readonly CascadingFixture _fixture;
+
+    public LeituraTipadaColetaEndpointTests(CascadingFixture fixture) => _fixture = fixture;
+
+    [Fact(DisplayName = "GET do processo devolve fatos coletados e regras de derivação tipados, com ausência como null")]
+    public async Task Get_ProjetaColetaEDerivacaoTipadas()
+    {
+        Contexto ctx = await SemearRascunhoAsync(nameof(Get_ProjetaColetaEDerivacaoTipadas));
+
+        // Coleta: COR_RACA (ordem 0, sem pré-condição); BAIXA_RENDA (ordem 1, com pré-condição citando o anterior).
+        (await ctx.PutFatosAsync(
+        [
+            new { fatoCodigo = "COR_RACA", ordem = 0, precondicao = (object?)null },
+            new
+            {
+                fatoCodigo = "BAIXA_RENDA",
+                ordem = 1,
+                precondicao = new[] { new[] { new { fato = "COR_RACA", operador = "IGUAL", valor = "PRETA" } } },
+            },
+        ])).StatusCode.Should().Be(HttpStatusCode.NoContent);
+
+        // Derivação de MODALIDADE: regra âncora (quando null) + condicional citando COR_RACA. Ambas contribuem AC (única modalidade ofertada pelo seeder).
+        (await ctx.PutRegrasAsync(
+        [
+            new
+            {
+                codigoFato = "MODALIDADE",
+                regras = new object[]
+                {
+                    new { ordem = 0, contribui = "AC", quando = (object?)null },
+                    new
+                    {
+                        ordem = 1,
+                        contribui = "AC",
+                        quando = new[] { new[] { new { fato = "COR_RACA", operador = "IGUAL", valor = "PRETA" } } },
+                    },
+                },
+            },
+        ])).StatusCode.Should().Be(HttpStatusCode.NoContent);
+
+        using JsonDocument doc = await ctx.ObterProcessoAsync();
+        JsonElement root = doc.RootElement;
+
+        // Fatos coletados — ordenados por ordem, precondicao ausente é null.
+        JsonElement fatos = root.GetProperty("fatosColetados");
+        fatos.GetArrayLength().Should().Be(2);
+
+        JsonElement corRaca = fatos[0];
+        corRaca.GetProperty("fatoCodigo").GetString().Should().Be("COR_RACA");
+        corRaca.GetProperty("precondicao").ValueKind.Should().Be(JsonValueKind.Null, "fato sem pré-condição é null, nunca []");
+
+        JsonElement baixaRenda = fatos[1];
+        baixaRenda.GetProperty("fatoCodigo").GetString().Should().Be("BAIXA_RENDA");
+        JsonElement precondicao = baixaRenda.GetProperty("precondicao");
+        precondicao.ValueKind.Should().Be(JsonValueKind.Array);
+        JsonElement condicao = precondicao[0][0];
+        condicao.GetProperty("fato").GetString().Should().Be("COR_RACA");
+        condicao.GetProperty("operador").GetString().Should().Be("IGUAL");
+        condicao.GetProperty("valor").GetString().Should().Be("PRETA");
+
+        // Regras de derivação — MODALIDADE, regras por ordem, âncora com quando null.
+        JsonElement regrasDerivacao = root.GetProperty("regrasDerivacao");
+        regrasDerivacao.GetArrayLength().Should().Be(1);
+        JsonElement config = regrasDerivacao[0];
+        config.GetProperty("codigoFato").GetString().Should().Be("MODALIDADE");
+        JsonElement regras = config.GetProperty("regras");
+        regras.GetArrayLength().Should().Be(2);
+        regras[0].GetProperty("contribui").GetString().Should().Be("AC");
+        regras[0].GetProperty("quando").ValueKind.Should().Be(JsonValueKind.Null, "a regra âncora tem quando null, nunca []");
+        regras[1].GetProperty("quando").ValueKind.Should().Be(JsonValueKind.Array);
+    }
+
+    [Fact(DisplayName = "GET de um processo sem coleta devolve listas vazias tipadas")]
+    public async Task Get_SemColeta_ListasVazias()
+    {
+        Contexto ctx = await SemearRascunhoAsync(nameof(Get_SemColeta_ListasVazias));
+
+        using JsonDocument doc = await ctx.ObterProcessoAsync();
+        JsonElement root = doc.RootElement;
+
+        root.GetProperty("fatosColetados").GetArrayLength().Should().Be(0);
+        root.GetProperty("regrasDerivacao").GetArrayLength().Should().Be(0);
+    }
+
+    private sealed record Contexto(CascadingApiFactory Api, HttpClient Client, Guid ProcessoId)
+    {
+        public Task<HttpResponseMessage> PutFatosAsync(IReadOnlyList<object> corpo) =>
+            PutAsync("fatos-coletados", corpo);
+
+        public Task<HttpResponseMessage> PutRegrasAsync(IReadOnlyList<object> corpo) =>
+            PutAsync("regras-derivacao", corpo);
+
+        private async Task<HttpResponseMessage> PutAsync(string recurso, object corpo)
+        {
+            using HttpRequestMessage request = new(
+                HttpMethod.Put,
+                new Uri($"/api/selecao/processos-seletivos/{ProcessoId}/{recurso}", UriKind.Relative))
+            {
+                Content = JsonContent.Create(corpo),
+            };
+            Autenticar(request);
+            request.Headers.TryAddWithoutValidation("Idempotency-Key", MakeIdempotencyKey());
+            return await Client.SendAsync(request).ConfigureAwait(false);
+        }
+
+        public async Task<JsonDocument> ObterProcessoAsync()
+        {
+            using HttpRequestMessage request = new(
+                HttpMethod.Get,
+                new Uri($"/api/selecao/processos-seletivos/{ProcessoId}", UriKind.Relative));
+            Autenticar(request);
+            request.Headers.Accept.Add(MediaTypeWithQualityHeaderValue.Parse(ProcessoMediaType));
+            HttpResponseMessage resposta = await Client.SendAsync(request).ConfigureAwait(false);
+            resposta.StatusCode.Should().Be(HttpStatusCode.OK);
+            return JsonDocument.Parse(await resposta.Content.ReadAsStringAsync().ConfigureAwait(false));
+        }
+    }
+
+    private async Task<Contexto> SemearRascunhoAsync(string nome)
+    {
+        CascadingApiFactory api = _fixture.Factory;
+        await TiposDeAtoSeeder.SemearAsync(api.Services);
+        HttpClient client = api.CreateClient();
+
+        Guid processoId;
+        await using (AsyncServiceScope scope = api.Services.CreateAsyncScope())
+        {
+            SelecaoDbContext db = scope.ServiceProvider.GetRequiredService<SelecaoDbContext>();
+            (ProcessoSeletivo processo, _) = await ProcessoSeletivoPublicavelSeeder
+                .SemearAsync(db, $"{nome} {Guid.CreateVersion7()}");
+            processoId = processo.Id;
+        }
+
+        return new Contexto(api, client, processoId);
+    }
+
+    private static void Autenticar(HttpRequestMessage request)
+    {
+        request.Headers.Authorization = new AuthenticationHeaderValue(
+            TestAuthHandler.AuthorizationScheme, TestAuthHandler.TokenValue);
+        request.Headers.TryAddWithoutValidation(TestAuthHandler.RolesHeader, "plataforma-admin");
+    }
+
+    private static string MakeIdempotencyKey() => Guid.CreateVersion7().ToString("N");
+}


### PR DESCRIPTION
## Objetivo

A consulta do processo (`GET /processos-seletivos/{id}`) passa a devolver `fatosColetados[]` e `regrasDerivacao[]` em DTOs **tipados** (Feature #983, Story #987). Fecha o round-trip GET→PUT da coleta e da derivação: o frontend administrativo lê a configuração na mesma forma que a escreve pelos endpoints de #984/#985, sem um blob opaco no meio.

## Contrato

- `fatosColetados[]` = `{ fatoCodigo, ordem, precondicao? }`; `regrasDerivacao[]` = `{ codigoFato, regras: [{ ordem, contribui, quando? }] }` — espelham os inputs de escrita.
- **Ausência é `null`, nunca `[]`:** fato sem pré-condição e regra âncora (incondicional) projetam `precondicao`/`quando` nulo.
- **Ordenação determinística:** fatos por `ordem`, configurações por `codigoFato` (ordinal), regras por `ordem`, condições de uma cláusula por conteúdo.
- **Valor tipado:** cada condição carrega o valor JSON tipado (string/booleano/número/array), que faz round-trip direto para o PUT.
- **Aditivo à v1 do recurso** — sem bump de versão; o `snapshot-vigente` permanece `JsonNode` opaco (contrato forense independente), só a configuração viva é tipada.

## Notas

- Projeção no `ObterProcessoSeletivoQueryHandler` via um helper genérico que agrupa o predicado relacional (linhas com ordinal de cláusula) na forma normal disjuntiva — reusado por fatos e regras.
- Sem mudança no `ProcessoSeletivoLinksBuilder` (ações são descobertas via OpenAPI, ADR-0029/0030).

## Testes

- Unit da projeção (ordenação; `null` nunca `[]`; round-trip do valor tipado; âncora com `quando` null).
- Integração HTTP (round-trip PUT fatos/regras → GET tipado; processo sem coleta → listas vazias). Testes de GET existentes seguem verdes (campos aditivos).
- Baseline OpenAPI regerada; suíte completa verde; `dotnet format` limpo.

Refs #987, #924