### PR TITLE
test(selecao): coleta na matriz Postman e fechamento da superfície HTTP de coleta/derivação

### DIFF
--- a/src/selecao/Unifesspa.UniPlus.Selecao.API/postman/selecao.postman_collection.json
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.API/postman/selecao.postman_collection.json
@@ -2222,6 +2222,130 @@
               }
             }
           ]
+        },
+        {
+          "name": "Definir Fatos Coletados",
+          "request": {
+            "method": "PUT",
+            "header": [
+              {
+                "key": "Idempotency-Key",
+                "value": "{{$guid}}",
+                "type": "text"
+              },
+              {
+                "key": "Content-Type",
+                "value": "application/json",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{base_url}}/api/selecao/processos-seletivos/{{processo_id}}/fatos-coletados",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "selecao",
+                "processos-seletivos",
+                "{{processo_id}}",
+                "fatos-coletados"
+              ]
+            },
+            "auth": {
+              "type": "bearer",
+              "bearer": [
+                {
+                  "key": "token",
+                  "value": "{{token}}",
+                  "type": "string"
+                }
+              ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "[\n  {\n    \"fatoCodigo\": \"COR_RACA\",\n    \"ordem\": 0,\n    \"precondicao\": null\n  },\n  {\n    \"fatoCodigo\": \"BAIXA_RENDA\",\n    \"ordem\": 1,\n    \"precondicao\": [\n      [\n        {\n          \"fato\": \"COR_RACA\",\n          \"operador\": \"IGUAL\",\n          \"valor\": \"PRETA\"\n        }\n      ]\n    ]\n  }\n]",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            }
+          },
+          "response": [],
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('204 No Content', () => pm.response.to.have.status(204));"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "Definir Regras de Derivação",
+          "request": {
+            "method": "PUT",
+            "header": [
+              {
+                "key": "Idempotency-Key",
+                "value": "{{$guid}}",
+                "type": "text"
+              },
+              {
+                "key": "Content-Type",
+                "value": "application/json",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{base_url}}/api/selecao/processos-seletivos/{{processo_id}}/regras-derivacao",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "selecao",
+                "processos-seletivos",
+                "{{processo_id}}",
+                "regras-derivacao"
+              ]
+            },
+            "auth": {
+              "type": "bearer",
+              "bearer": [
+                {
+                  "key": "token",
+                  "value": "{{token}}",
+                  "type": "string"
+                }
+              ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "[\n  {\n    \"codigoFato\": \"MODALIDADE\",\n    \"regras\": [\n      {\n        \"ordem\": 0,\n        \"contribui\": \"AC_SMK_{{run_suffix}}\",\n        \"quando\": null\n      },\n      {\n        \"ordem\": 1,\n        \"contribui\": \"AC_SMK_{{run_suffix}}\",\n        \"quando\": [\n          [\n            {\n              \"fato\": \"COR_RACA\",\n              \"operador\": \"IGUAL\",\n              \"valor\": \"PRETA\"\n            }\n          ]\n        ]\n      }\n    ]\n  }\n]",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            }
+          },
+          "response": [],
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('204 No Content', () => pm.response.to.have.status(204));"
+                ]
+              }
+            }
+          ]
         }
       ],
       "description": "Exercita as 9 dimensões de configuração (PUT idempotentes/substituição integral) na ordem exigida pelas dependências. Nenhuma requer If-Match nesta fase — a precondição só é obrigatória durante uma sessão editorial (ver folder de Sessão editorial)."
@@ -3187,6 +3311,78 @@
             "body": {
               "mode": "raw",
               "raw": "[\n  {\n    \"nome\": \"Prova Objetiva (revisada)\",\n    \"carater\": \"classificatoria\",\n    \"peso\": 2.0,\n    \"notaMinima\": null,\n    \"ordem\": 1\n  },\n  {\n    \"nome\": \"Entrevista\",\n    \"carater\": \"classificatoria\",\n    \"peso\": 1.0,\n    \"notaMinima\": null,\n    \"ordem\": 2\n  }\n]",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            }
+          },
+          "response": [],
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "pm.test('204 No Content com ETag novo', () => {",
+                  "  pm.response.to.have.status(204);",
+                  "  const etag = pm.response.headers.get('ETag');",
+                  "  pm.expect(etag).to.be.a('string');",
+                  "  pm.environment.set('etag', etag);",
+                  "});"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "name": "Editar Fatos Coletados dentro da sessão (troca ordens, com If-Match)",
+          "request": {
+            "method": "PUT",
+            "header": [
+              {
+                "key": "Idempotency-Key",
+                "value": "{{$guid}}",
+                "type": "text"
+              },
+              {
+                "key": "If-Match",
+                "value": "{{etag}}",
+                "type": "text"
+              },
+              {
+                "key": "Content-Type",
+                "value": "application/json",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{base_url}}/api/selecao/processos-seletivos/{{processo_id}}/fatos-coletados",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "selecao",
+                "processos-seletivos",
+                "{{processo_id}}",
+                "fatos-coletados"
+              ]
+            },
+            "auth": {
+              "type": "bearer",
+              "bearer": [
+                {
+                  "key": "token",
+                  "value": "{{token}}",
+                  "type": "string"
+                }
+              ]
+            },
+            "body": {
+              "mode": "raw",
+              "raw": "[\n  {\n    \"fatoCodigo\": \"BAIXA_RENDA\",\n    \"ordem\": 0,\n    \"precondicao\": null\n  },\n  {\n    \"fatoCodigo\": \"COR_RACA\",\n    \"ordem\": 1,\n    \"precondicao\": null\n  }\n]",
               "options": {
                 "raw": {
                   "language": "json"


### PR DESCRIPTION
## Objetivo

Fecha a Feature **Superfície HTTP de coleta de fatos e derivação** (#983, última Story #988): consolida o baseline OpenAPI final, adiciona os requests de coleta à matriz Postman ponta a ponta e valida as três changes juntas no Newman. Com isso, a superfície administrativa de fatos/regras está completa e o frontend `uniplus-web#464` fica **desbloqueado**.

## O que entra

- **Postman:** requests novos na coleção de smoke — `Definir Fatos Coletados` e `Definir Regras de Derivação` (fluxo de configuração) e `Editar Fatos Coletados dentro da sessão (troca de ordens, com If-Match)` (fluxo editorial). Exercitam coleta + composição + cobertura contra a stack real, incluindo o congelamento na publicação e a restauração no descarte.
- **Newman:** a matriz completa passa — **107 requisições, 109 assertions, 0 falhas**. O `contribui` das regras usa o código real da modalidade ofertada pelo processo do smoke (sufixado por execução), coerente com a validação de domínio de contribuição.
- **OpenAPI:** o baseline `contracts/openapi.selecao.json` já foi regerado por cada Story (#984/#985/#986/#987) e é o **final**; o drift-check (`OpenApiEndpointTests`) confirma que o runtime bate com o committed — sem alteração nesta Story (só a coleção Postman muda).

## Escopo da Feature #983 (todas as Stories mergeadas)

| Story | PR |
|---|---|
| #984 Definir fatos coletados (rascunho) | #989 |
| #985 Definir regras de derivação (rascunho) | #990 |
| #987 Leitura tipada de fatos/regras no GET | #991 |
| #986 Edição sob retificação + restauração fiel | #993 |
| #988 OpenAPI final + Postman e2e + fechamento | este PR |

## Desbloqueio do frontend

`uniplus-web#464` (tela admin) dependia desta superfície HTTP, que agora existe (endpoints de escrita, leitura tipada, edição sob retificação). Este PR **não fecha** `#464` — o trabalho de frontend é do `uniplus-web` —, apenas remove o bloqueio.

Closes #988
Refs #924, #983
