### PR TITLE
feat(selecao): edição de fatos/regras sob retificação + restauração fiel

### DIFF
--- a/contracts/openapi.selecao.json
+++ b/contracts/openapi.selecao.json
@@ -2321,6 +2321,13 @@
             }
           },
           {
+            "name": "If-Match",
+            "in": "header",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
             "name": "Idempotency-Key",
             "in": "header",
             "description": "Chave opaca (1-255 ASCII printable, sem \u0027,\u0027 ou \u0027;\u0027) para retry seguro do comando. Replay com mesma key \u002B mesmo body retorna response cacheada (ADR-0027).",
@@ -2364,7 +2371,15 @@
         },
         "responses": {
           "204": {
-            "description": "No Content"
+            "description": "No Content",
+            "headers": {
+              "ETag": {
+                "description": "ETag forte da sess\u00E3o editorial de retifica\u00E7\u00E3o, no formato \u0022{idDaSessao}:{revisao}\u0022. Devolva-o no If-Match da pr\u00F3xima muta\u00E7\u00E3o. Toda muta\u00E7\u00E3o aceita INCREMENTA a revis\u00E3o e emite o tag novo aqui \u2014 o cliente encadeia sem um GET no meio. Ausente quando n\u00E3o h\u00E1 sess\u00E3o em curso (o processo em rascunho n\u00E3o tem precondi\u00E7\u00E3o a satisfazer).",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
           },
           "400": {
             "description": "Bad Request",
@@ -2388,6 +2403,26 @@
           },
           "422": {
             "description": "Unprocessable Entity",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "412": {
+            "description": "Precondition Failed",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "428": {
+            "description": "Precondition Required",
             "content": {
               "application/problem\u002Bjson": {
                 "schema": {
@@ -2422,6 +2457,13 @@
             }
           },
           {
+            "name": "If-Match",
+            "in": "header",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
             "name": "Idempotency-Key",
             "in": "header",
             "description": "Chave opaca (1-255 ASCII printable, sem \u0027,\u0027 ou \u0027;\u0027) para retry seguro do comando. Replay com mesma key \u002B mesmo body retorna response cacheada (ADR-0027).",
@@ -2465,7 +2507,15 @@
         },
         "responses": {
           "204": {
-            "description": "No Content"
+            "description": "No Content",
+            "headers": {
+              "ETag": {
+                "description": "ETag forte da sess\u00E3o editorial de retifica\u00E7\u00E3o, no formato \u0022{idDaSessao}:{revisao}\u0022. Devolva-o no If-Match da pr\u00F3xima muta\u00E7\u00E3o. Toda muta\u00E7\u00E3o aceita INCREMENTA a revis\u00E3o e emite o tag novo aqui \u2014 o cliente encadeia sem um GET no meio. Ausente quando n\u00E3o h\u00E1 sess\u00E3o em curso (o processo em rascunho n\u00E3o tem precondi\u00E7\u00E3o a satisfazer).",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
           },
           "400": {
             "description": "Bad Request",
@@ -2489,6 +2539,26 @@
           },
           "422": {
             "description": "Unprocessable Entity",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "412": {
+            "description": "Precondition Failed",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "428": {
+            "description": "Precondition Required",
             "content": {
               "application/problem\u002Bjson": {
                 "schema": {

--- a/src/selecao/Unifesspa.UniPlus.Selecao.API/Controllers/ProcessoSeletivoController.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.API/Controllers/ProcessoSeletivoController.cs
@@ -405,12 +405,12 @@ public sealed class ProcessoSeletivoController : ControllerBase
 
     /// <summary>
     /// Substitui integralmente os fatos que o processo coleta do candidato, com a sua ordem de
-    /// coleta e a pré-condição opcional que decide se o campo produtor é apresentado (Story
-    /// #984). Só é coletável um fato declarado, respondido em campo de inscrição — derivados e
-    /// computados são recusados. Escopo desta Story: edição só em rascunho (pré-publicação); um
-    /// processo publicado é recusado com <c>422</c>. Sem <c>If-Match</c>: em rascunho não há
-    /// sessão editorial nem ETag — a resposta é <c>204</c> sem ETag (a edição sob retificação é
-    /// entregue junto do congelamento conjunto do grafo).
+    /// coleta e a pré-condição opcional que decide se o campo produtor é apresentado (Story #984).
+    /// Só é coletável um fato declarado, respondido em campo de inscrição — derivados e computados
+    /// são recusados. Editável em rascunho e sob sessão de retificação (Story #986): em rascunho a
+    /// resposta é <c>204</c> sem ETag e o <c>If-Match</c> é ignorado; sob sessão, o <c>If-Match</c>
+    /// é obrigatório (<c>428</c> ausente, <c>412</c> defasado) e o <c>204</c> devolve o ETag novo.
+    /// Processo publicado sem sessão é recusado com <c>422</c>.
     /// </summary>
     [HttpPut("{id:guid}/fatos-coletados")]
     [RequiresIdempotencyKey]
@@ -418,13 +418,20 @@ public sealed class ProcessoSeletivoController : ControllerBase
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status422UnprocessableEntity)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status412PreconditionFailed)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status428PreconditionRequired)]
+    [EmiteETag]
     public async Task<IActionResult> DefinirFatosColetados(
         Guid id,
         [FromBody] IReadOnlyList<FatoColetadoInput> fatos,
+        [FromHeader(Name = "If-Match")] string? ifMatch,
         CancellationToken cancellationToken)
     {
+        if (!TentarLerPrecondicao(ifMatch, out PrecondicaoIfMatch precondicao, out IActionResult? malformada))
+            return malformada!;
+
         Result<MutacaoAceita> resultado = await _commandBus.Send(
-            new DefinirFatosColetadosCommand(id, fatos), cancellationToken);
+            new DefinirFatosColetadosCommand(id, fatos, precondicao), cancellationToken);
         return ResponderMutacao(resultado);
     }
 
@@ -434,9 +441,9 @@ public sealed class ProcessoSeletivoController : ControllerBase
     /// regras <c>{ ordem, contribui, quando? }</c>; a regra incondicional (âncora) tem <c>quando</c>
     /// nulo. Só um fato derivado com binding de regra de derivação é alvo válido — para a
     /// modalidade, cada código contribuído tem de ser uma das modalidades ofertadas pelo processo.
-    /// Escopo desta Story: edição só em rascunho (pré-publicação); um processo publicado é recusado
-    /// com <c>422</c>. Sem <c>If-Match</c>: em rascunho não há sessão editorial nem ETag — a
-    /// resposta é <c>204</c> sem ETag.
+    /// Editável em rascunho e sob sessão de retificação (Story #986): em rascunho <c>204</c> sem
+    /// ETag e <c>If-Match</c> ignorado; sob sessão, <c>If-Match</c> obrigatório (<c>428</c>/<c>412</c>)
+    /// e <c>204</c> com o ETag novo. Processo publicado sem sessão é recusado com <c>422</c>.
     /// </summary>
     [HttpPut("{id:guid}/regras-derivacao")]
     [RequiresIdempotencyKey]
@@ -444,13 +451,20 @@ public sealed class ProcessoSeletivoController : ControllerBase
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status422UnprocessableEntity)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status412PreconditionFailed)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status428PreconditionRequired)]
+    [EmiteETag]
     public async Task<IActionResult> DefinirRegrasDerivacao(
         Guid id,
         [FromBody] IReadOnlyList<ConfiguracaoDerivacaoInput> configuracoes,
+        [FromHeader(Name = "If-Match")] string? ifMatch,
         CancellationToken cancellationToken)
     {
+        if (!TentarLerPrecondicao(ifMatch, out PrecondicaoIfMatch precondicao, out IActionResult? malformada))
+            return malformada!;
+
         Result<MutacaoAceita> resultado = await _commandBus.Send(
-            new DefinirRegrasDerivacaoCommand(id, configuracoes), cancellationToken);
+            new DefinirRegrasDerivacaoCommand(id, configuracoes, precondicao), cancellationToken);
         return ResponderMutacao(resultado);
     }
 

--- a/src/selecao/Unifesspa.UniPlus.Selecao.API/Errors/SelecaoDomainErrorRegistration.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.API/Errors/SelecaoDomainErrorRegistration.cs
@@ -207,11 +207,10 @@ internal sealed class SelecaoDomainErrorRegistration : IDomainErrorRegistration
         new("ProcessoSeletivo.ConformidadeLegalInsuficiente", new DomainErrorMapping(StatusCodes.Status422UnprocessableEntity, "uniplus.selecao.processo_seletivo.conformidade_legal_insuficiente", "Processo não conforme às obrigatoriedades legais vigentes")),
         new("ProcessoSeletivo.MutacaoPosPublicacaoBloqueada", new DomainErrorMapping(StatusCodes.Status422UnprocessableEntity, "uniplus.selecao.processo_seletivo.mutacao_pos_publicacao_bloqueada", "Processo publicado não aceita mutação direta da configuração")),
         // Grafo de coleta de fatos do candidato (Story #926). Todas as recusas são de configuração
-        // (422): grafo mal formado, ou tentativa de editá-lo após a publicação enquanto o
-        // congelamento conjunto (#928) ainda não existe. Os códigos de FatoColetado usam constantes
-        // e escapam do fitness test — registrados aqui à mão para não caírem em 500 genérico quando
-        // o endpoint de configuração do grafo existir.
-        new("ProcessoSeletivo.GrafoDeFatosSomenteEmRascunho", new DomainErrorMapping(StatusCodes.Status422UnprocessableEntity, "uniplus.selecao.processo_seletivo.grafo_de_fatos_somente_em_rascunho", "O grafo de coleta de fatos só é editável antes da primeira publicação")),
+        // (422): grafo mal formado. A edição é permitida em rascunho e sob sessão de retificação
+        // (Story #986) — a recusa de mutação de processo publicado sem sessão é a geral
+        // (ProcessoSeletivo.MutacaoPosPublicacaoBloqueada). Os códigos de FatoColetado usam
+        // constantes e escapam do fitness test — registrados aqui à mão para não caírem em 500.
         new("FatoColetado.FatoCodigoObrigatorio", new DomainErrorMapping(StatusCodes.Status422UnprocessableEntity, "uniplus.selecao.fato_coletado.fato_codigo_obrigatorio", "O código do fato coletado é obrigatório")),
         new("FatoColetado.OrdemInvalida", new DomainErrorMapping(StatusCodes.Status422UnprocessableEntity, "uniplus.selecao.fato_coletado.ordem_invalida", "A ordem de coleta não pode ser negativa")),
         new("FatoColetado.PrecondicaoAutorreferente", new DomainErrorMapping(StatusCodes.Status422UnprocessableEntity, "uniplus.selecao.fato_coletado.precondicao_autorreferente", "A pré-condição de um fato cita o próprio fato")),
@@ -227,10 +226,10 @@ internal sealed class SelecaoDomainErrorRegistration : IDomainErrorRegistration
         new("FatoColetado.FatoDesconhecido", new DomainErrorMapping(StatusCodes.Status422UnprocessableEntity, "uniplus.selecao.fato_coletado.fato_desconhecido", "O fato coletado não pertence ao vocabulário de fatos do candidato")),
         new("FatoColetado.FatoNaoColetavel", new DomainErrorMapping(StatusCodes.Status422UnprocessableEntity, "uniplus.selecao.fato_coletado.fato_nao_coletavel", "O fato não é coletável — só um fato declarado respondido em campo de inscrição pode ser coletado")),
         // Regra de derivação de fato (Story #927). Todas as recusas são de configuração (422): regra
-        // mal formada, ou tentativa de editá-la após a publicação enquanto o congelamento conjunto
-        // (#928) ainda não existe. Os códigos usam constantes e escapam do fitness test — registrados
-        // à mão para não caírem em 500 quando o endpoint de configuração da regra existir.
-        new("ProcessoSeletivo.RegrasDerivacaoSomenteEmRascunho", new DomainErrorMapping(StatusCodes.Status422UnprocessableEntity, "uniplus.selecao.processo_seletivo.regras_derivacao_somente_em_rascunho", "As regras de derivação só são editáveis antes da primeira publicação")),
+        // mal formada. A edição é permitida em rascunho e sob sessão de retificação (Story #986) — a
+        // recusa de mutação de processo publicado sem sessão é a geral
+        // (ProcessoSeletivo.MutacaoPosPublicacaoBloqueada). Os códigos usam constantes e escapam do
+        // fitness test — registrados à mão para não caírem em 500.
         // Alvo de derivação (Story #985) — semântica cross-módulo resolvida na Application: o fato
         // configurado tem de existir e ser derivado com binding de regra de derivação.
         new("ConfiguracaoDerivacaoFato.FatoDesconhecido", new DomainErrorMapping(StatusCodes.Status422UnprocessableEntity, "uniplus.selecao.configuracao_derivacao_fato.fato_desconhecido", "O fato derivado não pertence ao vocabulário de fatos do candidato")),

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Application/Abstractions/IRestauradorDeConfiguracao.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Application/Abstractions/IRestauradorDeConfiguracao.cs
@@ -2,37 +2,35 @@ namespace Unifesspa.UniPlus.Selecao.Application.Abstractions;
 
 using Unifesspa.UniPlus.Kernel.Results;
 using Unifesspa.UniPlus.Selecao.Domain.Entities;
+using Unifesspa.UniPlus.Selecao.Domain.ValueObjects;
 
 /// <summary>
-/// Repõe no <see cref="ProcessoSeletivo"/> a configuração de uma
-/// <see cref="VersaoConfiguracao"/> congelada — <b>e prova que repôs</b> (ADR-0110 D1/D2).
+/// Prova que a configuração de uma <see cref="VersaoConfiguracao"/> congelada pode ser reposta com
+/// fidelidade e devolve o grafo <b>já provado</b> para o chamador aplicar (ADR-0110 D1/D2).
 /// </summary>
 /// <remarks>
 /// <para>
-/// <b>É uma operação única, e é assim de propósito.</b> Decodificar, repor e provar são
-/// três passos que <b>não</b> podem ser oferecidos separadamente a um chamador: quem
-/// repusesse sem provar teria feito exatamente o que a ADR proíbe — um descarte que
-/// destrói configuração em silêncio. A raiz sabe repor um grafo e sabe recusar um grafo
-/// incoerente, mas <b>não</b> sabe recanonicalizar (ADR-0042: o Domain não chama o
-/// codec). Só aqui os dois lados existem ao mesmo tempo.
+/// <b>Prova primeiro, aplica depois — e a prova é aqui.</b> Decodifica o envelope, repõe numa
+/// <b>sombra destacada</b> (fora do change tracker), recanonicaliza com o encoder <b>daquela</b>
+/// versão e compara byte a byte com os bytes congelados. Só devolve <see cref="Result{T}.Success"/>
+/// — com o grafo congelado a aplicar — quando os bytes batem; se um único campo se perdeu na
+/// reconstrução, os bytes divergem e a operação <b>falha</b>, em vez de deixar o chamador repor uma
+/// configuração empobrecida que ninguém mais teria como detectar. A raiz sabe repor um grafo e
+/// recusar um incoerente, mas <b>não</b> sabe recanonicalizar (ADR-0042: o Domain não chama o
+/// codec); por isso a prova vive aqui.
 /// </para>
 /// <para>
-/// <b>A prova é o round-trip, e ela roda em produção — não só em teste.</b> Depois de
-/// repor, o agregado é recanonicalizado com o encoder <b>daquela</b> versão e os bytes
-/// têm de reproduzir os que estão congelados. Se um único campo se perdeu no caminho, os
-/// bytes divergem e a operação <b>falha</b> — em vez de gravar uma configuração
-/// empobrecida que ninguém mais teria como detectar.
-/// </para>
-/// <para>
-/// <b>Falhar aqui não deixa resíduo.</b> A reposição é em memória e a transação é do
-/// handler: uma prova que falha devolve <c>Failure</c> antes de qualquer
-/// <c>SalvarAlteracoesAsync</c>, e o agregado mutado morre com o escopo. É o mesmo
-/// contrato de toda regra de negócio recusada no projeto.
+/// <b>Não toca a raiz viva.</b> A reposição na raiz é do chamador, DEPOIS da prova — o descarte
+/// precisa intercalar um <c>SaveChanges</c> intermediário entre limpar as coleções mutáveis
+/// (fatos/regras) e reinserir as congeladas, para não colidir no índice único de ordem. Devolver o
+/// grafo provado (em vez de aplicá-lo aqui) é o que permite esse flush sem tocar a raiz antes de a
+/// prova passar. O grafo devolvido <b>já foi provado</b>: o chamador não repõe nada não verificado.
 /// </para>
 /// </remarks>
 public interface IRestauradorDeConfiguracao
 {
-    /// <param name="processo">O agregado a repor — carregado com o grafo completo, e o mesmo a que a versão pertence.</param>
+    /// <param name="processo">O agregado cuja identidade a sombra empresta — carregado com o grafo completo, e o mesmo a que a versão pertence.</param>
     /// <param name="versao">A versão congelada cuja configuração volta a valer.</param>
-    Result Restaurar(ProcessoSeletivo processo, VersaoConfiguracao versao);
+    /// <returns>O grafo congelado <b>provado</b>, pronto para o chamador aplicar na raiz viva; ou a falha da prova.</returns>
+    Result<GrafoConfiguracao> Restaurar(ProcessoSeletivo processo, VersaoConfiguracao versao);
 }

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Application/Commands/ProcessosSeletivos/DefinirFatosColetadosCommand.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Application/Commands/ProcessosSeletivos/DefinirFatosColetadosCommand.cs
@@ -2,6 +2,8 @@ namespace Unifesspa.UniPlus.Selecao.Application.Commands.ProcessosSeletivos;
 
 using System.Text.Json;
 
+using Domain.ValueObjects;
+
 using Kernel.Results;
 
 using Unifesspa.UniPlus.Application.Abstractions.Messaging;
@@ -29,11 +31,12 @@ public sealed record FatoColetadoInput(
     IReadOnlyList<IReadOnlyList<CondicaoPrecondicaoInput>>? Precondicao);
 
 /// <summary>
-/// Substitui integralmente os fatos que o processo coleta do candidato (Story #984). Escopo
-/// desta Story: edição só em rascunho (pré-publicação) — a edição sob sessão de retificação é
-/// entregue junto do congelamento conjunto do grafo. Por isso o comando não carrega
-/// precondição de concorrência: em rascunho não há sessão editorial nem ETag.
+/// Substitui integralmente os fatos que o processo coleta do candidato (Story #984). Editável em
+/// rascunho (pré-publicação) e sob sessão de retificação de um processo publicado (Story #986). Em
+/// rascunho puro a precondição é ignorada (não há sessão nem ETag); sob sessão, o <c>If-Match</c>
+/// é obrigatório e a revisão do rascunho avança.
 /// </summary>
 public sealed record DefinirFatosColetadosCommand(
     Guid ProcessoSeletivoId,
-    IReadOnlyList<FatoColetadoInput> Fatos) : ICommand<Result<MutacaoAceita>>;
+    IReadOnlyList<FatoColetadoInput> Fatos,
+    PrecondicaoIfMatch Precondicao) : ICommand<Result<MutacaoAceita>>;

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Application/Commands/ProcessosSeletivos/DefinirFatosColetadosCommandHandler.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Application/Commands/ProcessosSeletivos/DefinirFatosColetadosCommandHandler.cs
@@ -47,10 +47,11 @@ public static class DefinirFatosColetadosCommandHandler
                 $"Processo Seletivo {command.ProcessoSeletivoId} não encontrado."));
         }
 
-        // Guard de rascunho ANTES da resolução do vocabulário cross-módulo: um processo já
-        // publicado é recusado sem pagar o I/O do reader nem caçar um fato desconhecido que o
-        // cliente não errou. O mesmo guard continua dentro de DefinirFatosColetados.
-        if (processo.EdicaoDeGrafoDeFatosBloqueada() is { } bloqueio)
+        // A precondição (e o bloqueio de mutação pós-publicação sem sessão) é conferida AQUI, ANTES
+        // da resolução do vocabulário cross-módulo: um processo publicado sem sessão, ou um cliente
+        // com If-Match defasado, é recusado sem pagar o I/O do reader nem caçar um fato que ele não
+        // errou. O mesmo guard continua dentro de DefinirFatosColetados.
+        if (processo.MutacaoBloqueada(command.Precondicao) is { } bloqueio)
         {
             return Result<MutacaoAceita>.Failure(bloqueio);
         }
@@ -76,7 +77,7 @@ public static class DefinirFatosColetadosCommandHandler
             fatos.Add(fatoResult.Value!);
         }
 
-        Result result = processo.DefinirFatosColetados(fatos);
+        Result result = processo.DefinirFatosColetados(fatos, command.Precondicao);
         if (result.IsFailure)
         {
             return Result<MutacaoAceita>.Failure(result.Error!);
@@ -86,9 +87,8 @@ public static class DefinirFatosColetadosCommandHandler
         // persistida por change detection no SaveChanges — não chamar DbSet.Update.
         await unitOfWork.SalvarAlteracoesAsync(cancellationToken).ConfigureAwait(false);
 
-        // Rascunho não tem sessão editorial: ETagDaSessaoEditorial é nulo e a resposta é 204
-        // sem ETag. O tipo de retorno já prepara a Story da edição sob retificação, que passará
-        // a emitir a tag da revisão.
+        // Em rascunho puro não há sessão: ETagDaSessaoEditorial é nulo e a resposta é 204 sem ETag.
+        // Sob sessão de retificação, a revisão avançou e o ETag novo é devolvido.
         return Result<MutacaoAceita>.Success(new MutacaoAceita(processo.ETagDaSessaoEditorial));
     }
 

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Application/Commands/ProcessosSeletivos/DefinirRegrasDerivacaoCommand.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Application/Commands/ProcessosSeletivos/DefinirRegrasDerivacaoCommand.cs
@@ -2,6 +2,8 @@ namespace Unifesspa.UniPlus.Selecao.Application.Commands.ProcessosSeletivos;
 
 using System.Text.Json;
 
+using Domain.ValueObjects;
+
 using Kernel.Results;
 
 using Unifesspa.UniPlus.Application.Abstractions.Messaging;
@@ -35,10 +37,11 @@ public sealed record ConfiguracaoDerivacaoInput(
 
 /// <summary>
 /// Substitui integralmente as regras que derivam os fatos derivados do processo (Story #985).
-/// Escopo desta Story: edição só em rascunho (pré-publicação) — a edição sob sessão de retificação
-/// é entregue junto do congelamento conjunto da configuração. Por isso o comando não carrega
-/// precondição de concorrência: em rascunho não há sessão editorial nem ETag.
+/// Editável em rascunho (pré-publicação) e sob sessão de retificação de um processo publicado
+/// (Story #986). Em rascunho puro a precondição é ignorada (não há sessão nem ETag); sob sessão, o
+/// <c>If-Match</c> é obrigatório e a revisão do rascunho avança.
 /// </summary>
 public sealed record DefinirRegrasDerivacaoCommand(
     Guid ProcessoSeletivoId,
-    IReadOnlyList<ConfiguracaoDerivacaoInput> Configuracoes) : ICommand<Result<MutacaoAceita>>;
+    IReadOnlyList<ConfiguracaoDerivacaoInput> Configuracoes,
+    PrecondicaoIfMatch Precondicao) : ICommand<Result<MutacaoAceita>>;

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Application/Commands/ProcessosSeletivos/DefinirRegrasDerivacaoCommandHandler.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Application/Commands/ProcessosSeletivos/DefinirRegrasDerivacaoCommandHandler.cs
@@ -47,8 +47,9 @@ public static class DefinirRegrasDerivacaoCommandHandler
                 $"Processo Seletivo {command.ProcessoSeletivoId} não encontrado."));
         }
 
-        // Guard de rascunho ANTES da resolução do vocabulário cross-módulo.
-        if (processo.EdicaoDeRegrasDerivacaoBloqueada() is { } bloqueio)
+        // Precondição / bloqueio de mutação pós-publicação sem sessão ANTES da resolução do
+        // vocabulário cross-módulo. O mesmo guard continua dentro de DefinirRegrasDerivacao.
+        if (processo.MutacaoBloqueada(command.Precondicao) is { } bloqueio)
         {
             return Result<MutacaoAceita>.Failure(bloqueio);
         }
@@ -88,7 +89,7 @@ public static class DefinirRegrasDerivacaoCommandHandler
             configuracoes.Add(configResult.Value!);
         }
 
-        Result result = processo.DefinirRegrasDerivacao(configuracoes);
+        Result result = processo.DefinirRegrasDerivacao(configuracoes, command.Precondicao);
         if (result.IsFailure)
         {
             return Result<MutacaoAceita>.Failure(result.Error!);
@@ -96,6 +97,7 @@ public static class DefinirRegrasDerivacaoCommandHandler
 
         await unitOfWork.SalvarAlteracoesAsync(cancellationToken).ConfigureAwait(false);
 
+        // Rascunho puro: 204 sem ETag. Sob sessão de retificação: 204 com o ETag da nova revisão.
         return Result<MutacaoAceita>.Success(new MutacaoAceita(processo.ETagDaSessaoEditorial));
     }
 

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Application/Commands/ProcessosSeletivos/DescartarRetificacaoCommandHandler.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Application/Commands/ProcessosSeletivos/DescartarRetificacaoCommandHandler.cs
@@ -4,6 +4,7 @@ using Abstractions;
 
 using Domain.Entities;
 using Domain.Interfaces;
+using Domain.ValueObjects;
 
 using Kernel.Results;
 
@@ -110,19 +111,41 @@ public static class DescartarRetificacaoCommandHandler
                 + "a sessão não pode ser descartada com segurança."));
         }
 
-        // Repõe E PROVA (round-trip byte a byte com o encoder daquela versão). Falha aqui não
-        // deixa resíduo: a prova roda numa sombra destacada, antes de a raiz viva ser tocada.
-        Result restauracao = restaurador.Restaurar(processo, versaoAtual);
-        if (restauracao.IsFailure)
+        // PROVA (round-trip byte a byte com o encoder daquela versão) numa sombra destacada, sem
+        // tocar a raiz viva. Falha aqui não deixa resíduo. Devolve o grafo congelado a aplicar.
+        Result<GrafoConfiguracao> prova = restaurador.Restaurar(processo, versaoAtual);
+        if (prova.IsFailure)
         {
-            return restauracao;
+            return Result.Failure(prova.Error!);
         }
 
-        // Só agora — com a configuração já de volta ao que o documento publicado diz.
+        // A sessão pode ter EDITADO fatos/regras (Story #986) — inclusive trocado ordens. Repor as
+        // instâncias congeladas por cima das vivas colidiria no índice único de ordem/código na
+        // mesma transação. Limpa as duas coleções e FAZ UM SaveChanges intermediário para que os
+        // DELETEs saiam ANTES dos INSERTs das congeladas; a reposição fiel de graça.
+        //
+        // A partir deste flush, NENHUM caminho pode retornar Failure: o Wolverine commita a
+        // transação ambiente ao término normal do handler (AutoApplyTransactions), inclusive num
+        // Result.Failure — que gravaria o DELETE sem o INSERT correspondente. Uma falha após o
+        // flush é bug (a sombra já provou o MESMO grafo, contra o mesmo Tipo e Status) e LANÇA,
+        // forçando o rollback da transação em vez de commitar uma restauração meia-feita.
+        processo.LimparColetaEDerivacaoParaRestauracao();
+        await unitOfWork.SalvarAlteracoesAsync(cancellationToken).ConfigureAwait(false);
+
+        Result aplicar = processo.RestaurarConfiguracaoCongelada(versaoAtual, prova.Value!);
+        if (aplicar.IsFailure)
+        {
+            throw new InvalidOperationException(
+                $"A restauração da versão {versaoAtual.NumeroVersao} foi provada na sombra mas falhou ao aplicar na "
+                + $"raiz viva ({aplicar.Error!.Code}) — estado inconsistente após o flush, revertendo a transação.");
+        }
+
         Result descarte = processo.DescartarRetificacao(command.Precondicao);
         if (descarte.IsFailure)
         {
-            return descarte;
+            throw new InvalidOperationException(
+                $"O descarte falhou após a configuração congelada já ter sido reaplicada ({descarte.Error!.Code}) — "
+                + "estado inconsistente após o flush, revertendo a transação.");
         }
 
         await unitOfWork.SalvarAlteracoesAsync(cancellationToken).ConfigureAwait(false);

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Application/Services/RestauradorDeConfiguracao.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Application/Services/RestauradorDeConfiguracao.cs
@@ -3,6 +3,7 @@ namespace Unifesspa.UniPlus.Selecao.Application.Services;
 using Unifesspa.UniPlus.Kernel.Results;
 using Unifesspa.UniPlus.Selecao.Application.Abstractions;
 using Unifesspa.UniPlus.Selecao.Domain.Entities;
+using Unifesspa.UniPlus.Selecao.Domain.ValueObjects;
 
 /// <summary>
 /// Implementação de <see cref="IRestauradorDeConfiguracao"/>: decodifica, repõe e
@@ -17,7 +18,7 @@ public sealed class RestauradorDeConfiguracao(IRegistroCodecsEnvelope registro) 
     /// </summary>
     public const string RoundTripDivergente = "EnvelopeCodec.RoundTripDivergente";
 
-    public Result Restaurar(ProcessoSeletivo processo, VersaoConfiguracao versao)
+    public Result<GrafoConfiguracao> Restaurar(ProcessoSeletivo processo, VersaoConfiguracao versao)
     {
         ArgumentNullException.ThrowIfNull(processo);
         ArgumentNullException.ThrowIfNull(versao);
@@ -25,7 +26,7 @@ public sealed class RestauradorDeConfiguracao(IRegistroCodecsEnvelope registro) 
         Result<EnvelopeReidratado> reidratado = registro.Reidratar(versao);
         if (reidratado.IsFailure)
         {
-            return Result.Failure(reidratado.Error!);
+            return Result<GrafoConfiguracao>.Failure(reidratado.Error!);
         }
 
         EnvelopeReidratado envelope = reidratado.Value!;
@@ -44,7 +45,7 @@ public sealed class RestauradorDeConfiguracao(IRegistroCodecsEnvelope registro) 
         Result ensaio = sombra.RestaurarConfiguracaoCongelada(versao, envelope.Grafo);
         if (ensaio.IsFailure)
         {
-            return ensaio;
+            return Result<GrafoConfiguracao>.Failure(ensaio.Error!);
         }
 
         // Recanonicaliza com o encoder DAQUELA versão — não com o corrente: no dia da 1.2, o
@@ -62,21 +63,21 @@ public sealed class RestauradorDeConfiguracao(IRegistroCodecsEnvelope registro) 
 
         if (recodificado.IsFailure)
         {
-            return Result.Failure(recodificado.Error!);
+            return Result<GrafoConfiguracao>.Failure(recodificado.Error!);
         }
 
         if (!recodificado.Value!.Bytes.AsSpan().SequenceEqual(versao.ConfiguracaoCongeladaCanonica))
         {
-            return Result.Failure(new DomainError(
+            return Result<GrafoConfiguracao>.Failure(new DomainError(
                 RoundTripDivergente,
                 $"A configuração reidratada da versão {versao.NumeroVersao} não reproduz os bytes congelados — " +
                 "algum dado se perdeu na reconstrução. A restauração é recusada: repor uma configuração empobrecida " +
                 "faria o certame publicado divergir do documento que o publicou, sem que nada acusasse."));
         }
 
-        // Provado. Só agora a raiz viva é tocada — e esta chamada não tem como falhar por
-        // outro motivo que a sombra não tenha encontrado: as duas validam o MESMO grafo,
-        // contra o mesmo Tipo e o mesmo Status.
-        return processo.RestaurarConfiguracaoCongelada(versao, envelope.Grafo);
+        // Provado. Devolve o grafo congelado para o chamador aplicá-lo na raiz viva — o descarte
+        // intercala um SaveChanges entre limpar fatos/regras e reinserir as congeladas (evita a
+        // colisão no índice único de ordem), o que exige não tocar a raiz aqui.
+        return Result<GrafoConfiguracao>.Success(envelope.Grafo);
     }
 }

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Domain/Entities/ProcessoSeletivo.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Domain/Entities/ProcessoSeletivo.cs
@@ -923,35 +923,20 @@ public sealed class ProcessoSeletivo : SoftDeletableEntity
     /// configuração — enquanto o erro de ordem apontaria só um par de fatos.
     /// </para>
     /// <para>
-    /// <b>Só é aceito antes da primeira publicação</b> (processo em <c>Rascunho</c>), e por isso
-    /// não recebe precondição de concorrência — em rascunho não há sessão editorial nem ETag. Ao
-    /// contrário dos demais <c>Definir*</c>, o grafo ainda não participa do congelamento nem da
-    /// restauração da configuração; enquanto essa integração não existe, permitir a edição sob
-    /// retificação criaria um estado mutável que o envelope congelado não cobre e que o descarte
-    /// da retificação não reverteria. A edição sob retificação, junto do congelamento do grafo no
-    /// envelope, é entregue na story do congelamento conjunto (#928).
+    /// Editável em <b>rascunho</b> (pré-publicação) e sob <b>sessão de retificação</b> de um
+    /// processo publicado — o mesmo padrão dos demais <c>Definir*</c>: <see cref="MutacaoBloqueada"/>
+    /// primeiro, e a revisão do rascunho da sessão é incrementada ao final. Em rascunho puro não há
+    /// sessão nem ETag (a precondição é ignorada); sob sessão, a precondição de concorrência é
+    /// obrigatória. Os fatos coletados já participam do congelamento no envelope e da restauração
+    /// da configuração (Story #928, §7.4), então o descarte da sessão repõe fielmente a coleta
+    /// congelada — por isso a edição sob retificação é segura.
     /// </para>
     /// </remarks>
-    /// <summary>
-    /// Guard não-mutante da edição do grafo de coleta: devolve o erro de "só em rascunho" quando
-    /// o processo já foi publicado, ou <see langword="null"/> quando a edição é permitida. Existe
-    /// para que a Application possa recusar a operação <b>antes</b> de resolver o vocabulário
-    /// cross-módulo e validar o corpo — o mesmo guard continua dentro de
-    /// <see cref="DefinirFatosColetados"/>, esta antecipação dá a ordem, não a garantia.
-    /// </summary>
-    public DomainError? EdicaoDeGrafoDeFatosBloqueada() =>
-        Status != StatusProcesso.Rascunho
-            ? new DomainError(
-                "ProcessoSeletivo.GrafoDeFatosSomenteEmRascunho",
-                "O grafo de coleta de fatos só pode ser definido antes da primeira publicação — "
-                + "a edição sob retificação depende do congelamento conjunto do grafo (#928).")
-            : null;
-
-    public Result DefinirFatosColetados(IReadOnlyList<FatoColetado> fatosColetados)
+    public Result DefinirFatosColetados(IReadOnlyList<FatoColetado> fatosColetados, PrecondicaoIfMatch precondicao)
     {
         ArgumentNullException.ThrowIfNull(fatosColetados);
 
-        if (EdicaoDeGrafoDeFatosBloqueada() is { } bloqueio)
+        if (MutacaoBloqueada(precondicao) is { } bloqueio)
         {
             return Result.Failure(bloqueio);
         }
@@ -968,6 +953,7 @@ public sealed class ProcessoSeletivo : SoftDeletableEntity
             _fatosColetados.Add(fato);
         }
 
+        Rascunho?.IncrementarRevisao();
         return Result.Success();
     }
 
@@ -975,33 +961,19 @@ public sealed class ProcessoSeletivo : SoftDeletableEntity
     /// Substitui integralmente as regras de derivação dos fatos derivados do processo (Story #927).
     /// </summary>
     /// <remarks>
-    /// Só é aceito antes da primeira publicação (processo em rascunho), como a coleta de fatos: a
-    /// regra ainda não entra no envelope congelado nem na restauração, e permitir a edição sob
-    /// retificação criaria estado mutável fora da configuração congelada. A validação aqui é
-    /// estrutural — código de fato único no processo. A validação semântica (o fato alvo é derivado
-    /// com binding de regra; fatos citados e código contribuído no vocabulário e no domínio) depende
-    /// de dados cross-módulo e é do comando na Application.
+    /// Editável em rascunho (pré-publicação) e sob sessão de retificação de um processo publicado —
+    /// o mesmo padrão da coleta de fatos: <see cref="MutacaoBloqueada"/> primeiro, revisão do
+    /// rascunho da sessão incrementada ao final. As regras já entram no envelope congelado e na
+    /// restauração (Story #928, §7.4), então o descarte da sessão as repõe fielmente. A validação
+    /// aqui é estrutural — código de fato único no processo. A validação semântica (o fato alvo é
+    /// derivado com binding de regra; fatos citados e código contribuído no vocabulário e no
+    /// domínio) depende de dados cross-módulo e é do comando na Application.
     /// </remarks>
-    /// <summary>
-    /// Guard não-mutante da edição das regras de derivação: devolve o erro de "só em rascunho"
-    /// quando o processo já foi publicado, ou <see langword="null"/> quando a edição é permitida.
-    /// Existe para que a Application possa recusar a operação <b>antes</b> de resolver o vocabulário
-    /// cross-módulo e validar o corpo — o mesmo guard continua dentro de
-    /// <see cref="DefinirRegrasDerivacao"/>, esta antecipação dá a ordem, não a garantia.
-    /// </summary>
-    public DomainError? EdicaoDeRegrasDerivacaoBloqueada() =>
-        Status != StatusProcesso.Rascunho
-            ? new DomainError(
-                "ProcessoSeletivo.RegrasDerivacaoSomenteEmRascunho",
-                "As regras de derivação só podem ser definidas antes da primeira publicação — "
-                + "a edição sob retificação depende do congelamento conjunto da configuração (#928).")
-            : null;
-
-    public Result DefinirRegrasDerivacao(IReadOnlyList<ConfiguracaoDerivacaoFato> regrasDerivacao)
+    public Result DefinirRegrasDerivacao(IReadOnlyList<ConfiguracaoDerivacaoFato> regrasDerivacao, PrecondicaoIfMatch precondicao)
     {
         ArgumentNullException.ThrowIfNull(regrasDerivacao);
 
-        if (EdicaoDeRegrasDerivacaoBloqueada() is { } bloqueio)
+        if (MutacaoBloqueada(precondicao) is { } bloqueio)
         {
             return Result.Failure(bloqueio);
         }
@@ -1024,7 +996,26 @@ public sealed class ProcessoSeletivo : SoftDeletableEntity
             _regrasDerivacao.Add(config);
         }
 
+        Rascunho?.IncrementarRevisao();
         return Result.Success();
+    }
+
+    /// <summary>
+    /// Limpa a coleta de fatos e as regras de derivação como passo da <b>restauração fiel</b> no
+    /// descarte de uma retificação (Story #986). São as duas coleções que a edição sob retificação
+    /// tornou mutáveis: uma sessão pode ter trocado ordens (0↔1) ou alterado pré-condições/regras,
+    /// e repor as instâncias congeladas por cima das vivas colidiria no índice único de
+    /// <c>Ordem</c>/código na mesma transação. A orquestração do descarte chama este método, faz um
+    /// <c>SaveChanges</c> intermediário (os <c>DELETE</c>s saem primeiro) e só então aplica o grafo
+    /// congelado (<c>INSERT</c> das instâncias reidratadas) — a reposição fiel de graça, sem
+    /// reconciliação profunda dos filhos. Nenhuma identidade precisa sobreviver: são
+    /// <c>EntityBase</c> puros, sem soft-delete, e o <c>Id</c> não é congelado no envelope nem
+    /// referenciado por FK externa.
+    /// </summary>
+    public void LimparColetaEDerivacaoParaRestauracao()
+    {
+        _fatosColetados.Clear();
+        _regrasDerivacao.Clear();
     }
 
     /// <summary>
@@ -2939,14 +2930,16 @@ public sealed class ProcessoSeletivo : SoftDeletableEntity
 
         // Fatos coletados e regras de derivação (Story #928, §7.4): repostos da configuração
         // congelada. A reconciliação é por chave natural (FatoCodigo / CodigoFato) reusando a
-        // instância TRACKED quando o código bate — nunca substituindo por uma instância nova de
-        // mesmo Id, o que colidiria com o identity map, e nunca fazendo DELETE+INSERT do mesmo
-        // (ProcessoSeletivoId, FatoCodigo)/(…, Ordem)/(…, CodigoFato) único na mesma transação. É
-        // seguro reusar a tracked por INTEIRO (com os seus filhos) porque, enquanto a edição sob
-        // retificação não é liberada (§8), fatos/regras são imutáveis após a primeira publicação: o
-        // conteúdo da instância viva JÁ É, por construção, o mesmo do congelado — a mesma garantia
-        // que sustenta a reconciliação de arvoreSatisfacao acima. A reconciliação profunda dos
-        // filhos (sob edição) chega com o §8.
+        // instância TRACKED quando o código bate — segura quando a coleção viva NÃO foi editada (o
+        // conteúdo da viva JÁ É o do congelado, como na sombra de verificação, que nasce vazia, e no
+        // caminho de restauração sem edição prévia). Sob edição sob retificação (Story #986), a viva
+        // pode ter trocado ordens ou alterado pré-condições/regras: reusá-la NÃO restauraria o
+        // congelado, e substituí-la na mesma transação colidiria no índice único de Ordem/código.
+        // Por isso a orquestração do descarte chama LimparColetaEDerivacaoParaRestauracao() e FAZ UM
+        // SaveChanges intermediário ANTES desta reposição: as coleções chegam aqui vazias, o ramo
+        // TRACKED não é tomado, e as instâncias CONGELADAS entram como INSERT (Id novo da
+        // reidratação — nenhuma identidade precisa sobreviver). A reposição fiel de graça, sem
+        // reconciliação profunda dos filhos.
         Dictionary<string, FatoColetado> fatosTracked = _fatosColetados.ToDictionary(f => f.FatoCodigo, StringComparer.Ordinal);
         _fatosColetados.Clear();
         foreach (FatoColetado congelado in grafo.FatosColetados)

--- a/tests/Unifesspa.UniPlus.Selecao.Application.UnitTests/Commands/DefinirFatosColetadosCommandHandlerTests.cs
+++ b/tests/Unifesspa.UniPlus.Selecao.Application.UnitTests/Commands/DefinirFatosColetadosCommandHandlerTests.cs
@@ -13,6 +13,7 @@ using Unifesspa.UniPlus.Selecao.Application.Commands.ProcessosSeletivos;
 using Unifesspa.UniPlus.Selecao.Domain.Entities;
 using Unifesspa.UniPlus.Selecao.Domain.Enums;
 using Unifesspa.UniPlus.Selecao.Domain.Interfaces;
+using Unifesspa.UniPlus.Selecao.Domain.ValueObjects;
 
 /// <summary>
 /// Cobertura do <see cref="DefinirFatosColetadosCommandHandler"/> (Story #984): a coletabilidade
@@ -63,7 +64,7 @@ public sealed class DefinirFatosColetadosCommandHandlerTests
     {
         Guid processoId = Guid.CreateVersion7();
         Mocks mocks = NovosMocks(processo: null, processoId);
-        DefinirFatosColetadosCommand command = new(processoId, []);
+        DefinirFatosColetadosCommand command = new(processoId, [], PrecondicaoIfMatch.Ausente);
 
         Result<MutacaoAceita> resultado = await HandleAsync(mocks, command);
 
@@ -81,7 +82,7 @@ public sealed class DefinirFatosColetadosCommandHandlerTests
         [
             new FatoColetadoInput("COR_RACA", 0, null),
             new FatoColetadoInput("BAIXA_RENDA", 1, [[Condicao("COR_RACA", "IGUAL", "PRETA")]]),
-        ]);
+        ], PrecondicaoIfMatch.Ausente);
 
         Result<MutacaoAceita> resultado = await HandleAsync(mocks, command);
 
@@ -96,7 +97,7 @@ public sealed class DefinirFatosColetadosCommandHandlerTests
     {
         ProcessoSeletivo processo = ProcessoEmRascunho();
         Mocks mocks = NovosMocks(processo, processo.Id);
-        DefinirFatosColetadosCommand command = new(processo.Id, [new FatoColetadoInput("MODALIDADE", 0, null)]);
+        DefinirFatosColetadosCommand command = new(processo.Id, [new FatoColetadoInput("MODALIDADE", 0, null)], PrecondicaoIfMatch.Ausente);
 
         Result<MutacaoAceita> resultado = await HandleAsync(mocks, command);
 
@@ -110,7 +111,7 @@ public sealed class DefinirFatosColetadosCommandHandlerTests
     {
         ProcessoSeletivo processo = ProcessoEmRascunho();
         Mocks mocks = NovosMocks(processo, processo.Id);
-        DefinirFatosColetadosCommand command = new(processo.Id, [new FatoColetadoInput("RENDA_PER_CAPITA", 0, null)]);
+        DefinirFatosColetadosCommand command = new(processo.Id, [new FatoColetadoInput("RENDA_PER_CAPITA", 0, null)], PrecondicaoIfMatch.Ausente);
 
         Result<MutacaoAceita> resultado = await HandleAsync(mocks, command);
 
@@ -123,7 +124,7 @@ public sealed class DefinirFatosColetadosCommandHandlerTests
     {
         ProcessoSeletivo processo = ProcessoEmRascunho();
         Mocks mocks = NovosMocks(processo, processo.Id);
-        DefinirFatosColetadosCommand command = new(processo.Id, [new FatoColetadoInput("V", 0, null)]);
+        DefinirFatosColetadosCommand command = new(processo.Id, [new FatoColetadoInput("V", 0, null)], PrecondicaoIfMatch.Ausente);
 
         Result<MutacaoAceita> resultado = await HandleAsync(mocks, command);
 
@@ -142,7 +143,7 @@ public sealed class DefinirFatosColetadosCommandHandlerTests
         [
             new FatoColetadoInput("COR_RACA", 0, null),
             new FatoColetadoInput("BAIXA_RENDA", 1, [[Condicao("COR_RACA", "MAIOR_IGUAL", "PRETA")]]),
-        ]);
+        ], PrecondicaoIfMatch.Ausente);
 
         Result<MutacaoAceita> resultado = await HandleAsync(mocks, command);
 
@@ -161,7 +162,7 @@ public sealed class DefinirFatosColetadosCommandHandlerTests
         [
             new FatoColetadoInput("BAIXA_RENDA", 0, [[Condicao("COR_RACA", "IGUAL", "PRETA")]]),
             new FatoColetadoInput("COR_RACA", 1, null),
-        ]);
+        ], PrecondicaoIfMatch.Ausente);
 
         Result<MutacaoAceita> resultado = await HandleAsync(mocks, command);
 

--- a/tests/Unifesspa.UniPlus.Selecao.Application.UnitTests/Commands/DefinirRegrasDerivacaoCommandHandlerTests.cs
+++ b/tests/Unifesspa.UniPlus.Selecao.Application.UnitTests/Commands/DefinirRegrasDerivacaoCommandHandlerTests.cs
@@ -61,7 +61,7 @@ public sealed class DefinirRegrasDerivacaoCommandHandlerTests
     {
         ProcessoSeletivo processo = ProcessoBase();
 
-        processo.DefinirFatosColetados([FatoColetado.Criar("COR_RACA", 0, null).Value!])
+        processo.DefinirFatosColetados([FatoColetado.Criar("COR_RACA", 0, null).Value!], PrecondicaoIfMatch.Ausente)
             .IsSuccess.Should().BeTrue();
 
         ReferenciaRegra regraDistribuicao = ReferenciaRegra.Criar(
@@ -106,7 +106,7 @@ public sealed class DefinirRegrasDerivacaoCommandHandlerTests
         Guid processoId = Guid.CreateVersion7();
         Mocks mocks = NovosMocks(processo: null, processoId);
 
-        Result<MutacaoAceita> resultado = await HandleAsync(mocks, new DefinirRegrasDerivacaoCommand(processoId, []));
+        Result<MutacaoAceita> resultado = await HandleAsync(mocks, new DefinirRegrasDerivacaoCommand(processoId, [], PrecondicaoIfMatch.Ausente));
 
         resultado.IsFailure.Should().BeTrue();
         resultado.Error!.Code.Should().Be("ProcessoSeletivo.NaoEncontrado");
@@ -123,7 +123,7 @@ public sealed class DefinirRegrasDerivacaoCommandHandlerTests
             ConfigModalidade(
                 new RegraDerivacaoInput(0, "AC", null),
                 new RegraDerivacaoInput(1, "AC", [[Condicao("COR_RACA", "IGUAL", "PRETA")]])),
-        ]);
+        ], PrecondicaoIfMatch.Ausente);
 
         Result<MutacaoAceita> resultado = await HandleAsync(mocks, command);
 
@@ -139,7 +139,7 @@ public sealed class DefinirRegrasDerivacaoCommandHandlerTests
         ProcessoSeletivo processo = ProcessoBase();
         Mocks mocks = NovosMocks(processo, processo.Id);
         DefinirRegrasDerivacaoCommand command = new(processo.Id,
-            [new ConfiguracaoDerivacaoInput("BOGUS", [new RegraDerivacaoInput(0, "AC", null)])]);
+            [new ConfiguracaoDerivacaoInput("BOGUS", [new RegraDerivacaoInput(0, "AC", null)])], PrecondicaoIfMatch.Ausente);
 
         Result<MutacaoAceita> resultado = await HandleAsync(mocks, command);
 
@@ -153,7 +153,7 @@ public sealed class DefinirRegrasDerivacaoCommandHandlerTests
         ProcessoSeletivo processo = ProcessoBase();
         Mocks mocks = NovosMocks(processo, processo.Id);
         DefinirRegrasDerivacaoCommand command = new(processo.Id,
-            [new ConfiguracaoDerivacaoInput("COR_RACA", [new RegraDerivacaoInput(0, "PRETA", null)])]);
+            [new ConfiguracaoDerivacaoInput("COR_RACA", [new RegraDerivacaoInput(0, "PRETA", null)])], PrecondicaoIfMatch.Ausente);
 
         Result<MutacaoAceita> resultado = await HandleAsync(mocks, command);
 
@@ -169,7 +169,7 @@ public sealed class DefinirRegrasDerivacaoCommandHandlerTests
 
         // "V" não é uma modalidade ofertada (só AC é).
         DefinirRegrasDerivacaoCommand command = new(processo.Id,
-            [ConfigModalidade(new RegraDerivacaoInput(0, "V", null))]);
+            [ConfigModalidade(new RegraDerivacaoInput(0, "V", null))], PrecondicaoIfMatch.Ausente);
 
         Result<MutacaoAceita> resultado = await HandleAsync(mocks, command);
 
@@ -185,7 +185,7 @@ public sealed class DefinirRegrasDerivacaoCommandHandlerTests
 
         // BAIXA_RENDA existe no vocabulário mas não é coletado nem derivado neste processo.
         DefinirRegrasDerivacaoCommand command = new(processo.Id,
-            [ConfigModalidade(new RegraDerivacaoInput(0, "AC", [[Condicao("BAIXA_RENDA", "IGUAL", true)]]))]);
+            [ConfigModalidade(new RegraDerivacaoInput(0, "AC", [[Condicao("BAIXA_RENDA", "IGUAL", true)]]))], PrecondicaoIfMatch.Ausente);
 
         Result<MutacaoAceita> resultado = await HandleAsync(mocks, command);
 
@@ -201,7 +201,7 @@ public sealed class DefinirRegrasDerivacaoCommandHandlerTests
 
         // COR_RACA é categórico: MAIOR_IGUAL não se aplica.
         DefinirRegrasDerivacaoCommand command = new(processo.Id,
-            [ConfigModalidade(new RegraDerivacaoInput(0, "AC", [[Condicao("COR_RACA", "MAIOR_IGUAL", "PRETA")]]))]);
+            [ConfigModalidade(new RegraDerivacaoInput(0, "AC", [[Condicao("COR_RACA", "MAIOR_IGUAL", "PRETA")]]))], PrecondicaoIfMatch.Ausente);
 
         Result<MutacaoAceita> resultado = await HandleAsync(mocks, command);
 

--- a/tests/Unifesspa.UniPlus.Selecao.Application.UnitTests/Queries/ObterProcessoSeletivoQueryHandlerColetaDeFatosTests.cs
+++ b/tests/Unifesspa.UniPlus.Selecao.Application.UnitTests/Queries/ObterProcessoSeletivoQueryHandlerColetaDeFatosTests.cs
@@ -47,7 +47,7 @@ public sealed class ObterProcessoSeletivoQueryHandlerColetaDeFatosTests
         FatoColetado corRaca = FatoColetado.Criar("COR_RACA", 1,
             [Precondicao(0, "BAIXA_RENDA", Operador.Igual, true)]).Value!;
         // Passa fora de ordem de propósito — a projeção é quem ordena.
-        processo.DefinirFatosColetados([corRaca, baixaRenda]).IsSuccess.Should().BeTrue();
+        processo.DefinirFatosColetados([corRaca, baixaRenda], PrecondicaoIfMatch.Ausente).IsSuccess.Should().BeTrue();
 
         ProcessoSeletivoDto dto = await ProjetarAsync(processo);
 
@@ -73,7 +73,7 @@ public sealed class ObterProcessoSeletivoQueryHandlerColetaDeFatosTests
             [CondicaoRegra(0, "COR_RACA", Operador.Igual, "PRETA")]).Value!;
         // Regras fora de ordem — a projeção ordena por Ordem.
         ConfiguracaoDerivacaoFato config = ConfiguracaoDerivacaoFato.Criar("MODALIDADE", [condicional, ancora]).Value!;
-        processo.DefinirRegrasDerivacao([config]).IsSuccess.Should().BeTrue();
+        processo.DefinirRegrasDerivacao([config], PrecondicaoIfMatch.Ausente).IsSuccess.Should().BeTrue();
 
         ProcessoSeletivoDto dto = await ProjetarAsync(processo);
 

--- a/tests/Unifesspa.UniPlus.Selecao.Application.UnitTests/Validators/DefinirFatosColetadosCommandValidatorTests.cs
+++ b/tests/Unifesspa.UniPlus.Selecao.Application.UnitTests/Validators/DefinirFatosColetadosCommandValidatorTests.cs
@@ -8,6 +8,7 @@ using FluentValidation.Results;
 
 using Unifesspa.UniPlus.Selecao.Application.Commands.ProcessosSeletivos;
 using Unifesspa.UniPlus.Selecao.Application.Validators.ProcessosSeletivos;
+using Unifesspa.UniPlus.Selecao.Domain.ValueObjects;
 
 public sealed class DefinirFatosColetadosCommandValidatorTests
 {
@@ -19,7 +20,7 @@ public sealed class DefinirFatosColetadosCommandValidatorTests
     [Fact(DisplayName = "Passa com lista de fatos vazia — zera a coleta")]
     public void Aceita_ListaVazia()
     {
-        ValidationResult result = Validator.Validate(new DefinirFatosColetadosCommand(Guid.CreateVersion7(), []));
+        ValidationResult result = Validator.Validate(new DefinirFatosColetadosCommand(Guid.CreateVersion7(), [], PrecondicaoIfMatch.Ausente));
 
         result.IsValid.Should().BeTrue();
     }
@@ -28,7 +29,7 @@ public sealed class DefinirFatosColetadosCommandValidatorTests
     public void Aceita_FatoSemPrecondicao()
     {
         ValidationResult result = Validator.Validate(new DefinirFatosColetadosCommand(
-            Guid.CreateVersion7(), [new FatoColetadoInput("COR_RACA", 0, null)]));
+            Guid.CreateVersion7(), [new FatoColetadoInput("COR_RACA", 0, null)], PrecondicaoIfMatch.Ausente));
 
         result.IsValid.Should().BeTrue();
     }
@@ -36,7 +37,7 @@ public sealed class DefinirFatosColetadosCommandValidatorTests
     [Fact(DisplayName = "Falha quando a lista de fatos é nula (payload malformado)")]
     public void Rejeita_FatosNulo()
     {
-        ValidationResult result = Validator.Validate(new DefinirFatosColetadosCommand(Guid.CreateVersion7(), null!));
+        ValidationResult result = Validator.Validate(new DefinirFatosColetadosCommand(Guid.CreateVersion7(), null!, PrecondicaoIfMatch.Ausente));
 
         result.IsValid.Should().BeFalse();
         result.Errors.Should().Contain(e => e.PropertyName == "Fatos");
@@ -46,7 +47,7 @@ public sealed class DefinirFatosColetadosCommandValidatorTests
     public void Rejeita_FatoCodigoVazio()
     {
         ValidationResult result = Validator.Validate(new DefinirFatosColetadosCommand(
-            Guid.CreateVersion7(), [new FatoColetadoInput("", 0, null)]));
+            Guid.CreateVersion7(), [new FatoColetadoInput("", 0, null)], PrecondicaoIfMatch.Ausente));
 
         result.IsValid.Should().BeFalse();
         result.Errors.Should().Contain(e => e.PropertyName == "Fatos[0].FatoCodigo");
@@ -56,7 +57,7 @@ public sealed class DefinirFatosColetadosCommandValidatorTests
     public void Rejeita_OrdemNegativa()
     {
         ValidationResult result = Validator.Validate(new DefinirFatosColetadosCommand(
-            Guid.CreateVersion7(), [new FatoColetadoInput("COR_RACA", -1, null)]));
+            Guid.CreateVersion7(), [new FatoColetadoInput("COR_RACA", -1, null)], PrecondicaoIfMatch.Ausente));
 
         result.IsValid.Should().BeFalse();
         result.Errors.Should().Contain(e => e.PropertyName == "Fatos[0].Ordem");
@@ -66,7 +67,7 @@ public sealed class DefinirFatosColetadosCommandValidatorTests
     public void Rejeita_PrecondicaoListaExternaVazia()
     {
         ValidationResult result = Validator.Validate(new DefinirFatosColetadosCommand(
-            Guid.CreateVersion7(), [new FatoColetadoInput("BAIXA_RENDA", 0, [])]));
+            Guid.CreateVersion7(), [new FatoColetadoInput("BAIXA_RENDA", 0, [])], PrecondicaoIfMatch.Ausente));
 
         result.IsValid.Should().BeFalse();
         result.Errors.Should().Contain(e => e.PropertyName == "Fatos[0].Precondicao");
@@ -76,7 +77,7 @@ public sealed class DefinirFatosColetadosCommandValidatorTests
     public void Rejeita_PrecondicaoClausulaVazia()
     {
         ValidationResult result = Validator.Validate(new DefinirFatosColetadosCommand(
-            Guid.CreateVersion7(), [new FatoColetadoInput("BAIXA_RENDA", 0, [[]])]));
+            Guid.CreateVersion7(), [new FatoColetadoInput("BAIXA_RENDA", 0, [[]])], PrecondicaoIfMatch.Ausente));
 
         result.IsValid.Should().BeFalse();
         result.Errors.Should().Contain(e => e.PropertyName == "Fatos[0].Precondicao");
@@ -86,7 +87,7 @@ public sealed class DefinirFatosColetadosCommandValidatorTests
     public void Rejeita_PrecondicaoCondicaoNula()
     {
         ValidationResult result = Validator.Validate(new DefinirFatosColetadosCommand(
-            Guid.CreateVersion7(), [new FatoColetadoInput("BAIXA_RENDA", 0, [[null!]])]));
+            Guid.CreateVersion7(), [new FatoColetadoInput("BAIXA_RENDA", 0, [[null!]])], PrecondicaoIfMatch.Ausente));
 
         result.IsValid.Should().BeFalse();
         result.Errors.Should().Contain(e => e.PropertyName == "Fatos[0].Precondicao");
@@ -96,7 +97,7 @@ public sealed class DefinirFatosColetadosCommandValidatorTests
     public void Aceita_PrecondicaoBemFormada()
     {
         ValidationResult result = Validator.Validate(new DefinirFatosColetadosCommand(
-            Guid.CreateVersion7(), [new FatoColetadoInput("BAIXA_RENDA", 0, [[Condicao("COR_RACA")]])]));
+            Guid.CreateVersion7(), [new FatoColetadoInput("BAIXA_RENDA", 0, [[Condicao("COR_RACA")]])], PrecondicaoIfMatch.Ausente));
 
         result.IsValid.Should().BeTrue();
     }

--- a/tests/Unifesspa.UniPlus.Selecao.Application.UnitTests/Validators/DefinirRegrasDerivacaoCommandValidatorTests.cs
+++ b/tests/Unifesspa.UniPlus.Selecao.Application.UnitTests/Validators/DefinirRegrasDerivacaoCommandValidatorTests.cs
@@ -8,6 +8,7 @@ using FluentValidation.Results;
 
 using Unifesspa.UniPlus.Selecao.Application.Commands.ProcessosSeletivos;
 using Unifesspa.UniPlus.Selecao.Application.Validators.ProcessosSeletivos;
+using Unifesspa.UniPlus.Selecao.Domain.ValueObjects;
 
 public sealed class DefinirRegrasDerivacaoCommandValidatorTests
 {
@@ -17,12 +18,12 @@ public sealed class DefinirRegrasDerivacaoCommandValidatorTests
         new("COR_RACA", "IGUAL", JsonSerializer.SerializeToElement("PRETA"));
 
     private static DefinirRegrasDerivacaoCommand Comando(params RegraDerivacaoInput[] regras) =>
-        new(Guid.CreateVersion7(), [new ConfiguracaoDerivacaoInput("MODALIDADE", regras)]);
+        new(Guid.CreateVersion7(), [new ConfiguracaoDerivacaoInput("MODALIDADE", regras)], PrecondicaoIfMatch.Ausente);
 
     [Fact(DisplayName = "Passa com lista de configurações vazia — zera as regras")]
     public void Aceita_ListaVazia()
     {
-        ValidationResult result = Validator.Validate(new DefinirRegrasDerivacaoCommand(Guid.CreateVersion7(), []));
+        ValidationResult result = Validator.Validate(new DefinirRegrasDerivacaoCommand(Guid.CreateVersion7(), [], PrecondicaoIfMatch.Ausente));
 
         result.IsValid.Should().BeTrue();
     }
@@ -46,7 +47,7 @@ public sealed class DefinirRegrasDerivacaoCommandValidatorTests
     [Fact(DisplayName = "Falha quando a lista de configurações é nula")]
     public void Rejeita_ConfiguracoesNulo()
     {
-        ValidationResult result = Validator.Validate(new DefinirRegrasDerivacaoCommand(Guid.CreateVersion7(), null!));
+        ValidationResult result = Validator.Validate(new DefinirRegrasDerivacaoCommand(Guid.CreateVersion7(), null!, PrecondicaoIfMatch.Ausente));
 
         result.IsValid.Should().BeFalse();
         result.Errors.Should().Contain(e => e.PropertyName == "Configuracoes");
@@ -56,7 +57,7 @@ public sealed class DefinirRegrasDerivacaoCommandValidatorTests
     public void Rejeita_CodigoFatoVazio()
     {
         ValidationResult result = Validator.Validate(new DefinirRegrasDerivacaoCommand(
-            Guid.CreateVersion7(), [new ConfiguracaoDerivacaoInput("", [new RegraDerivacaoInput(0, "AC", null)])]));
+            Guid.CreateVersion7(), [new ConfiguracaoDerivacaoInput("", [new RegraDerivacaoInput(0, "AC", null)])], PrecondicaoIfMatch.Ausente));
 
         result.IsValid.Should().BeFalse();
         result.Errors.Should().Contain(e => e.PropertyName == "Configuracoes[0].CodigoFato");
@@ -66,7 +67,7 @@ public sealed class DefinirRegrasDerivacaoCommandValidatorTests
     public void Rejeita_SemRegras()
     {
         ValidationResult result = Validator.Validate(new DefinirRegrasDerivacaoCommand(
-            Guid.CreateVersion7(), [new ConfiguracaoDerivacaoInput("MODALIDADE", [])]));
+            Guid.CreateVersion7(), [new ConfiguracaoDerivacaoInput("MODALIDADE", [])], PrecondicaoIfMatch.Ausente));
 
         result.IsValid.Should().BeFalse();
         result.Errors.Should().Contain(e => e.PropertyName == "Configuracoes[0].Regras");

--- a/tests/Unifesspa.UniPlus.Selecao.ArchTests/RestauracaoSempreProvadaTests.cs
+++ b/tests/Unifesspa.UniPlus.Selecao.ArchTests/RestauracaoSempreProvadaTests.cs
@@ -29,21 +29,31 @@ public sealed class RestauracaoSempreProvadaTests
 {
     private const string MetodoDoDominio = "RestaurarConfiguracaoCongelada";
 
+    private const string HandlerDoDescarte =
+        "Unifesspa.UniPlus.Selecao.Application/Commands/ProcessosSeletivos/DescartarRetificacaoCommandHandler.cs";
+
     /// <summary>
-    /// Os três lugares onde o nome do método pode aparecer legitimamente em <c>src/</c> —
-    /// declarados como caminhos relativos com <c>/</c>, e comparados contra o caminho do
-    /// arquivo já normalizado (<see cref="Normalizar"/>).
+    /// Os lugares onde o nome do método pode aparecer legitimamente em <c>src/</c> — declarados
+    /// como caminhos relativos com <c>/</c>, e comparados contra o caminho do arquivo já
+    /// normalizado (<see cref="Normalizar"/>).
     /// </summary>
     private static readonly string[] CallersAutorizados =
     [
         // A própria declaração, no agregado.
         "Unifesspa.UniPlus.Selecao.Domain/Entities/ProcessoSeletivo.cs",
 
-        // O único caller: decodifica, repõe e PROVA — numa operação só.
+        // O restaurador PROVA (round-trip byte-a-byte numa sombra) e devolve o grafo provado — mas
+        // não toca a raiz viva (Story #986): o descarte precisa intercalar um SaveChanges entre
+        // limpar as coleções mutáveis e reinserir as congeladas, para não colidir no índice único.
         "Unifesspa.UniPlus.Selecao.Application/Services/RestauradorDeConfiguracao.cs",
 
         // A porta que o descreve.
         "Unifesspa.UniPlus.Selecao.Application/Abstractions/IRestauradorDeConfiguracao.cs",
+
+        // O descarte APLICA na raiz viva o grafo que o restaurador provou-e-devolveu — nunca um
+        // grafo qualquer. O teste DescarteProvaAntesDeAplicar abaixo é o que garante que a prova
+        // precede a aplicação aqui, fechando a mesma porta que o split de #986 abriu.
+        HandlerDoDescarte,
     ];
 
     /// <summary>Caminho com separador <c>/</c>, para comparar do mesmo jeito em qualquer host.</summary>
@@ -138,6 +148,39 @@ public sealed class RestauracaoSempreProvadaTests
         fonte.Should().Contain("SombraParaVerificacao(",
             "a prova roda ANTES de tocar a raiz viva — provar depois deixaria o agregado tracked empobrecido quando " +
             "a prova falhasse, e a atomicidade dependeria de o handler lembrar de não salvar");
+    }
+
+    /// <summary>
+    /// O descarte é o único caller da raiz viva além do agregado/restaurador (Story #986), e ele
+    /// só é legítimo porque APLICA o grafo que o restaurador <b>provou-e-devolveu</b> — nunca um
+    /// grafo qualquer. Este teste fecha a porta que o split abriu: exige que, no handler do
+    /// descarte, a prova (<c>restaurador.Restaurar</c>) apareça ANTES da aplicação na raiz viva
+    /// (<c>RestaurarConfiguracaoCongelada</c>). Um handler que aplicasse sem provar antes passaria
+    /// no fitness de allowlist, mas não aqui.
+    /// </summary>
+    [Fact(DisplayName = "O descarte PROVA (chama o restaurador) antes de aplicar a configuração congelada na raiz viva")]
+    public void DescarteProvaAntesDeAplicar()
+    {
+        string handler = Path.Join(
+            RaizDoSrc(),
+            "selecao",
+            "Unifesspa.UniPlus.Selecao.Application",
+            "Commands",
+            "ProcessosSeletivos",
+            "DescartarRetificacaoCommandHandler.cs");
+
+        File.Exists(handler).Should().BeTrue($"o handler do descarte deveria existir em {handler}");
+
+        string fonte = CodigoSemComentarios(handler);
+        int posProva = fonte.IndexOf("restaurador.Restaurar(", StringComparison.Ordinal);
+        int posAplicacao = fonte.IndexOf($".{MetodoDoDominio}(", StringComparison.Ordinal);
+
+        posProva.Should().BeGreaterThanOrEqualTo(0,
+            "o descarte tem de PROVAR pelo restaurador — sem a prova, ele repõe um grafo que o agregado não autentica");
+        posAplicacao.Should().BeGreaterThanOrEqualTo(0, "o descarte aplica o grafo provado na raiz viva");
+        posProva.Should().BeLessThan(posAplicacao,
+            "a prova precede a aplicação: o restaurador devolve o grafo só quando o round-trip byte-a-byte bate, e é " +
+            "esse grafo — nunca um qualquer — que o descarte aplica na raiz viva");
     }
 
     /// <summary>

--- a/tests/Unifesspa.UniPlus.Selecao.Domain.UnitTests/Entities/ProcessoSeletivoFatosColetadosTests.cs
+++ b/tests/Unifesspa.UniPlus.Selecao.Domain.UnitTests/Entities/ProcessoSeletivoFatosColetadosTests.cs
@@ -33,7 +33,7 @@ public sealed class ProcessoSeletivoFatosColetadosTests
         ProcessoSeletivo processo = NovoProcesso();
 
         Result resultado = processo.DefinirFatosColetados(
-            [Fato("PCD", 0), Fato("EGRESSO_ESCOLA_PUBLICA", 1), Fato("CONCORRER_PCD", 2, "PCD")]);
+            [Fato("PCD", 0), Fato("EGRESSO_ESCOLA_PUBLICA", 1), Fato("CONCORRER_PCD", 2, "PCD")], PrecondicaoIfMatch.Ausente);
 
         resultado.IsSuccess.Should().BeTrue();
         processo.FatosColetados.Should().HaveCount(3);
@@ -47,7 +47,7 @@ public sealed class ProcessoSeletivoFatosColetadosTests
         // Grafo perfeitamente acíclico: CONCORRER_PCD depende de PCD e nada depende de CONCORRER_PCD.
         // Mas PCD vem DEPOIS na ordem de coleta, então a pergunta seria feita antes da resposta existir.
         Result resultado = processo.DefinirFatosColetados(
-            [Fato("CONCORRER_PCD", 0, "PCD"), Fato("PCD", 1)]);
+            [Fato("CONCORRER_PCD", 0, "PCD"), Fato("PCD", 1)], PrecondicaoIfMatch.Ausente);
 
         resultado.IsFailure.Should().BeTrue("aciclicidade sozinha não garante que a dependência venha antes");
         resultado.Error!.Code.Should().Be(FatoColetadoErrorCodes.PrecondicaoCitaFatoPosterior);
@@ -59,7 +59,7 @@ public sealed class ProcessoSeletivoFatosColetadosTests
         ProcessoSeletivo processo = NovoProcesso();
 
         Result resultado = processo.DefinirFatosColetados(
-            [Fato("A", 0, "C"), Fato("B", 1, "A"), Fato("C", 2, "B")]);
+            [Fato("A", 0, "C"), Fato("B", 1, "A"), Fato("C", 2, "B")], PrecondicaoIfMatch.Ausente);
 
         resultado.IsFailure.Should().BeTrue();
         resultado.Error!.Code.Should().Be(FatoColetadoErrorCodes.GrafoComCiclo);
@@ -78,7 +78,7 @@ public sealed class ProcessoSeletivoFatosColetadosTests
         // ENTRADA cita A; A e B formam o ciclo (A cita B, B cita A). O caminho reportado deve ser
         // "A → B → A", nunca "ENTRADA → A → B → A": ENTRADA leva ao ciclo mas não faz parte dele.
         Result resultado = processo.DefinirFatosColetados(
-            [Fato("ENTRADA", 0, "A"), Fato("A", 1, "B"), Fato("B", 2, "A")]);
+            [Fato("ENTRADA", 0, "A"), Fato("A", 1, "B"), Fato("B", 2, "A")], PrecondicaoIfMatch.Ausente);
 
         resultado.IsFailure.Should().BeTrue();
         resultado.Error!.Code.Should().Be(FatoColetadoErrorCodes.GrafoComCiclo);
@@ -100,7 +100,7 @@ public sealed class ProcessoSeletivoFatosColetadosTests
         ProcessoSeletivo processo = NovoProcesso();
 
         Result resultado = processo.DefinirFatosColetados(
-            [Fato("CONCORRER_PCD", 0, "PCD")]);
+            [Fato("CONCORRER_PCD", 0, "PCD")], PrecondicaoIfMatch.Ausente);
 
         resultado.IsFailure.Should().BeTrue("o gate ficaria preso a um fato que este processo nunca vai resolver");
         resultado.Error!.Code.Should().Be(FatoColetadoErrorCodes.PrecondicaoCitaFatoNaoColetado);
@@ -121,7 +121,7 @@ public sealed class ProcessoSeletivoFatosColetadosTests
         ProcessoSeletivo processo = NovoProcesso();
 
         Result resultado = processo.DefinirFatosColetados(
-            [Fato("PCD", 0), Fato("PCD", 1)]);
+            [Fato("PCD", 0), Fato("PCD", 1)], PrecondicaoIfMatch.Ausente);
 
         resultado.IsFailure.Should().BeTrue();
         resultado.Error!.Code.Should().Be(FatoColetadoErrorCodes.FatoDuplicado);
@@ -133,7 +133,7 @@ public sealed class ProcessoSeletivoFatosColetadosTests
         ProcessoSeletivo processo = NovoProcesso();
 
         Result resultado = processo.DefinirFatosColetados(
-            [Fato("PCD", 0), Fato("EGRESSO_ESCOLA_PUBLICA", 0)]);
+            [Fato("PCD", 0), Fato("EGRESSO_ESCOLA_PUBLICA", 0)], PrecondicaoIfMatch.Ausente);
 
         resultado.IsFailure.Should().BeTrue(
             "com empate de ordem, 'anterior' deixa de ser decidível entre os dois fatos");
@@ -144,10 +144,10 @@ public sealed class ProcessoSeletivoFatosColetadosTests
     public void Definir_SubstituiPorInteiro()
     {
         ProcessoSeletivo processo = NovoProcesso();
-        processo.DefinirFatosColetados([Fato("PCD", 0), Fato("EGRESSO_ESCOLA_PUBLICA", 1)])
+        processo.DefinirFatosColetados([Fato("PCD", 0), Fato("EGRESSO_ESCOLA_PUBLICA", 1)], PrecondicaoIfMatch.Ausente)
             .IsSuccess.Should().BeTrue();
 
-        processo.DefinirFatosColetados([Fato("SEXO", 0)]).IsSuccess.Should().BeTrue();
+        processo.DefinirFatosColetados([Fato("SEXO", 0)], PrecondicaoIfMatch.Ausente).IsSuccess.Should().BeTrue();
 
         processo.FatosColetados.Should().HaveCount(1);
         processo.FatosColetados.Single().FatoCodigo.Should().Be("SEXO");
@@ -158,7 +158,7 @@ public sealed class ProcessoSeletivoFatosColetadosTests
     {
         ProcessoSeletivo processo = NovoProcesso();
 
-        Result resultado = processo.DefinirFatosColetados([]);
+        Result resultado = processo.DefinirFatosColetados([], PrecondicaoIfMatch.Ausente);
 
         resultado.IsSuccess.Should().BeTrue();
         processo.FatosColetados.Should().BeEmpty();
@@ -169,7 +169,7 @@ public sealed class ProcessoSeletivoFatosColetadosTests
     {
         ProcessoSeletivo processo = NovoProcesso();
 
-        processo.DefinirFatosColetados([Fato("PCD", 0), Fato("CONCORRER_PCD", 1, "PCD")])
+        processo.DefinirFatosColetados([Fato("PCD", 0), Fato("CONCORRER_PCD", 1, "PCD")], PrecondicaoIfMatch.Ausente)
             .IsSuccess.Should().BeTrue();
 
         processo.FatosColetados.Should().OnlyContain(f => f.ProcessoSeletivoId == processo.Id);

--- a/tests/Unifesspa.UniPlus.Selecao.Domain.UnitTests/Entities/ProcessoSeletivoRegrasDerivacaoTests.cs
+++ b/tests/Unifesspa.UniPlus.Selecao.Domain.UnitTests/Entities/ProcessoSeletivoRegrasDerivacaoTests.cs
@@ -89,7 +89,7 @@ public sealed class ProcessoSeletivoRegrasDerivacaoTests
         ConfiguracaoDerivacaoFato d1 = ConfiguracaoDerivacaoFato.Criar("D1", [Regra(0, "X", ("D2", true))]).Value!;
         ConfiguracaoDerivacaoFato d2 = ConfiguracaoDerivacaoFato.Criar("D2", [Regra(0, "Y", ("D1", true))]).Value!;
 
-        processo.DefinirRegrasDerivacao([d1, d2]).IsSuccess.Should().BeTrue(
+        processo.DefinirRegrasDerivacao([d1, d2], PrecondicaoIfMatch.Ausente).IsSuccess.Should().BeTrue(
             "a definição isolada só barra código duplicado — o ciclo cruza duas configurações e passa aqui");
 
         processo.PendenciaPreCanonicalizacao().Should().NotBeNull();
@@ -105,7 +105,7 @@ public sealed class ProcessoSeletivoRegrasDerivacaoTests
 
         // "V" é rótulo de exibição de AC_PCD no edital, nunca código — e não está entre as
         // modalidades ofertadas por este processo. Contribuí-lo é recusado, sem tradução de alias.
-        processo.DefinirRegrasDerivacao([ConfiguracaoDerivacaoFato.Criar("MODALIDADE", [Ancora(0, "V")]).Value!])
+        processo.DefinirRegrasDerivacao([ConfiguracaoDerivacaoFato.Criar("MODALIDADE", [Ancora(0, "V")]).Value!], PrecondicaoIfMatch.Ausente)
             .IsSuccess.Should().BeTrue("a definição isolada não conhece o domínio de modalidades ofertadas");
 
         processo.PendenciaPreCanonicalizacao().Should().NotBeNull();
@@ -119,7 +119,7 @@ public sealed class ProcessoSeletivoRegrasDerivacaoTests
         ProcessoSeletivo processo = NovoProcesso();
         OfertarModalidades(processo, "AC");
 
-        processo.DefinirRegrasDerivacao([ConfiguracaoDerivacaoFato.Criar("MODALIDADE", [Ancora(0, "AC")]).Value!])
+        processo.DefinirRegrasDerivacao([ConfiguracaoDerivacaoFato.Criar("MODALIDADE", [Ancora(0, "AC")]).Value!], PrecondicaoIfMatch.Ausente)
             .IsSuccess.Should().BeTrue();
 
         processo.PendenciaPreCanonicalizacao().Should().BeNull(
@@ -133,7 +133,7 @@ public sealed class ProcessoSeletivoRegrasDerivacaoTests
 
         ConfiguracaoDerivacaoFato d1 = ConfiguracaoDerivacaoFato.Criar("D1", [Regra(0, "X", ("BOGUS", true))]).Value!;
 
-        processo.DefinirRegrasDerivacao([d1]).IsSuccess.Should().BeTrue(
+        processo.DefinirRegrasDerivacao([d1], PrecondicaoIfMatch.Ausente).IsSuccess.Should().BeTrue(
             "a definição isolada só valida forma e unicidade — não conhece o universo de fatos do processo");
 
         processo.PendenciaPreCanonicalizacao().Should().NotBeNull();
@@ -146,7 +146,7 @@ public sealed class ProcessoSeletivoRegrasDerivacaoTests
     {
         ProcessoSeletivo processo = NovoProcesso();
 
-        Result resultado = processo.DefinirRegrasDerivacao([ConfigModalidade()]);
+        Result resultado = processo.DefinirRegrasDerivacao([ConfigModalidade()], PrecondicaoIfMatch.Ausente);
 
         resultado.IsSuccess.Should().BeTrue(resultado.Error?.Message);
         processo.RegrasDerivacao.Should().ContainSingle(c => c.CodigoFato == "MODALIDADE");
@@ -194,7 +194,7 @@ public sealed class ProcessoSeletivoRegrasDerivacaoTests
     {
         ProcessoSeletivo processo = NovoProcesso();
 
-        Result resultado = processo.DefinirRegrasDerivacao([ConfigModalidade(), ConfigModalidade()]);
+        Result resultado = processo.DefinirRegrasDerivacao([ConfigModalidade(), ConfigModalidade()], PrecondicaoIfMatch.Ausente);
 
         resultado.IsFailure.Should().BeTrue();
         resultado.Error!.Code.Should().Be(ConfiguracaoDerivacaoFatoErrorCodes.CodigoFatoDuplicado);
@@ -223,11 +223,11 @@ public sealed class ProcessoSeletivoRegrasDerivacaoTests
     public void Definir_SubstituiPorInteiro()
     {
         ProcessoSeletivo processo = NovoProcesso();
-        processo.DefinirRegrasDerivacao([ConfigModalidade()]).IsSuccess.Should().BeTrue();
+        processo.DefinirRegrasDerivacao([ConfigModalidade()], PrecondicaoIfMatch.Ausente).IsSuccess.Should().BeTrue();
 
         ConfiguracaoDerivacaoFato outra = ConfiguracaoDerivacaoFato.Criar("OUTRO_DERIVADO",
             [Ancora(0, "X")]).Value!;
-        processo.DefinirRegrasDerivacao([outra]).IsSuccess.Should().BeTrue();
+        processo.DefinirRegrasDerivacao([outra], PrecondicaoIfMatch.Ausente).IsSuccess.Should().BeTrue();
 
         processo.RegrasDerivacao.Should().ContainSingle(c => c.CodigoFato == "OUTRO_DERIVADO");
     }
@@ -237,7 +237,7 @@ public sealed class ProcessoSeletivoRegrasDerivacaoTests
     {
         ProcessoSeletivo processo = NovoProcesso();
 
-        processo.DefinirRegrasDerivacao([ConfigModalidade()]).IsSuccess.Should().BeTrue();
+        processo.DefinirRegrasDerivacao([ConfigModalidade()], PrecondicaoIfMatch.Ausente).IsSuccess.Should().BeTrue();
 
         ConfiguracaoDerivacaoFato config = processo.RegrasDerivacao.Single();
         config.ProcessoSeletivoId.Should().Be(processo.Id);
@@ -267,8 +267,8 @@ public sealed class ProcessoSeletivoRegrasDerivacaoTests
         [
             FatoColetado.Criar("PCD", 0, null).Value!,
             FatoColetado.Criar("CONCORRER_PCD", 1, [Precond("PCD")]).Value!,
-        ]).IsSuccess.Should().BeTrue();
-        processo.DefinirRegrasDerivacao([DerivadoDe("MODALIDADE", "CONCORRER_PCD")]).IsSuccess.Should().BeTrue();
+        ], PrecondicaoIfMatch.Ausente).IsSuccess.Should().BeTrue();
+        processo.DefinirRegrasDerivacao([DerivadoDe("MODALIDADE", "CONCORRER_PCD")], PrecondicaoIfMatch.Ausente).IsSuccess.Should().BeTrue();
 
         Result<GrafoDependenciaConjunta> grafo = processo.ConstruirGrafoDependencia();
 
@@ -282,7 +282,7 @@ public sealed class ProcessoSeletivoRegrasDerivacaoTests
         ProcessoSeletivo processo = NovoProcesso();
         // Cada ConfiguracaoDerivacaoFato é válida isoladamente (a factory não checa citação); o ciclo
         // D1↔D2 só emerge quando as arestas de derivação são consideradas juntas.
-        processo.DefinirRegrasDerivacao([DerivadoDe("D1", "D2"), DerivadoDe("D2", "D1")]).IsSuccess.Should().BeTrue();
+        processo.DefinirRegrasDerivacao([DerivadoDe("D1", "D2"), DerivadoDe("D2", "D1")], PrecondicaoIfMatch.Ausente).IsSuccess.Should().BeTrue();
 
         Result<GrafoDependenciaConjunta> grafo = processo.ConstruirGrafoDependencia();
 

--- a/tests/Unifesspa.UniPlus.Selecao.Domain.UnitTests/Entities/ProcessoSeletivoSessaoEditorialTests.cs
+++ b/tests/Unifesspa.UniPlus.Selecao.Domain.UnitTests/Entities/ProcessoSeletivoSessaoEditorialTests.cs
@@ -246,32 +246,44 @@ public sealed class ProcessoSeletivoSessaoEditorialTests
         rascunho.Revisao.Should().Be(3);
     }
 
-    [Fact(DisplayName = "O grafo de coleta de fatos NÃO é editável após a publicação — nem sob retificação (aguarda o congelamento conjunto de #928)")]
-    public void DefinirFatosColetados_ProcessoPublicado_Recusa()
+    [Fact(DisplayName = "O grafo de coleta de fatos É editável sob sessão de retificação — a revisão avança; publicado sem sessão é bloqueado (Story #986)")]
+    public void DefinirFatosColetados_SobSessao_AceitaEIncrementaRevisao()
     {
-        // Publicado, com sessão de retificação aberta: os demais Definir* aceitam neste estado.
-        // O grafo de fatos não, porque ainda não entra no congelamento nem na restauração — aceitá-lo
-        // deixaria estado mutável fora do envelope congelado e sem rollback no descarte.
-        ProcessoSeletivo processo = ComSessaoAberta(out _);
+        // Sob sessão de retificação, o grafo de fatos passa a ser editável como os demais Definir*:
+        // já entra no congelamento do envelope e é reposto fielmente no descarte (Story #928/#986).
+        ProcessoSeletivo processo = ComSessaoAberta(out RascunhoRetificacao rascunho);
+        int revisaoAntes = rascunho.Revisao;
 
-        Result resultado = processo.DefinirFatosColetados([FatoColetado.Criar("PCD", 0, null).Value!]);
+        processo.DefinirFatosColetados([FatoColetado.Criar("PCD", 0, null).Value!], PrecondicaoIfMatch.DeTags([rascunho.ETag]))
+            .IsSuccess.Should().BeTrue();
+        rascunho.Revisao.Should().Be(revisaoAntes + 1);
 
-        resultado.IsFailure.Should().BeTrue();
-        resultado.Error!.Code.Should().Be("ProcessoSeletivo.GrafoDeFatosSomenteEmRascunho");
+        // Publicado SEM sessão: bloqueado pela recusa geral de mutação pós-publicação.
+        ProcessoSeletivo semSessao = NovoProcessoPublicado(out _);
+        Result recusa = semSessao.DefinirFatosColetados([FatoColetado.Criar("PCD", 0, null).Value!], PrecondicaoIfMatch.Ausente);
+        recusa.IsFailure.Should().BeTrue();
+        recusa.Error!.Code.Should().Be("ProcessoSeletivo.MutacaoPosPublicacaoBloqueada");
     }
 
-    [Fact(DisplayName = "As regras de derivação NÃO são editáveis após a publicação (aguardam o congelamento conjunto de #928)")]
-    public void DefinirRegrasDerivacao_ProcessoPublicado_Recusa()
+    [Fact(DisplayName = "As regras de derivação SÃO editáveis sob sessão de retificação — a revisão avança; publicado sem sessão é bloqueado (Story #986)")]
+    public void DefinirRegrasDerivacao_SobSessao_AceitaEIncrementaRevisao()
     {
-        ProcessoSeletivo processo = ComSessaoAberta(out _);
+        ProcessoSeletivo processo = ComSessaoAberta(out RascunhoRetificacao rascunho);
+        int revisaoAntes = rascunho.Revisao;
 
         ConfiguracaoDerivacaoFato config = ConfiguracaoDerivacaoFato.Criar("MODALIDADE",
             [RegraDerivacaoConfigurada.Criar(0, "AC", condicoes: null).Value!]).Value!;
 
-        Result resultado = processo.DefinirRegrasDerivacao([config]);
+        processo.DefinirRegrasDerivacao([config], PrecondicaoIfMatch.DeTags([rascunho.ETag]))
+            .IsSuccess.Should().BeTrue();
+        rascunho.Revisao.Should().Be(revisaoAntes + 1);
 
-        resultado.IsFailure.Should().BeTrue();
-        resultado.Error!.Code.Should().Be("ProcessoSeletivo.RegrasDerivacaoSomenteEmRascunho");
+        ProcessoSeletivo semSessao = NovoProcessoPublicado(out _);
+        ConfiguracaoDerivacaoFato config2 = ConfiguracaoDerivacaoFato.Criar("MODALIDADE",
+            [RegraDerivacaoConfigurada.Criar(0, "AC", condicoes: null).Value!]).Value!;
+        Result recusa = semSessao.DefinirRegrasDerivacao([config2], PrecondicaoIfMatch.Ausente);
+        recusa.IsFailure.Should().BeTrue();
+        recusa.Error!.Code.Should().Be("ProcessoSeletivo.MutacaoPosPublicacaoBloqueada");
     }
 
     [Fact(DisplayName = "Uma mutação RECUSADA não move a revisão — o ETag do cliente continua válido")]

--- a/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/Outbox/Cascading/EdicaoColetaSobRetificacaoEndpointTests.cs
+++ b/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/Outbox/Cascading/EdicaoColetaSobRetificacaoEndpointTests.cs
@@ -71,6 +71,29 @@ public sealed class EdicaoColetaSobRetificacaoEndpointTests
         (await ctx.PutFatosAsync(FatosTrocados, ifMatch: etagInicial)).StatusCode.Should().Be(HttpStatusCode.PreconditionFailed);
     }
 
+    [Fact(DisplayName = "Editar fatos sob sessão TROCANDO as ordens (0↔1) de uma coleta já persistida persiste sem colisão de índice único")]
+    public async Task Fatos_SobSessao_TrocaOrdens_Persiste()
+    {
+        // A edição sob sessão substitui a coleta inteira: as duas linhas persistidas saem e duas
+        // novas entram, reusando as mesmas chaves (processo, ordem) e (processo, fatoCodigo). O EF
+        // Core ordena os DELETEs antes dos INSERTs para o conflito de índice único (entidades novas,
+        // PKs distintas), então a troca persiste — não há colisão nem necessidade de flush aqui,
+        // diferente do descarte, cujo flush existe pela FIDELIDADE (repor as congeladas, não as vivas).
+        Contexto ctx = await PublicarComColetaAsync(nameof(Fatos_SobSessao_TrocaOrdens_Persiste));
+        string etag = await ctx.AbrirSessaoAsync();
+
+        (await ctx.PutFatosAsync(FatosTrocados, ifMatch: etag)).StatusCode.Should().Be(HttpStatusCode.NoContent);
+
+        using JsonDocument doc = await ctx.ObterProcessoAsync();
+        JsonElement fatos = doc.RootElement.GetProperty("fatosColetados");
+        fatos.EnumerateArray().Select(f => f.GetProperty("fatoCodigo").GetString())
+            .Should().Equal(["BAIXA_RENDA", "COR_RACA"], "a troca de ordens sob sessão persistiu");
+
+        await using AsyncServiceScope scope = ctx.Api.Services.CreateAsyncScope();
+        SelecaoDbContext db = scope.ServiceProvider.GetRequiredService<SelecaoDbContext>();
+        db.Set<FatoColetado>().Count(f => f.ProcessoSeletivoId == ctx.ProcessoId).Should().Be(2, "sem linha órfã");
+    }
+
     [Fact(DisplayName = "Editar fatos de um processo publicado SEM sessão é 422")]
     public async Task Fatos_PublicadoSemSessao_422()
     {

--- a/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/Outbox/Cascading/EdicaoColetaSobRetificacaoEndpointTests.cs
+++ b/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/Outbox/Cascading/EdicaoColetaSobRetificacaoEndpointTests.cs
@@ -1,0 +1,263 @@
+namespace Unifesspa.UniPlus.Selecao.IntegrationTests.Outbox.Cascading;
+
+using System.Globalization;
+using System.Net;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using System.Text.Json;
+
+using AwesomeAssertions;
+
+using Domain.Entities;
+
+using Microsoft.Extensions.DependencyInjection;
+
+using Unifesspa.UniPlus.IntegrationTests.Fixtures.Authentication;
+using Unifesspa.UniPlus.Selecao.Infrastructure.Persistence;
+
+/// <summary>
+/// Edição de fatos coletados e regras de derivação <b>sob sessão de retificação</b> (Story #986),
+/// fim a fim pelo HTTP: o <c>If-Match</c> passa a ser exigido (428/412/curinga), a revisão avança,
+/// e o descarte repõe fielmente a coleta congelada — inclusive quando a sessão trocou as ordens dos
+/// fatos (0↔1), o caso que colidiria no índice único sem a estratégia limpar + flush + inserir.
+/// </summary>
+[Collection(CascadingCollection.Name)]
+[Trait("Category", "Integration")]
+[Trait("Category", "OutboxCapability")]
+[Trait("Category", "OutboxCascading")]
+public sealed class EdicaoColetaSobRetificacaoEndpointTests
+{
+    private const string ProcessoMediaType = "application/vnd.uniplus.processo-seletivo.v1+json";
+
+    private static readonly object[] FatosOriginais =
+    [
+        new { fatoCodigo = "COR_RACA", ordem = 0, precondicao = (object?)null },
+        new { fatoCodigo = "BAIXA_RENDA", ordem = 1, precondicao = (object?)null },
+    ];
+
+    // Mesmas duas coletas, ORDENS TROCADAS — o que a sessão edita e o descarte tem de desfazer.
+    private static readonly object[] FatosTrocados =
+    [
+        new { fatoCodigo = "BAIXA_RENDA", ordem = 0, precondicao = (object?)null },
+        new { fatoCodigo = "COR_RACA", ordem = 1, precondicao = (object?)null },
+    ];
+
+    private static readonly object[] RegrasOriginais =
+    [
+        new
+        {
+            codigoFato = "MODALIDADE",
+            regras = new object[] { new { ordem = 0, contribui = "AC", quando = (object?)null } },
+        },
+    ];
+
+    private readonly CascadingFixture _fixture;
+
+    public EdicaoColetaSobRetificacaoEndpointTests(CascadingFixture fixture) => _fixture = fixture;
+
+    [Fact(DisplayName = "Sob sessão, PUT /fatos-coletados sem If-Match é 428; com If-Match defasado é 412; com o corrente é 204 com ETag novo")]
+    public async Task Fatos_SobSessao_Precondicao()
+    {
+        Contexto ctx = await PublicarComColetaAsync(nameof(Fatos_SobSessao_Precondicao));
+        string etagInicial = await ctx.AbrirSessaoAsync();
+
+        (await ctx.PutFatosAsync(FatosTrocados, ifMatch: null)).StatusCode.Should().Be(HttpStatusCode.PreconditionRequired);
+
+        HttpResponseMessage aceito = await ctx.PutFatosAsync(FatosTrocados, ifMatch: etagInicial);
+        aceito.StatusCode.Should().Be(HttpStatusCode.NoContent);
+        string etagNovo = LerETag(aceito);
+        etagNovo.Should().NotBe(etagInicial, "toda mutação aceita sob sessão incrementa a revisão");
+
+        (await ctx.PutFatosAsync(FatosTrocados, ifMatch: etagInicial)).StatusCode.Should().Be(HttpStatusCode.PreconditionFailed);
+    }
+
+    [Fact(DisplayName = "Editar fatos de um processo publicado SEM sessão é 422")]
+    public async Task Fatos_PublicadoSemSessao_422()
+    {
+        Contexto ctx = await PublicarComColetaAsync(nameof(Fatos_PublicadoSemSessao_422));
+
+        HttpResponseMessage resposta = await ctx.PutFatosAsync(FatosTrocados, ifMatch: null);
+
+        resposta.StatusCode.Should().Be(HttpStatusCode.UnprocessableEntity);
+    }
+
+    [Fact(DisplayName = "O descarte da sessão que TROCOU as ordens dos fatos repõe a coleta congelada, sem colisão de índice único e sem órfãos")]
+    public async Task Descarte_ComOrdensTrocadas_ReporFielmente()
+    {
+        Contexto ctx = await PublicarComColetaAsync(nameof(Descarte_ComOrdensTrocadas_ReporFielmente));
+        string etag = await ctx.AbrirSessaoAsync();
+
+        // A sessão troca as ordens (0↔1) — sem o limpar+flush+inserir, o descarte colidiria no
+        // índice único (processo, ordem) ao repor as congeladas por cima das editadas.
+        string etagAposFatos = LerETag(await Aceito(ctx.PutFatosAsync(FatosTrocados, ifMatch: etag)));
+
+        // Descarta com o ETag corrente — é aqui que a restauração fiel roda.
+        HttpResponseMessage descarte = await ctx.DescartarAsync(ifMatch: etagAposFatos);
+        descarte.StatusCode.Should().Be(HttpStatusCode.NoContent, "o descarte não pode colidir no índice único ao repor as congeladas");
+
+        // A coleta voltou byte-a-byte à ordem congelada.
+        using JsonDocument doc = await ctx.ObterProcessoAsync();
+        JsonElement fatos = doc.RootElement.GetProperty("fatosColetados");
+        fatos.EnumerateArray().Select(f => f.GetProperty("fatoCodigo").GetString())
+            .Should().Equal(["COR_RACA", "BAIXA_RENDA"], "as ordens congeladas voltaram");
+        fatos[0].GetProperty("ordem").GetInt32().Should().Be(0);
+        fatos[1].GetProperty("ordem").GetInt32().Should().Be(1);
+
+        // Sem órfãos: exatamente dois fatos coletados persistidos.
+        await using AsyncServiceScope scope = ctx.Api.Services.CreateAsyncScope();
+        SelecaoDbContext db = scope.ServiceProvider.GetRequiredService<SelecaoDbContext>();
+        int total = db.Set<FatoColetado>().Count(f => f.ProcessoSeletivoId == ctx.ProcessoId);
+        total.Should().Be(2, "o descarte não deixa linha órfã");
+    }
+
+    private static async Task<HttpResponseMessage> Aceito(Task<HttpResponseMessage> chamada)
+    {
+        HttpResponseMessage r = await chamada;
+        r.StatusCode.Should().Be(HttpStatusCode.NoContent);
+        return r;
+    }
+
+    private sealed record Contexto(CascadingApiFactory Api, HttpClient Client, Guid ProcessoId, Guid DocumentoId)
+    {
+        public Task<HttpResponseMessage> PutFatosAsync(IReadOnlyList<object> corpo, string? ifMatch) =>
+            EnviarAsync(HttpMethod.Put, "fatos-coletados", corpo, ifMatch);
+
+        public Task<HttpResponseMessage> PutRegrasAsync(IReadOnlyList<object> corpo, string? ifMatch) =>
+            EnviarAsync(HttpMethod.Put, "regras-derivacao", corpo, ifMatch);
+
+        public async Task<string> AbrirSessaoAsync()
+        {
+            using HttpRequestMessage request = new(
+                HttpMethod.Post,
+                new Uri($"/api/selecao/processos-seletivos/{ProcessoId}/retificacao-em-curso", UriKind.Relative))
+            {
+                Content = JsonContent.Create(new { motivo = "Correção da coleta" }),
+            };
+            Autenticar(request);
+            request.Headers.TryAddWithoutValidation("Idempotency-Key", MakeIdempotencyKey());
+            HttpResponseMessage resposta = await Client.SendAsync(request).ConfigureAwait(false);
+            resposta.StatusCode.Should().Be(HttpStatusCode.Created);
+            return LerETag(resposta);
+        }
+
+        public async Task<HttpResponseMessage> DescartarAsync(string ifMatch)
+        {
+            using HttpRequestMessage request = new(
+                HttpMethod.Delete,
+                new Uri($"/api/selecao/processos-seletivos/{ProcessoId}/retificacao-em-curso", UriKind.Relative));
+            Autenticar(request);
+            request.Headers.TryAddWithoutValidation("Idempotency-Key", MakeIdempotencyKey());
+            request.Headers.TryAddWithoutValidation("If-Match", ifMatch);
+            return await Client.SendAsync(request).ConfigureAwait(false);
+        }
+
+        public async Task<JsonDocument> ObterProcessoAsync()
+        {
+            using HttpRequestMessage request = new(
+                HttpMethod.Get,
+                new Uri($"/api/selecao/processos-seletivos/{ProcessoId}", UriKind.Relative));
+            Autenticar(request);
+            request.Headers.Accept.Add(MediaTypeWithQualityHeaderValue.Parse(ProcessoMediaType));
+            HttpResponseMessage resposta = await Client.SendAsync(request).ConfigureAwait(false);
+            resposta.StatusCode.Should().Be(HttpStatusCode.OK);
+            return JsonDocument.Parse(await resposta.Content.ReadAsStringAsync().ConfigureAwait(false));
+        }
+
+        private async Task<HttpResponseMessage> EnviarAsync(HttpMethod metodo, string recurso, object corpo, string? ifMatch)
+        {
+            using HttpRequestMessage request = new(
+                metodo,
+                new Uri($"/api/selecao/processos-seletivos/{ProcessoId}/{recurso}", UriKind.Relative))
+            {
+                Content = JsonContent.Create(corpo),
+            };
+            Autenticar(request);
+            request.Headers.TryAddWithoutValidation("Idempotency-Key", MakeIdempotencyKey());
+            if (ifMatch is not null)
+            {
+                request.Headers.TryAddWithoutValidation("If-Match", ifMatch);
+            }
+
+            return await Client.SendAsync(request).ConfigureAwait(false);
+        }
+
+        public async Task PublicarAsync()
+        {
+            using HttpRequestMessage publicar = new(
+                HttpMethod.Post,
+                new Uri($"/api/selecao/processos-seletivos/{ProcessoId}/publicacao", UriKind.Relative))
+            {
+                Content = JsonContent.Create(new
+                {
+                    numero = "001/2026",
+                    periodoInscricaoInicio = Hoje(),
+                    periodoInscricaoFim = HojeMais(30),
+                    documentoEditalId = DocumentoId,
+                    ato = new
+                    {
+                        orgao = "CEPS",
+                        serie = "EDITAL",
+                        ano = 2026,
+                        dataPublicacao = Hoje(),
+                        assinante = "Diretor do CEPS",
+                        tipoAtoCodigo = "EDITAL_ABERTURA",
+                    },
+                }),
+            };
+            Autenticar(publicar);
+            publicar.Headers.TryAddWithoutValidation("Idempotency-Key", MakeIdempotencyKey());
+            HttpResponseMessage resposta = await Client.SendAsync(publicar).ConfigureAwait(false);
+            resposta.StatusCode.Should().Be(HttpStatusCode.NoContent, "o cenário depende de um certame publicado com coleta");
+        }
+    }
+
+    private async Task<Contexto> PublicarComColetaAsync(string nome)
+    {
+        CascadingApiFactory api = _fixture.Factory;
+        await TiposDeAtoSeeder.SemearAsync(api.Services);
+        HttpClient client = api.CreateClient();
+
+        Guid processoId;
+        Guid documentoId;
+        await using (AsyncServiceScope scope = api.Services.CreateAsyncScope())
+        {
+            SelecaoDbContext db = scope.ServiceProvider.GetRequiredService<SelecaoDbContext>();
+            (ProcessoSeletivo processo, DocumentoEdital documento) = await ProcessoSeletivoPublicavelSeeder
+                .SemearAsync(db, $"{nome} {Guid.CreateVersion7()}");
+            processoId = processo.Id;
+            documentoId = documento.Id;
+        }
+
+        Contexto ctx = new(api, client, processoId, documentoId);
+
+        // Coleta e derivação definidas em rascunho, ANTES de publicar — para o congelamento e a
+        // restauração terem o que repor.
+        (await ctx.PutFatosAsync(FatosOriginais, ifMatch: null)).StatusCode.Should().Be(HttpStatusCode.NoContent);
+        (await ctx.PutRegrasAsync(RegrasOriginais, ifMatch: null)).StatusCode.Should().Be(HttpStatusCode.NoContent);
+        await ctx.PublicarAsync();
+
+        return ctx;
+    }
+
+    private static string LerETag(HttpResponseMessage resposta)
+    {
+        resposta.Headers.ETag.Should().NotBeNull(
+            $"a resposta {(int)resposta.StatusCode} de uma sessão editorial carrega o ETag");
+        return resposta.Headers.ETag!.ToString();
+    }
+
+    private static void Autenticar(HttpRequestMessage request)
+    {
+        request.Headers.Authorization = new AuthenticationHeaderValue(
+            TestAuthHandler.AuthorizationScheme, TestAuthHandler.TokenValue);
+        request.Headers.TryAddWithoutValidation(TestAuthHandler.RolesHeader, "plataforma-admin");
+    }
+
+    private static string Hoje() =>
+        DateOnly.FromDateTime(DateTime.UtcNow).ToString("yyyy-MM-dd", CultureInfo.InvariantCulture);
+
+    private static string HojeMais(int dias) =>
+        DateOnly.FromDateTime(DateTime.UtcNow.AddDays(dias)).ToString("yyyy-MM-dd", CultureInfo.InvariantCulture);
+
+    private static string MakeIdempotencyKey() => Guid.CreateVersion7().ToString("N");
+}

--- a/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/ProcessosSeletivos/CorpusEnvelope.cs
+++ b/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/ProcessosSeletivos/CorpusEnvelope.cs
@@ -164,7 +164,7 @@ internal static class CorpusEnvelope
             FatoColetado.Criar("RENDA", 1, [
                 CondicaoPrecondicaoFato.Criar(0, "COR_RACA", Operador.Igual, JsonSerializer.SerializeToElement("PRETA")).Value!,
             ]).Value!,
-        ], permutar)).IsSuccess.Should().BeTrue();
+        ], permutar), PrecondicaoIfMatch.Ausente).IsSuccess.Should().BeTrue();
 
         processo.DefinirRegrasDerivacao(Ordem([
             ConfiguracaoDerivacaoFato.Criar("MODALIDADE", Ordem([
@@ -183,7 +183,7 @@ internal static class CorpusEnvelope
                     CondicaoRegraDerivacao.Criar(0, "COR_RACA", Operador.Igual, JsonSerializer.SerializeToElement("PRETA")).Value!,
                 ]).Value!,
             ]).Value!,
-        ], permutar)).IsSuccess.Should().BeTrue();
+        ], permutar), PrecondicaoIfMatch.Ausente).IsSuccess.Should().BeTrue();
 
         return processo;
     }

--- a/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/ProcessosSeletivos/EnvelopeCanonicoGoldenTests.cs
+++ b/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/ProcessosSeletivos/EnvelopeCanonicoGoldenTests.cs
@@ -204,7 +204,7 @@ public sealed class EnvelopeCanonicoGoldenTests
             FatoColetado.Criar("RENDA", 1, [
                 CondicaoPrecondicaoFato.Criar(0, "COR_RACA", Operador.Igual, JsonSerializer.SerializeToElement("PRETA")).Value!,
             ]).Value!,
-        ]).IsSuccess.Should().BeTrue();
+        ], PrecondicaoIfMatch.Ausente).IsSuccess.Should().BeTrue();
 
         processo.DefinirRegrasDerivacao([
             ConfiguracaoDerivacaoFato.Criar("MODALIDADE", [
@@ -213,7 +213,7 @@ public sealed class EnvelopeCanonicoGoldenTests
                     CondicaoRegraDerivacao.Criar(0, "RENDA", Operador.Igual, JsonSerializer.SerializeToElement("ATE_1_SM")).Value!,
                 ]).Value!,
             ]).Value!,
-        ]).IsSuccess.Should().BeTrue();
+        ], PrecondicaoIfMatch.Ausente).IsSuccess.Should().BeTrue();
 
         return processo;
     }

--- a/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/ProcessosSeletivos/ProcessoSeletivoPersistenciaTests.cs
+++ b/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/ProcessosSeletivos/ProcessoSeletivoPersistenciaTests.cs
@@ -135,7 +135,7 @@ public sealed class ProcessoSeletivoPersistenciaTests : IClassFixture<ProcessoSe
             RegraDerivacaoConfigurada.Criar(1, "AC_PCD",
                 [CondicaoRegraDerivacao.Criar(1, "CONCORRER_PCD", Operador.Igual, JsonSerializer.SerializeToElement(true)).Value!]).Value!,
         ]).Value!;
-        processo.DefinirRegrasDerivacao([config]).IsSuccess.Should().BeTrue();
+        processo.DefinirRegrasDerivacao([config], PrecondicaoIfMatch.Ausente).IsSuccess.Should().BeTrue();
 
         await using (SelecaoDbContext writeContext = _fixture.CreateDbContext())
         {
@@ -172,7 +172,7 @@ public sealed class ProcessoSeletivoPersistenciaTests : IClassFixture<ProcessoSe
                 RegraDerivacaoConfigurada.Criar(1, "AC_PCD",
                     [CondicaoRegraDerivacao.Criar(1, "CONCORRER_PCD", Operador.Igual, JsonSerializer.SerializeToElement(true)).Value!]).Value!,
             ]).Value!,
-        ]).IsSuccess.Should().BeTrue();
+        ], PrecondicaoIfMatch.Ausente).IsSuccess.Should().BeTrue();
 
         await using (SelecaoDbContext writeContext = _fixture.CreateDbContext())
         {
@@ -194,7 +194,7 @@ public sealed class ProcessoSeletivoPersistenciaTests : IClassFixture<ProcessoSe
                 [
                     RegraDerivacaoConfigurada.Criar(0, "AC", condicoes: null).Value!,
                 ]).Value!,
-            ]).IsSuccess.Should().BeTrue();
+            ], PrecondicaoIfMatch.Ausente).IsSuccess.Should().BeTrue();
 
             await mutateContext.SaveChangesAsync(CancellationToken.None);
         }

--- a/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/ProcessosSeletivos/RestauradorDeConfiguracaoTests.cs
+++ b/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/ProcessosSeletivos/RestauradorDeConfiguracaoTests.cs
@@ -50,9 +50,14 @@ public sealed class RestauradorDeConfiguracaoTests
 
         RestauradorDeConfiguracao restaurador = new(CorpusEnvelope.Registro);
 
-        Result resultado = restaurador.Restaurar(processo, versao);
+        Result<GrafoConfiguracao> resultado = restaurador.Restaurar(processo, versao);
 
         resultado.IsSuccess.Should().BeTrue(resultado.Error?.Message);
+
+        // A prova é a do restaurador; a APLICAÇÃO na raiz viva é do descarte (Story #986): limpa as
+        // coleções mutáveis e repõe o grafo provado — as demais dimensões reconciliam por reuse.
+        processo.LimparColetaEDerivacaoParaRestauracao();
+        processo.RestaurarConfiguracaoCongelada(versao, resultado.Value!).IsSuccess.Should().BeTrue();
 
         CorpusEnvelope.Codec.Codificar(CorpusEnvelope.Entrada(processo)).Bytes
             .Should().Equal(congelado.Bytes, "o agregado voltou a ser, byte a byte, o que a versão congelou");
@@ -97,7 +102,7 @@ public sealed class RestauradorDeConfiguracaoTests
 
         RestauradorDeConfiguracao restaurador = new(CorpusEnvelope.Registro);
 
-        Result resultado = restaurador.Restaurar(processo, versao);
+        Result<GrafoConfiguracao> resultado = restaurador.Restaurar(processo, versao);
 
         resultado.IsSuccess.Should().BeTrue(resultado.Error?.Message);
     }
@@ -140,7 +145,7 @@ public sealed class RestauradorDeConfiguracaoTests
         VersaoConfiguracao versao = CorpusEnvelope.VersaoDeAbertura(processo, congelado.Bytes);
         processo.RestaurarConfiguracaoCongelada(versao, CorpusEnvelope.GrafoPobre()).IsSuccess.Should().BeTrue();
 
-        Result resultado = new RestauradorDeConfiguracao(CorpusEnvelope.Registro).Restaurar(processo, versao);
+        Result<GrafoConfiguracao> resultado = new RestauradorDeConfiguracao(CorpusEnvelope.Registro).Restaurar(processo, versao);
 
         resultado.IsSuccess.Should().BeTrue(resultado.Error?.Message);
     }
@@ -178,7 +183,7 @@ public sealed class RestauradorDeConfiguracaoTests
 
         byte[] antesDaTentativa = CorpusEnvelope.Codec.Codificar(CorpusEnvelope.Entrada(processo)).Bytes;
 
-        Result resultado = restaurador.Restaurar(processo, versao);
+        Result<GrafoConfiguracao> resultado = restaurador.Restaurar(processo, versao);
 
         resultado.IsFailure.Should().BeTrue(
             "a configuração reposta não recanonicaliza nos bytes congelados — algo se perdeu. Aceitar isto faria o " +
@@ -308,7 +313,7 @@ public sealed class RestauradorDeConfiguracaoTests
 
         RestauradorDeConfiguracao restaurador = new(new RegistroCodecsEnvelope());
 
-        Result resultado = restaurador.Restaurar(processo, versao);
+        Result<GrafoConfiguracao> resultado = restaurador.Restaurar(processo, versao);
 
         resultado.IsSuccess.Should().BeTrue(
             resultado.Error?.Message ?? "sem o Id da fase congelado no envelope 1.2, ResolverDataReferenciaFatos " +
@@ -396,9 +401,14 @@ public sealed class RestauradorDeConfiguracaoTests
 
         RestauradorDeConfiguracao restaurador = new(new RegistroCodecsEnvelope());
 
-        Result resultado = restaurador.Restaurar(processo, versao);
+        Result<GrafoConfiguracao> resultado = restaurador.Restaurar(processo, versao);
 
         resultado.IsSuccess.Should().BeTrue(resultado.Error?.Message);
+
+        // A APLICAÇÃO na raiz viva é do descarte (Story #986): limpa as coleções mutáveis e repõe o
+        // grafo provado.
+        processo.LimparColetaEDerivacaoParaRestauracao();
+        processo.RestaurarConfiguracaoCongelada(versao, resultado.Value!).IsSuccess.Should().BeTrue();
 
         // A prova final: recanonicalizar o agregado reposto reproduz os MESMOS bytes —
         // incluindo o bloco metadadosFatos, que só sobreviveu porque veio inteiro dentro do
@@ -427,7 +437,7 @@ public sealed class RestauradorDeConfiguracaoTests
 
         byte[] antes = CorpusEnvelope.Codec.Codificar(CorpusEnvelope.Entrada(processo)).Bytes;
 
-        Result resultado = new RestauradorDeConfiguracao(CorpusEnvelope.Registro).Restaurar(processo, versao10);
+        Result<GrafoConfiguracao> resultado = new RestauradorDeConfiguracao(CorpusEnvelope.Registro).Restaurar(processo, versao10);
 
         resultado.IsFailure.Should().BeTrue();
         resultado.Error!.Code.Should().Be(ErrosCodecEnvelope.VersaoDesconhecida);

--- a/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/ProcessosSeletivos/RestaurarConfiguracaoPersistenciaTests.cs
+++ b/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/ProcessosSeletivos/RestaurarConfiguracaoPersistenciaTests.cs
@@ -8,6 +8,7 @@ using Unifesspa.UniPlus.Kernel.Results;
 using Unifesspa.UniPlus.Selecao.Application.Abstractions;
 using Unifesspa.UniPlus.Selecao.Application.Services;
 using Unifesspa.UniPlus.Selecao.Domain.Entities;
+using Unifesspa.UniPlus.Selecao.Domain.ValueObjects;
 using Unifesspa.UniPlus.Selecao.Infrastructure.Persistence;
 
 using Xunit;
@@ -76,9 +77,16 @@ public sealed class RestaurarConfiguracaoPersistenciaTests(ProcessoSeletivoDbFix
         {
             ProcessoSeletivo tracked = await CarregarAsync(descarte, processoId);
 
-            Result resultado = new RestauradorDeConfiguracao(CorpusEnvelope.Registro).Restaurar(tracked, versao);
-            resultado.IsSuccess.Should().BeTrue(resultado.Error?.Message);
+            // A prova é do restaurador; a APLICAÇÃO com flush intermediário é do descarte (Story
+            // #986): limpa as coleções mutáveis, flusha os DELETEs, e só então repõe o grafo
+            // congelado (INSERT) — os DELETEs saem antes dos INSERTs, sem colidir no índice único.
+            Result<GrafoConfiguracao> prova = new RestauradorDeConfiguracao(CorpusEnvelope.Registro).Restaurar(tracked, versao);
+            prova.IsSuccess.Should().BeTrue(prova.Error?.Message);
 
+            tracked.LimparColetaEDerivacaoParaRestauracao();
+            await descarte.SaveChangesAsync();
+
+            tracked.RestaurarConfiguracaoCongelada(versao, prova.Value!).IsSuccess.Should().BeTrue();
             await descarte.SaveChangesAsync();
         }
 
@@ -184,8 +192,16 @@ public sealed class RestaurarConfiguracaoPersistenciaTests(ProcessoSeletivoDbFix
         await using (SelecaoDbContext descarte = fixture.CreateDbContext())
         {
             ProcessoSeletivo tracked = await CarregarAsync(descarte, processoId);
-            new RestauradorDeConfiguracao(CorpusEnvelope.Registro).Restaurar(tracked, versao)
-                .IsSuccess.Should().BeTrue();
+
+            // Orquestração do descarte (Story #986): prova, limpa fatos/regras + flush, aplica. A
+            // etapa NÃO é limpa — reconcilia por Id (reuse-tracked), preservando o CreatedAt.
+            Result<GrafoConfiguracao> prova = new RestauradorDeConfiguracao(CorpusEnvelope.Registro).Restaurar(tracked, versao);
+            prova.IsSuccess.Should().BeTrue(prova.Error?.Message);
+
+            tracked.LimparColetaEDerivacaoParaRestauracao();
+            await descarte.SaveChangesAsync();
+
+            tracked.RestaurarConfiguracaoCongelada(versao, prova.Value!).IsSuccess.Should().BeTrue();
             await descarte.SaveChangesAsync();
         }
 


### PR DESCRIPTION
## Objetivo

Libera a edição de **fatos coletados** e **regras de derivação** sob sessão de retificação de um processo publicado (Feature #983, Story #986), e garante a **restauração fiel** dessas coleções no descarte.

## Edição sob retificação
- Domínio troca o guard `SomenteEmRascunho` por `MutacaoBloqueada`, exige `PrecondicaoIfMatch` e incrementa a revisão da sessão.
- Endpoints ganham `If-Match`: rascunho → `204` sem ETag (If-Match ignorado); sob sessão → `428`/`412`/`204` com ETag. Publicado sem sessão → `422 MutacaoPosPublicacaoBloqueada`. Códigos `SomenteEmRascunho` removidos.

## Restauração fiel (limpar + flush + inserir)
- O restaurador passa a **provar** o round-trip e **devolver** o grafo (`Result<GrafoConfiguracao>`), sem tocar a raiz viva.
- O descarte limpa as coleções mutáveis, faz um `SaveChanges` intermediário (DELETEs antes dos INSERTs) e aplica o grafo provado — repõe byte-a-byte mesmo com ordens trocadas (0↔1), sem colisão de índice nem órfãos.
- O flush só ocorre após a prova; falha pós-flush **lança** para reverter a transação (`Result.Failure` a comitaria — AutoApplyTransactions do Wolverine). Um ArchTest exige que o descarte prove antes de aplicar.

## Testes
Domínio (editável sob sessão; bloqueado sem sessão), e2e (If-Match 428/412; descarte com ordens trocadas repõe byte-a-byte sem colisão/órfãos), persistência ajustada, ArchTest. Baseline OpenAPI regerada; suíte completa verde; `dotnet format` limpo.

Refs #986, #924