### PR TITLE
feat(configuracao): protege as modalidades legais fixas do cadastro

### DIFF
--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.API/Errors/ConfiguracaoDomainErrorRegistration.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.API/Errors/ConfiguracaoDomainErrorRegistration.cs
@@ -779,6 +779,24 @@ internal sealed class ConfiguracaoDomainErrorRegistration : IDomainErrorRegistra
                 "uniplus.configuracao.modalidade.remocao_bloqueada_por_referencia",
                 "Não é possível remover uma modalidade referenciada por outra modalidade ativa")),
 
+        new(ModalidadeErrorCodes.EstruturaProtegidaNaoEditavel,
+            new DomainErrorMapping(
+                StatusCodes.Status422UnprocessableEntity,
+                "uniplus.configuracao.modalidade.estrutura_protegida_nao_editavel",
+                "A modalidade legal fixa admite alteração apenas de descrição e base legal")),
+
+        new(ModalidadeErrorCodes.RemocaoBloqueadaCodigoProtegido,
+            new DomainErrorMapping(
+                StatusCodes.Status409Conflict,
+                "uniplus.configuracao.modalidade.remocao_bloqueada_codigo_protegido",
+                "A modalidade legal fixa não pode ser removida")),
+
+        new(ModalidadeErrorCodes.CriacaoBloqueadaCodigoProtegido,
+            new DomainErrorMapping(
+                StatusCodes.Status409Conflict,
+                "uniplus.configuracao.modalidade.criacao_bloqueada_codigo_protegido",
+                "Código reservado ao catálogo legal fixo de modalidades")),
+
         new(ModalidadeErrorCodes.BaseLegalTamanho,
             new DomainErrorMapping(
                 StatusCodes.Status422UnprocessableEntity,

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/Modalidades/AtualizarModalidadeCommand.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/Modalidades/AtualizarModalidadeCommand.cs
@@ -10,6 +10,14 @@ using Unifesspa.UniPlus.Kernel.Results;
 /// chegam como tokens canônicos UPPER_SNAKE. O ator (<c>updated_by</c>) é carimbado
 /// server-side via <c>IUserContext</c>.
 /// </summary>
+/// <remarks>
+/// A operação é <b>substituição integral</b>: campo omitido não é "mantido como está",
+/// é reenviado com o default (natureza <c>AMPLA</c>, composição <c>RESIDUAL_DO_VO</c>,
+/// demais nulos). Numa modalidade do catálogo legal fixo, onde só descrição e base legal
+/// são editáveis, isso significa reenviar a estrutura tal como está — omitir a natureza de
+/// uma cota federal para corrigir a descrição resulta em <c>EstruturaProtegidaNaoEditavel</c>
+/// (422), não em edição parcial silenciosa.
+/// </remarks>
 public sealed record AtualizarModalidadeCommand(
     Guid Id,
     string? Descricao = null,

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/Modalidades/CriarModalidadeCommandHandler.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/Modalidades/CriarModalidadeCommandHandler.cs
@@ -4,11 +4,13 @@ using Unifesspa.UniPlus.Configuracao.Application.Abstractions;
 using Unifesspa.UniPlus.Configuracao.Domain.Entities;
 using Unifesspa.UniPlus.Configuracao.Domain.Errors;
 using Unifesspa.UniPlus.Configuracao.Domain.Interfaces;
+using Unifesspa.UniPlus.Configuracao.Domain.ValueObjects;
 using Unifesspa.UniPlus.Kernel.Results;
 
 /// <summary>
 /// Handler do <see cref="CriarModalidadeCommand"/> (convention-based Wolverine).
-/// Orquestra: unicidade do código entre vivos (409), construção do agregado
+/// Orquestra: reserva dos códigos do catálogo legal fixo (409), unicidade do
+/// código entre vivos (409), construção do agregado
 /// (invariantes de coerência, 422), integridade referencial dos códigos citados em
 /// composição/remanejamento (422), persistência e commit. Protege a corrida
 /// check-then-act traduzindo a violação do índice único parcial em
@@ -25,6 +27,19 @@ public static class CriarModalidadeCommandHandler
         ArgumentNullException.ThrowIfNull(command);
         ArgumentNullException.ThrowIfNull(repository);
         ArgumentNullException.ThrowIfNull(unitOfWork);
+
+        // Os dez códigos legais fixos só nascem do seed. A reserva precede a checagem de
+        // unicidade porque é propriedade do código, não do estado do banco: o índice único é
+        // parcial (WHERE is_deleted = false), então uma dessas linhas removida antes desta
+        // regra existir libera o código — e o cadastro recriaria a modalidade com estrutura
+        // de vagas arbitrária, que a proteção de atualização então congelaria.
+        if (CodigoModalidade.EhCodigoLegalFixo(command.Codigo))
+        {
+            return Result<Guid>.Failure(new DomainError(
+                ModalidadeErrorCodes.CriacaoBloqueadaCodigoProtegido,
+                $"O código '{command.Codigo.Trim()}' é reservado ao catálogo legal fixo "
+                + "e não pode ser criado por cadastro."));
+        }
 
         if (await repository.CodigoExisteEntreVivosAsync(command.Codigo, null, cancellationToken).ConfigureAwait(false))
         {

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/Modalidades/RemoverModalidadeCommandHandler.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/Modalidades/RemoverModalidadeCommandHandler.cs
@@ -8,7 +8,8 @@ using Unifesspa.UniPlus.Kernel.Results;
 
 /// <summary>
 /// Handler do <see cref="RemoverModalidadeCommand"/>. Soft-delete via
-/// <c>SoftDeleteInterceptor</c> — bloqueia (409) quando ESTA modalidade é
+/// <c>SoftDeleteInterceptor</c> — bloqueia (409) as modalidades do catálogo legal fixo
+/// (<c>RemocaoBloqueadaCodigoProtegido</c>) e bloqueia (409) quando ESTA modalidade é
 /// referenciada por OUTRA modalidade viva como <c>composicao_origem</c> ou como
 /// destino/par/fallback em <c>remanejamento_args</c> (integridade referencial
 /// intra-banco, invariante 7). Nunca é bloqueada por snapshot-copy de Seleção
@@ -35,6 +36,17 @@ public static class RemoverModalidadeCommandHandler
             return Result.Failure(new DomainError(
                 ModalidadeErrorCodes.NaoEncontrada,
                 "Modalidade de concorrência não encontrada."));
+        }
+
+        // As dez modalidades legais fixas são o piso de ações afirmativas exigido pela Lei
+        // 12.711/2012 (red. Lei 14.723/2023): sem elas não há como configurar a distribuição
+        // de vagas de um edital que aplique a lei. A checagem precede a de referência —
+        // é determinística e não vai ao banco.
+        if (modalidade.Codigo.EhLegalFixa)
+        {
+            return Result.Failure(new DomainError(
+                ModalidadeErrorCodes.RemocaoBloqueadaCodigoProtegido,
+                $"A modalidade legal fixa '{modalidade.Codigo.Valor}' não pode ser removida."));
         }
 
         // Check-then-act, simétrico ao bloqueio de remoção dos demais cadastros. A

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Domain/Entities/Modalidade.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Domain/Entities/Modalidade.cs
@@ -30,7 +30,15 @@ using Unifesspa.UniPlus.Kernel.Results;
 /// exige consulta ao banco e mora no handler via repositório.</para>
 /// <para>A remoção é sempre soft-delete; nunca bloqueada por snapshot-copy de
 /// Seleção (ADR-0061), apenas por referência intra-banco viva (outra modalidade
-/// viva que a aponte como origem ou destino/par/fallback).</para>
+/// viva que a aponte como origem ou destino/par/fallback) — ou por ser uma
+/// modalidade do catálogo legal fixo.</para>
+/// <para>As dez modalidades do <b>catálogo legal fixo</b>
+/// (<see cref="CodigoModalidade.CodigosLegaisFixos"/>) são cadastro só na forma: a
+/// estrutura de vagas de cada uma vem da Lei 12.711/2012 (red. Lei 14.723/2023), não
+/// da universidade. Nelas <see cref="Atualizar"/> aceita apenas <see cref="Descricao"/>
+/// e <see cref="BaseLegal"/>; os handlers recusam removê-las e recusam cadastrar os
+/// seus códigos. Alterar a estrutura exige mudança no seed e migração — o mesmo canal
+/// que as criou.</para>
 /// </remarks>
 public sealed class Modalidade : SoftDeletableEntity, IAuditableEntity
 {
@@ -89,7 +97,7 @@ public sealed class Modalidade : SoftDeletableEntity, IAuditableEntity
             return Result<Modalidade>.Failure(codigoResult.Error!);
         }
 
-        Result<CamposResolvidos> camposResult = ValidarComuns(
+        Result<CamposResolvidos> camposResult = ResolverCampos(
             descricao, naturezaLegal, composicaoVagas, composicaoOrigem, regraRemanejamento,
             remanejamentoDestino, remanejamentoPar, remanejamentoFallback,
             criteriosCumulativos, acaoQuandoIndeferido, baseLegal);
@@ -98,8 +106,16 @@ public sealed class Modalidade : SoftDeletableEntity, IAuditableEntity
             return Result<Modalidade>.Failure(camposResult.Error!);
         }
 
+        CamposResolvidos campos = camposResult.Value!;
+
+        Result<CamposResolvidos>? coerencia = ValidarCoerencia(campos);
+        if (coerencia is not null)
+        {
+            return Result<Modalidade>.Failure(coerencia.Error!);
+        }
+
         var modalidade = new Modalidade { Codigo = codigoResult.Value! };
-        modalidade.AplicarCampos(camposResult.Value!);
+        modalidade.AplicarCampos(campos);
 
         return Result<Modalidade>.Success(modalidade);
     }
@@ -109,6 +125,14 @@ public sealed class Modalidade : SoftDeletableEntity, IAuditableEntity
     /// são <b>imutáveis</b> — este método não os recebe nem os altera. Revalida
     /// todas as invariantes de coerência de domínio.
     /// </summary>
+    /// <remarks>
+    /// Numa modalidade do catálogo legal fixo (<see cref="ValueObjects.CodigoModalidade.EhLegalFixa"/>)
+    /// só <c>Descricao</c> e <c>BaseLegal</c> são editáveis; divergência em qualquer outro
+    /// campo retorna <c>EstruturaProtegidaNaoEditavel</c>. A guarda roda depois de resolver
+    /// os campos e <b>antes</b> das invariantes cruzadas: assim uma tentativa de alterar a
+    /// natureza de uma cota federal responde "esta modalidade não se edita" em vez de
+    /// "corrija a coerência do payload", que sugeriria que a edição seria possível.
+    /// </remarks>
     public Result Atualizar(
         string? descricao,
         string? naturezaLegal,
@@ -122,7 +146,7 @@ public sealed class Modalidade : SoftDeletableEntity, IAuditableEntity
         string? acaoQuandoIndeferido,
         string? baseLegal)
     {
-        Result<CamposResolvidos> camposResult = ValidarComuns(
+        Result<CamposResolvidos> camposResult = ResolverCampos(
             descricao, naturezaLegal, composicaoVagas, composicaoOrigem, regraRemanejamento,
             remanejamentoDestino, remanejamentoPar, remanejamentoFallback,
             criteriosCumulativos, acaoQuandoIndeferido, baseLegal);
@@ -131,10 +155,42 @@ public sealed class Modalidade : SoftDeletableEntity, IAuditableEntity
             return Result.Failure(camposResult.Error!);
         }
 
-        AplicarCampos(camposResult.Value!);
+        CamposResolvidos campos = camposResult.Value!;
+
+        if (Codigo.EhLegalFixa && EstruturaDivergeDe(campos))
+        {
+            return Result.Failure(new DomainError(
+                ModalidadeErrorCodes.EstruturaProtegidaNaoEditavel,
+                $"A modalidade legal fixa '{Codigo.Valor}' admite alteração apenas de descrição "
+                + "e base legal — natureza, composição, remanejamento, critérios e ação no "
+                + "indeferimento são fixados em lei."));
+        }
+
+        Result<CamposResolvidos>? coerencia = ValidarCoerencia(campos);
+        if (coerencia is not null)
+        {
+            return Result.Failure(coerencia.Error!);
+        }
+
+        AplicarCampos(campos);
 
         return Result.Success();
     }
+
+    /// <summary>
+    /// Indica se <paramref name="campos"/> altera algum atributo fora da allowlist de
+    /// edição do catálogo legal fixo. A allowlist enumera o que <b>pode</b> mudar
+    /// (descrição e base legal) — assim um atributo novo do agregado nasce protegido por
+    /// omissão, em vez de desprotegido.
+    /// </summary>
+    private bool EstruturaDivergeDe(CamposResolvidos campos) =>
+        campos.NaturezaLegal != NaturezaLegal
+        || campos.ComposicaoVagas != ComposicaoVagas
+        || !string.Equals(campos.ComposicaoOrigem, ComposicaoOrigem, StringComparison.Ordinal)
+        || campos.RegraRemanejamento != RegraRemanejamento
+        || campos.RemanejamentoArgs != RemanejamentoArgs
+        || !campos.CriteriosCumulativos.SequenceEqual(CriteriosCumulativos, StringComparer.Ordinal)
+        || campos.AcaoQuandoIndeferido != AcaoQuandoIndeferido;
 
     private void AplicarCampos(CamposResolvidos campos)
     {
@@ -149,7 +205,13 @@ public sealed class Modalidade : SoftDeletableEntity, IAuditableEntity
         BaseLegal = campos.BaseLegal;
     }
 
-    private static Result<CamposResolvidos> ValidarComuns(
+    /// <summary>
+    /// Primeira metade da validação: analisa os tokens dos enums, normaliza os textos e
+    /// confere tamanhos — tudo que depende só do valor recebido. As invariantes que
+    /// cruzam campos ficam em <see cref="ValidarCoerencia"/>, para que a guarda do
+    /// catálogo legal fixo possa correr entre as duas.
+    /// </summary>
+    private static Result<CamposResolvidos> ResolverCampos(
         string? descricao,
         string? naturezaLegalToken,
         string? composicaoVagasToken,
@@ -232,35 +294,8 @@ public sealed class Modalidade : SoftDeletableEntity, IAuditableEntity
                 $"Código de origem da composição deve ter no máximo {CodigoReferenciaMaxLength} caracteres.");
         }
 
-        // Invariante 4 — equivalência exata RetiraDe ⟺ ComposicaoOrigem preenchida.
-        bool ehRetiraDe = composicao == ComposicaoVagas.RetiraDe;
-        if (ehRetiraDe && origemNorm is null)
-        {
-            return Falha(ModalidadeErrorCodes.OrigemObrigatoriaParaRetiraDe,
-                "Composição RETIRA_DE exige o código de origem (composicao_origem).");
-        }
-
-        if (!ehRetiraDe && origemNorm is not null)
-        {
-            return Falha(ModalidadeErrorCodes.OrigemApenasParaRetiraDe,
-                "Código de origem (composicao_origem) só é permitido na composição RETIRA_DE.");
-        }
-
-        // Invariante 3 — coerência natureza ↔ regra de remanejamento.
-        Result<CamposResolvidos>? coerencia = ValidarCoerenciaNaturezaRemanejamento(natureza, regra);
-        if (coerencia is not null)
-        {
-            return coerencia;
-        }
-
-        // Invariante 5 — argumentos exigidos/proibidos por regra.
         RemanejamentoArgs args = RemanejamentoArgs.Criar(
             remanejamentoDestino, remanejamentoPar, remanejamentoFallback);
-        Result<CamposResolvidos>? argsCheck = ValidarArgumentosPorRegra(regra, args);
-        if (argsCheck is not null)
-        {
-            return argsCheck;
-        }
 
         IReadOnlyList<string> criterios = NormalizarCriterios(criteriosCumulativos);
 
@@ -274,6 +309,39 @@ public sealed class Modalidade : SoftDeletableEntity, IAuditableEntity
             criterios,
             acao,
             NormalizarOpcional(baseLegal)));
+    }
+
+    /// <summary>
+    /// Segunda metade da validação: as invariantes que cruzam campos já resolvidos —
+    /// RetiraDe⟺origem, natureza↔regra de remanejamento e argumentos exigidos ou
+    /// proibidos por regra. Retorna <see langword="null"/> quando tudo é coerente.
+    /// </summary>
+    private static Result<CamposResolvidos>? ValidarCoerencia(CamposResolvidos campos)
+    {
+        // Invariante 4 — equivalência exata RetiraDe ⟺ ComposicaoOrigem preenchida.
+        bool ehRetiraDe = campos.ComposicaoVagas == ComposicaoVagas.RetiraDe;
+        if (ehRetiraDe && campos.ComposicaoOrigem is null)
+        {
+            return Falha(ModalidadeErrorCodes.OrigemObrigatoriaParaRetiraDe,
+                "Composição RETIRA_DE exige o código de origem (composicao_origem).");
+        }
+
+        if (!ehRetiraDe && campos.ComposicaoOrigem is not null)
+        {
+            return Falha(ModalidadeErrorCodes.OrigemApenasParaRetiraDe,
+                "Código de origem (composicao_origem) só é permitido na composição RETIRA_DE.");
+        }
+
+        // Invariante 3 — coerência natureza ↔ regra de remanejamento.
+        Result<CamposResolvidos>? coerencia = ValidarCoerenciaNaturezaRemanejamento(
+            campos.NaturezaLegal, campos.RegraRemanejamento);
+        if (coerencia is not null)
+        {
+            return coerencia;
+        }
+
+        // Invariante 5 — argumentos exigidos/proibidos por regra.
+        return ValidarArgumentosPorRegra(campos.RegraRemanejamento, campos.RemanejamentoArgs);
     }
 
     private static Result<CamposResolvidos>? ValidarCoerenciaNaturezaRemanejamento(

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Domain/Errors/ModalidadeErrorCodes.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Domain/Errors/ModalidadeErrorCodes.cs
@@ -7,6 +7,8 @@ namespace Unifesspa.UniPlus.Configuracao.Domain.Errors;
 /// <list type="bullet">
 ///   <item><description><see cref="CodigoJaExiste"/> → 409 Conflict</description></item>
 ///   <item><description><see cref="RemocaoBloqueadaPorReferencia"/> → 409 Conflict</description></item>
+///   <item><description><see cref="RemocaoBloqueadaCodigoProtegido"/> → 409 Conflict</description></item>
+///   <item><description><see cref="CriacaoBloqueadaCodigoProtegido"/> → 409 Conflict</description></item>
 ///   <item><description><see cref="NaoEncontrada"/> → 404 Not Found</description></item>
 ///   <item><description>demais → 422 Unprocessable Entity</description></item>
 /// </list>
@@ -27,6 +29,19 @@ public static class ModalidadeErrorCodes
     public const string AcaoIndeferimentoInvalida = "Modalidade.AcaoIndeferimentoInvalida";
     public const string ReferenciaInexistenteOuInativa = "Modalidade.ReferenciaInexistenteOuInativa";
     public const string RemocaoBloqueadaPorReferencia = "Modalidade.RemocaoBloqueadaPorReferencia";
+
+    /// <summary>
+    /// Tentativa de alterar natureza, composição, remanejamento, critérios ou ação no
+    /// indeferimento de uma modalidade do catálogo legal fixo — nessas, só descrição e
+    /// base legal são editáveis.
+    /// </summary>
+    public const string EstruturaProtegidaNaoEditavel = "Modalidade.EstruturaProtegidaNaoEditavel";
+
+    /// <summary>Tentativa de remover uma modalidade do catálogo legal fixo.</summary>
+    public const string RemocaoBloqueadaCodigoProtegido = "Modalidade.RemocaoBloqueadaCodigoProtegido";
+
+    /// <summary>Tentativa de cadastrar uma modalidade com código reservado ao catálogo legal fixo.</summary>
+    public const string CriacaoBloqueadaCodigoProtegido = "Modalidade.CriacaoBloqueadaCodigoProtegido";
     public const string BaseLegalTamanho = "Modalidade.BaseLegalTamanho";
     public const string NaoEncontrada = "Modalidade.NaoEncontrada";
 }

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Domain/ValueObjects/CodigoModalidade.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Domain/ValueObjects/CodigoModalidade.cs
@@ -1,5 +1,6 @@
 namespace Unifesspa.UniPlus.Configuracao.Domain.ValueObjects;
 
+using System.Collections.Frozen;
 using System.Text.RegularExpressions;
 
 using Unifesspa.UniPlus.Configuracao.Domain.Errors;
@@ -14,19 +15,80 @@ using Unifesspa.UniPlus.Kernel.Results;
 /// reidratação).
 /// </summary>
 /// <remarks>
-/// Diferente do <c>TipoDocumento</c>, o código da Modalidade é <b>imutável</b>: o
+/// <para>Diferente do <c>TipoDocumento</c>, o código da Modalidade é <b>imutável</b>: o
 /// comando de atualização não o aceita como campo editável, pois a cascata de
 /// remanejamento e as referências de composição (<c>ComposicaoOrigem</c>,
 /// <c>RemanejamentoArgs</c>) apontam para modalidades por código — renomear
-/// quebraria a integridade referencial intra-banco.
+/// quebraria a integridade referencial intra-banco.</para>
+/// <para>Dez códigos são <b>reservados</b> ao catálogo legal fixo (ver
+/// <see cref="CodigosLegaisFixos"/>): as oito modalidades da Lei 12.711/2012 (red. Lei
+/// 14.723/2023), a ampla concorrência e a modalidade de pessoa com deficiência fora da
+/// reserva federal. A proteção é exposta por <see cref="EhLegalFixa"/> e aplicada pelo
+/// agregado (atualização) e pelos handlers (criação e remoção), não pelo banco.</para>
 /// </remarks>
 public sealed partial record CodigoModalidade
 {
     private const int TamanhoMaximo = 60;
 
+    /// <summary>Ampla concorrência.</summary>
+    public const string Ac = "AC";
+
+    /// <summary>Pessoa com deficiência na ampla concorrência (rótulo <c>V</c> nos editais).</summary>
+    public const string AcPcd = "AC_PCD";
+
+    /// <summary>Cota de baixa renda para pessoa preta, parda ou indígena.</summary>
+    public const string LbPpi = "LB_PPI";
+
+    /// <summary>Cota de baixa renda para pessoa quilombola.</summary>
+    public const string LbQ = "LB_Q";
+
+    /// <summary>Cota de baixa renda para pessoa com deficiência.</summary>
+    public const string LbPcd = "LB_PCD";
+
+    /// <summary>Cota de baixa renda para egresso de escola pública.</summary>
+    public const string LbEp = "LB_EP";
+
+    /// <summary>Cota independente de renda para pessoa preta, parda ou indígena.</summary>
+    public const string LiPpi = "LI_PPI";
+
+    /// <summary>Cota independente de renda para pessoa quilombola.</summary>
+    public const string LiQ = "LI_Q";
+
+    /// <summary>Cota independente de renda para pessoa com deficiência.</summary>
+    public const string LiPcd = "LI_PCD";
+
+    /// <summary>Cota independente de renda para egresso de escola pública.</summary>
+    public const string LiEp = "LI_EP";
+
+    /// <summary>
+    /// Os dez códigos do catálogo legal fixo — piso de ações afirmativas da Lei
+    /// 12.711/2012 (red. Lei 14.723/2023) mais a ampla concorrência e a modalidade de
+    /// pessoa com deficiência fora da reserva federal. Não são cadastro: nascem do seed,
+    /// e a estrutura de vagas de cada um (natureza, composição, remanejamento) é ditada
+    /// pela lei, não pela universidade. Alterá-la exige mudança no seed e migração.
+    /// </summary>
+    public static FrozenSet<string> CodigosLegaisFixos { get; } = FrozenSet.ToFrozenSet(
+        [Ac, AcPcd, LbPpi, LbQ, LbPcd, LbEp, LiPpi, LiQ, LiPcd, LiEp],
+        StringComparer.Ordinal);
+
     public string Valor { get; }
 
     private CodigoModalidade(string valor) => Valor = valor;
+
+    /// <summary>
+    /// Indica se este código pertence ao catálogo legal fixo — comparação case-sensitive
+    /// (<see cref="StringComparison.Ordinal"/>), alinhada ao formato canônico do value
+    /// object (maiúsculas).
+    /// </summary>
+    public bool EhLegalFixa => CodigosLegaisFixos.Contains(Valor);
+
+    /// <summary>
+    /// Indica se <paramref name="valor"/> é um código do catálogo legal fixo, sem alocar
+    /// value object. Apara o valor antes de comparar, como faz <see cref="Criar"/> — um
+    /// código com espaços à volta é o mesmo código.
+    /// </summary>
+    public static bool EhCodigoLegalFixo(string? valor) =>
+        !string.IsNullOrWhiteSpace(valor) && CodigosLegaisFixos.Contains(valor.Trim());
 
     /// <summary>
     /// Cria um <see cref="CodigoModalidade"/> validando o formato fechado. Valor

--- a/tests/Unifesspa.UniPlus.ArchTests/SolutionRules/CatalogoLegalDeModalidadesTests.cs
+++ b/tests/Unifesspa.UniPlus.ArchTests/SolutionRules/CatalogoLegalDeModalidadesTests.cs
@@ -1,0 +1,41 @@
+namespace Unifesspa.UniPlus.ArchTests.SolutionRules;
+
+using AwesomeAssertions;
+
+using Unifesspa.UniPlus.Configuracao.Domain.ValueObjects;
+using Unifesspa.UniPlus.Selecao.Domain.Enums;
+
+/// <summary>
+/// Amarra as duas listas de códigos de modalidade legal que a solução mantém: o catálogo
+/// protegido em Configuração (<see cref="CodigoModalidade.CodigosLegaisFixos"/>), que
+/// recusa edição e remoção por cadastro, e o conjunto exigido em Seleção
+/// (<see cref="ModalidadesFederaisLei12711"/>), que a distribuição de vagas obriga quando
+/// o edital aplica a Lei 12.711/2012.
+/// </summary>
+/// <remarks>
+/// As duas listas existem separadas de propósito: Configuração é o catálogo e Seleção é a
+/// consumidora, e um módulo não referencia o domínio do outro. A cópia é aceitável porque
+/// a lei é o contrato comum — mas só enquanto não divergirem. Um código renomeado de um
+/// lado e não do outro produziria um edital que exige uma modalidade que o catálogo não
+/// tem, e o erro só apareceria na hora de publicar.
+/// </remarks>
+public sealed class CatalogoLegalDeModalidadesTests
+{
+    [Fact(DisplayName = "Todo código exigido pela distribuição da Lei 12.711 está protegido no catálogo")]
+    public void CodigosDeSelecao_SaoSubconjuntoDoCatalogoProtegido() =>
+        ModalidadesFederaisLei12711.CodigosComAc.Should().BeSubsetOf(
+            CodigoModalidade.CodigosLegaisFixos,
+            "um código que a distribuição de vagas exige mas o catálogo não protege pode "
+            + "ser apagado por cadastro, inviabilizando configurar a lei depois");
+
+    [Fact(DisplayName = "O catálogo protegido acrescenta a modalidade de pessoa com deficiência fora da reserva federal")]
+    public void CatalogoProtegido_ExcedeSelecaoApenasEmAcPcd()
+    {
+        IEnumerable<string> exclusivosDoCatalogo = CodigoModalidade.CodigosLegaisFixos
+            .Except(ModalidadesFederaisLei12711.CodigosComAc, StringComparer.Ordinal);
+
+        exclusivosDoCatalogo.Should().Equal([CodigoModalidade.AcPcd],
+            "AC_PCD não entra na cascata das oito federais — as suas vagas são retiradas da "
+            + "ampla concorrência —, mas é igualmente fixada em lei");
+    }
+}

--- a/tests/Unifesspa.UniPlus.Configuracao.Application.UnitTests/Commands/AtualizarModalidadeCommandHandlerTests.cs
+++ b/tests/Unifesspa.UniPlus.Configuracao.Application.UnitTests/Commands/AtualizarModalidadeCommandHandlerTests.cs
@@ -16,7 +16,7 @@ public sealed class AtualizarModalidadeCommandHandlerTests
     private readonly IModalidadeRepository _repository = Substitute.For<IModalidadeRepository>();
     private readonly IConfiguracaoUnitOfWork _unitOfWork = Substitute.For<IConfiguracaoUnitOfWork>();
 
-    private static Modalidade Existente(string codigo = "AC") =>
+    private static Modalidade Existente(string codigo = "PSVR_AMPLA") =>
         Modalidade.Criar(codigo, "Ampla", "AMPLA", "RESIDUAL_DO_VO", null, null, null, null, null, null, null, null)
             .Value!;
 
@@ -37,7 +37,7 @@ public sealed class AtualizarModalidadeCommandHandlerTests
     [Fact(DisplayName = "Atualização válida persiste e o código permanece imutável")]
     public async Task Handle_Valido_PersisteCodigoImutavel()
     {
-        Modalidade existente = Existente("AC");
+        Modalidade existente = Existente();
         _repository.ObterPorIdAsync(existente.Id, Arg.Any<CancellationToken>()).Returns(existente);
 
         var comando = new AtualizarModalidadeCommand(
@@ -47,9 +47,29 @@ public sealed class AtualizarModalidadeCommandHandlerTests
             comando, _repository, _unitOfWork, CancellationToken.None);
 
         resultado.IsSuccess.Should().BeTrue();
-        existente.Codigo.Valor.Should().Be("AC", "o código é imutável — não há campo para alterá-lo");
+        existente.Codigo.Valor.Should().Be("PSVR_AMPLA", "o código é imutável — não há campo para alterá-lo");
         existente.Descricao.Should().Be("Descrição nova");
         await _unitOfWork.Received(1).SalvarAlteracoesAsync(Arg.Any<CancellationToken>());
+    }
+
+    [Fact(DisplayName = "Modalidade legal fixa recusa alteração estrutural antes de checar referências")]
+    public async Task Handle_LegalFixa_RecusaSemChecarReferencias()
+    {
+        Modalidade existente = Existente("LB_PPI");
+        _repository.ObterPorIdAsync(existente.Id, Arg.Any<CancellationToken>()).Returns(existente);
+
+        var comando = new AtualizarModalidadeCommand(
+            existente.Id, NaturezaLegal: "SUPLEMENTAR", ComposicaoVagas: "SUPLEMENTAR_AO_TOTAL",
+            RegraRemanejamento: "DESTINO_UNICO", RemanejamentoDestino: "AC");
+
+        Result resultado = await AtualizarModalidadeCommandHandler.Handle(
+            comando, _repository, _unitOfWork, CancellationToken.None);
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be(ModalidadeErrorCodes.EstruturaProtegidaNaoEditavel);
+        await _repository.DidNotReceive().CodigosVivosExistemAsync(
+            Arg.Any<IReadOnlyCollection<string>>(), Arg.Any<CancellationToken>());
+        await _unitOfWork.DidNotReceive().SalvarAlteracoesAsync(Arg.Any<CancellationToken>());
     }
 
     [Fact(DisplayName = "Referência de remanejamento inexistente entre vivos retorna 422 sem persistir")]

--- a/tests/Unifesspa.UniPlus.Configuracao.Application.UnitTests/Commands/CriarModalidadeCommandHandlerTests.cs
+++ b/tests/Unifesspa.UniPlus.Configuracao.Application.UnitTests/Commands/CriarModalidadeCommandHandlerTests.cs
@@ -16,13 +16,15 @@ public sealed class CriarModalidadeCommandHandlerTests
     private readonly IModalidadeRepository _repository = Substitute.For<IModalidadeRepository>();
     private readonly IConfiguracaoUnitOfWork _unitOfWork = Substitute.For<IConfiguracaoUnitOfWork>();
 
+    private const string CodigoInstitucional = "PSVR_AMPLA";
+
     private static CriarModalidadeCommand ComandoAmpla() =>
-        new("AC", Descricao: "Ampla concorrência", NaturezaLegal: "AMPLA");
+        new(CodigoInstitucional, Descricao: "Ampla concorrência do vestibular remanescente", NaturezaLegal: "AMPLA");
 
     [Fact(DisplayName = "Código livre cria a modalidade, persiste e retorna o Id")]
     public async Task Handle_CodigoLivre_CriaEPersiste()
     {
-        _repository.CodigoExisteEntreVivosAsync("AC", null, Arg.Any<CancellationToken>()).Returns(false);
+        _repository.CodigoExisteEntreVivosAsync(CodigoInstitucional, null, Arg.Any<CancellationToken>()).Returns(false);
 
         Result<Guid> resultado = await CriarModalidadeCommandHandler.Handle(
             ComandoAmpla(), _repository, _unitOfWork, CancellationToken.None);
@@ -33,10 +35,30 @@ public sealed class CriarModalidadeCommandHandlerTests
         await _unitOfWork.Received(1).SalvarAlteracoesAsync(Arg.Any<CancellationToken>());
     }
 
+    [Theory(DisplayName = "Código reservado ao catálogo legal fixo é recusado (409) antes de consultar o banco")]
+    [InlineData("LB_PPI")]
+    [InlineData("AC")]
+    [InlineData("AC_PCD")]
+    [InlineData(" LB_PPI ")]
+    public async Task Handle_CodigoReservado_RetornaConflito(string codigo)
+    {
+        var comando = new CriarModalidadeCommand(codigo, NaturezaLegal: "AMPLA");
+
+        Result<Guid> resultado = await CriarModalidadeCommandHandler.Handle(
+            comando, _repository, _unitOfWork, CancellationToken.None);
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be(ModalidadeErrorCodes.CriacaoBloqueadaCodigoProtegido);
+        await _repository.DidNotReceive().CodigoExisteEntreVivosAsync(
+            Arg.Any<string>(), Arg.Any<Guid?>(), Arg.Any<CancellationToken>());
+        await _repository.DidNotReceive().AdicionarAsync(Arg.Any<Modalidade>(), Arg.Any<CancellationToken>());
+        await _unitOfWork.DidNotReceive().SalvarAlteracoesAsync(Arg.Any<CancellationToken>());
+    }
+
     [Fact(DisplayName = "Código já existente entre vivos retorna conflito (CodigoJaExiste) sem persistir")]
     public async Task Handle_CodigoDuplicado_RetornaConflito()
     {
-        _repository.CodigoExisteEntreVivosAsync("AC", null, Arg.Any<CancellationToken>()).Returns(true);
+        _repository.CodigoExisteEntreVivosAsync(CodigoInstitucional, null, Arg.Any<CancellationToken>()).Returns(true);
 
         Result<Guid> resultado = await CriarModalidadeCommandHandler.Handle(
             ComandoAmpla(), _repository, _unitOfWork, CancellationToken.None);
@@ -49,13 +71,13 @@ public sealed class CriarModalidadeCommandHandlerTests
     [Fact(DisplayName = "Referência de composição inexistente entre vivos retorna 422 sem persistir")]
     public async Task Handle_ReferenciaInexistente_Retorna422()
     {
-        _repository.CodigoExisteEntreVivosAsync("LB_PPI", null, Arg.Any<CancellationToken>()).Returns(false);
+        _repository.CodigoExisteEntreVivosAsync("PSIQ_QUILOMBOLA", null, Arg.Any<CancellationToken>()).Returns(false);
         _repository.CodigosVivosExistemAsync(Arg.Any<IReadOnlyCollection<string>>(), Arg.Any<CancellationToken>())
             .Returns(false);
 
         // RETIRA_DE exige origem; a origem "XPTO" não existe viva.
         var comando = new CriarModalidadeCommand(
-            "LB_PPI", NaturezaLegal: "AMPLA", ComposicaoVagas: "RETIRA_DE", ComposicaoOrigem: "XPTO");
+            "PSIQ_QUILOMBOLA", NaturezaLegal: "AMPLA", ComposicaoVagas: "RETIRA_DE", ComposicaoOrigem: "XPTO");
 
         Result<Guid> resultado = await CriarModalidadeCommandHandler.Handle(
             comando, _repository, _unitOfWork, CancellationToken.None);
@@ -72,7 +94,7 @@ public sealed class CriarModalidadeCommandHandlerTests
         _repository.CodigoExisteEntreVivosAsync(Arg.Any<string>(), null, Arg.Any<CancellationToken>()).Returns(false);
 
         var comando = new CriarModalidadeCommand(
-            "LB_PPI", NaturezaLegal: "COTA_RESERVADA", ComposicaoVagas: "DENTRO_DO_VR");
+            "PSIQ_QUILOMBOLA", NaturezaLegal: "COTA_RESERVADA", ComposicaoVagas: "DENTRO_DO_VR");
 
         Result<Guid> resultado = await CriarModalidadeCommandHandler.Handle(
             comando, _repository, _unitOfWork, CancellationToken.None);

--- a/tests/Unifesspa.UniPlus.Configuracao.Application.UnitTests/Commands/RemoverModalidadeCommandHandlerTests.cs
+++ b/tests/Unifesspa.UniPlus.Configuracao.Application.UnitTests/Commands/RemoverModalidadeCommandHandlerTests.cs
@@ -16,8 +16,10 @@ public sealed class RemoverModalidadeCommandHandlerTests
     private readonly IModalidadeRepository _repository = Substitute.For<IModalidadeRepository>();
     private readonly IConfiguracaoUnitOfWork _unitOfWork = Substitute.For<IConfiguracaoUnitOfWork>();
 
-    private static Modalidade Modalidade() =>
-        Domain.Entities.Modalidade.Criar("AC", null, "AMPLA", "RESIDUAL_DO_VO", null, null, null, null, null, null, null, null)
+    private const string CodigoInstitucional = "PSVR_AMPLA";
+
+    private static Modalidade Modalidade(string codigo = CodigoInstitucional) =>
+        Domain.Entities.Modalidade.Criar(codigo, null, "AMPLA", "RESIDUAL_DO_VO", null, null, null, null, null, null, null, null)
             .Value!;
 
     [Fact(DisplayName = "Modalidade referenciada por outra viva bloqueia a remoção (409)")]
@@ -25,7 +27,7 @@ public sealed class RemoverModalidadeCommandHandlerTests
     {
         Modalidade modalidade = Modalidade();
         _repository.ObterPorIdAsync(modalidade.Id, Arg.Any<CancellationToken>()).Returns(modalidade);
-        _repository.EhReferenciadaPorOutraModalidadeVivaAsync("AC", modalidade.Id, Arg.Any<CancellationToken>())
+        _repository.EhReferenciadaPorOutraModalidadeVivaAsync(CodigoInstitucional, modalidade.Id, Arg.Any<CancellationToken>())
             .Returns(true);
 
         Result resultado = await RemoverModalidadeCommandHandler.Handle(
@@ -42,7 +44,7 @@ public sealed class RemoverModalidadeCommandHandlerTests
     {
         Modalidade modalidade = Modalidade();
         _repository.ObterPorIdAsync(modalidade.Id, Arg.Any<CancellationToken>()).Returns(modalidade);
-        _repository.EhReferenciadaPorOutraModalidadeVivaAsync("AC", modalidade.Id, Arg.Any<CancellationToken>())
+        _repository.EhReferenciadaPorOutraModalidadeVivaAsync(CodigoInstitucional, modalidade.Id, Arg.Any<CancellationToken>())
             .Returns(false);
 
         Result resultado = await RemoverModalidadeCommandHandler.Handle(
@@ -51,6 +53,26 @@ public sealed class RemoverModalidadeCommandHandlerTests
         resultado.IsSuccess.Should().BeTrue();
         _repository.Received(1).Remover(modalidade);
         await _unitOfWork.Received(1).SalvarAlteracoesAsync(Arg.Any<CancellationToken>());
+    }
+
+    [Theory(DisplayName = "Modalidade do catálogo legal fixo bloqueia a remoção (409) sem consultar referências")]
+    [InlineData("LB_PPI")]
+    [InlineData("AC")]
+    [InlineData("AC_PCD")]
+    public async Task Handle_LegalFixa_RetornaConflito(string codigo)
+    {
+        Modalidade modalidade = Modalidade(codigo);
+        _repository.ObterPorIdAsync(modalidade.Id, Arg.Any<CancellationToken>()).Returns(modalidade);
+
+        Result resultado = await RemoverModalidadeCommandHandler.Handle(
+            new RemoverModalidadeCommand(modalidade.Id), _repository, _unitOfWork, CancellationToken.None);
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be(ModalidadeErrorCodes.RemocaoBloqueadaCodigoProtegido);
+        await _repository.DidNotReceive().EhReferenciadaPorOutraModalidadeVivaAsync(
+            Arg.Any<string>(), Arg.Any<Guid>(), Arg.Any<CancellationToken>());
+        _repository.DidNotReceive().Remover(Arg.Any<Modalidade>());
+        await _unitOfWork.DidNotReceive().SalvarAlteracoesAsync(Arg.Any<CancellationToken>());
     }
 
     [Fact(DisplayName = "Modalidade inexistente retorna NaoEncontrada (404)")]

--- a/tests/Unifesspa.UniPlus.Configuracao.Domain.UnitTests/Entities/ModalidadeTests.cs
+++ b/tests/Unifesspa.UniPlus.Configuracao.Domain.UnitTests/Entities/ModalidadeTests.cs
@@ -248,7 +248,9 @@ public sealed class ModalidadeTests
     [Fact(DisplayName = "Atualizar troca atributos editáveis mantendo Codigo e Id imutáveis")]
     public void Atualizar_MantemCodigoEId()
     {
-        Modalidade m = Criar(codigo: "LB_PPI", natureza: "COTA_RESERVADA", regra: "SEGUE_CASCATA").Value!;
+        Modalidade m = Criar(
+            codigo: "PSIQ_INDIGENA", composicao: "DENTRO_DO_VR",
+            natureza: "COTA_RESERVADA", regra: "SEGUE_CASCATA").Value!;
         Guid idOriginal = m.Id;
 
         Result r = m.Atualizar(
@@ -258,7 +260,7 @@ public sealed class ModalidadeTests
             criteriosCumulativos: null, acaoQuandoIndeferido: null, baseLegal: null);
 
         r.IsSuccess.Should().BeTrue();
-        m.Codigo.Valor.Should().Be("LB_PPI", "o código é imutável");
+        m.Codigo.Valor.Should().Be("PSIQ_INDIGENA", "o código é imutável");
         m.Id.Should().Be(idOriginal, "o Id é imutável");
         m.NaturezaLegal.Should().Be(NaturezaLegal.Ampla);
         m.Descricao.Should().Be("Nova descrição");
@@ -267,7 +269,7 @@ public sealed class ModalidadeTests
     [Fact(DisplayName = "Atualizar revalida coerência (cota sem cascata falha)")]
     public void Atualizar_Incoerente_Falha()
     {
-        Modalidade m = Criar(codigo: "AC", natureza: "AMPLA").Value!;
+        Modalidade m = Criar(codigo: "PSVR_AMPLA", natureza: "AMPLA").Value!;
 
         Result r = m.Atualizar(
             descricao: null, naturezaLegal: "COTA_RESERVADA", composicaoVagas: "DENTRO_DO_VR",
@@ -277,5 +279,200 @@ public sealed class ModalidadeTests
 
         r.IsFailure.Should().BeTrue();
         r.Error!.Code.Should().Be(ModalidadeErrorCodes.NaturezaRemanejamentoIncoerente);
+    }
+
+    // ── Proteção do catálogo legal fixo ────────────────────────────────────────
+
+    /// <summary>Cota federal tal como semeada: reservada, dentro das vagas reservadas, cascata.</summary>
+    private static Modalidade CotaFederal(IReadOnlyList<string>? criterios = null) =>
+        Criar(codigo: "LB_PPI", descricao: "Cota", natureza: "COTA_RESERVADA",
+            composicao: "DENTRO_DO_VR", regra: "SEGUE_CASCATA", criterios: criterios,
+            baseLegal: "Lei 12.711/2012").Value!;
+
+    /// <summary>Pessoa com deficiência na ampla concorrência: única fixa com argumento de remanejamento.</summary>
+    private static Modalidade AcPcd() =>
+        Criar(codigo: "AC_PCD", natureza: "OUTRA_MODALIDADE", composicao: "RETIRA_DE",
+            origem: "AC", regra: "DESTINO_UNICO", destino: "AC").Value!;
+
+    [Fact(DisplayName = "Legal fixa recusa alteração de natureza")]
+    public void Atualizar_LegalFixaNatureza_Recusa()
+    {
+        Modalidade m = CotaFederal();
+
+        Result r = m.Atualizar(
+            descricao: "Cota", naturezaLegal: "AMPLA", composicaoVagas: "DENTRO_DO_VR",
+            composicaoOrigem: null, regraRemanejamento: "SEGUE_CASCATA",
+            remanejamentoDestino: null, remanejamentoPar: null, remanejamentoFallback: null,
+            criteriosCumulativos: null, acaoQuandoIndeferido: null, baseLegal: "Lei 12.711/2012");
+
+        r.IsFailure.Should().BeTrue();
+        r.Error!.Code.Should().Be(ModalidadeErrorCodes.EstruturaProtegidaNaoEditavel);
+        m.NaturezaLegal.Should().Be(NaturezaLegal.CotaReservada, "a recusa não muta a entidade");
+    }
+
+    [Fact(DisplayName = "Legal fixa recusa alteração de composição de vagas")]
+    public void Atualizar_LegalFixaComposicao_Recusa()
+    {
+        Modalidade m = CotaFederal();
+
+        Result r = m.Atualizar(
+            descricao: "Cota", naturezaLegal: "COTA_RESERVADA", composicaoVagas: "SUPLEMENTAR_AO_TOTAL",
+            composicaoOrigem: null, regraRemanejamento: "SEGUE_CASCATA",
+            remanejamentoDestino: null, remanejamentoPar: null, remanejamentoFallback: null,
+            criteriosCumulativos: null, acaoQuandoIndeferido: null, baseLegal: "Lei 12.711/2012");
+
+        r.IsFailure.Should().BeTrue();
+        r.Error!.Code.Should().Be(ModalidadeErrorCodes.EstruturaProtegidaNaoEditavel);
+        m.ComposicaoVagas.Should().Be(ComposicaoVagas.DentroDoVr);
+    }
+
+    [Fact(DisplayName = "Legal fixa recusa alteração da origem da composição")]
+    public void Atualizar_LegalFixaOrigem_Recusa()
+    {
+        Modalidade m = CotaFederal();
+
+        Result r = m.Atualizar(
+            descricao: "Cota", naturezaLegal: "COTA_RESERVADA", composicaoVagas: "DENTRO_DO_VR",
+            composicaoOrigem: "AC", regraRemanejamento: "SEGUE_CASCATA",
+            remanejamentoDestino: null, remanejamentoPar: null, remanejamentoFallback: null,
+            criteriosCumulativos: null, acaoQuandoIndeferido: null, baseLegal: "Lei 12.711/2012");
+
+        r.IsFailure.Should().BeTrue();
+        r.Error!.Code.Should().Be(ModalidadeErrorCodes.EstruturaProtegidaNaoEditavel);
+        m.ComposicaoOrigem.Should().BeNull();
+    }
+
+    [Fact(DisplayName = "Legal fixa recusa alteração da regra de remanejamento")]
+    public void Atualizar_LegalFixaRegra_Recusa()
+    {
+        Modalidade m = CotaFederal();
+
+        Result r = m.Atualizar(
+            descricao: "Cota", naturezaLegal: "COTA_RESERVADA", composicaoVagas: "DENTRO_DO_VR",
+            composicaoOrigem: null, regraRemanejamento: null,
+            remanejamentoDestino: null, remanejamentoPar: null, remanejamentoFallback: null,
+            criteriosCumulativos: null, acaoQuandoIndeferido: null, baseLegal: "Lei 12.711/2012");
+
+        r.IsFailure.Should().BeTrue();
+        r.Error!.Code.Should().Be(ModalidadeErrorCodes.EstruturaProtegidaNaoEditavel);
+        m.RegraRemanejamento.Should().Be(RegraRemanejamento.SegueCascata);
+    }
+
+    [Fact(DisplayName = "Legal fixa recusa alteração dos critérios cumulativos")]
+    public void Atualizar_LegalFixaCriterios_Recusa()
+    {
+        Modalidade m = CotaFederal();
+
+        Result r = m.Atualizar(
+            descricao: "Cota", naturezaLegal: "COTA_RESERVADA", composicaoVagas: "DENTRO_DO_VR",
+            composicaoOrigem: null, regraRemanejamento: "SEGUE_CASCATA",
+            remanejamentoDestino: null, remanejamentoPar: null, remanejamentoFallback: null,
+            criteriosCumulativos: ["RENDA_PER_CAPITA"], acaoQuandoIndeferido: null,
+            baseLegal: "Lei 12.711/2012");
+
+        r.IsFailure.Should().BeTrue();
+        r.Error!.Code.Should().Be(ModalidadeErrorCodes.EstruturaProtegidaNaoEditavel);
+        m.CriteriosCumulativos.Should().BeEmpty();
+    }
+
+    [Fact(DisplayName = "Legal fixa recusa alteração da ação quando indeferido")]
+    public void Atualizar_LegalFixaAcaoIndeferimento_Recusa()
+    {
+        Modalidade m = CotaFederal();
+
+        Result r = m.Atualizar(
+            descricao: "Cota", naturezaLegal: "COTA_RESERVADA", composicaoVagas: "DENTRO_DO_VR",
+            composicaoOrigem: null, regraRemanejamento: "SEGUE_CASCATA",
+            remanejamentoDestino: null, remanejamentoPar: null, remanejamentoFallback: null,
+            criteriosCumulativos: null, acaoQuandoIndeferido: "RECLASSIFICAR_AC",
+            baseLegal: "Lei 12.711/2012");
+
+        r.IsFailure.Should().BeTrue();
+        r.Error!.Code.Should().Be(ModalidadeErrorCodes.EstruturaProtegidaNaoEditavel);
+        m.AcaoQuandoIndeferido.Should().BeNull();
+    }
+
+    [Theory(DisplayName = "Legal fixa recusa alteração de cada argumento de remanejamento")]
+    [InlineData("LB_PPI", null, null)]
+    [InlineData("AC", "AC", null)]
+    [InlineData("AC", null, "AC")]
+    public void Atualizar_LegalFixaArgumentos_Recusa(string? destino, string? par, string? fallback)
+    {
+        Modalidade m = AcPcd();
+
+        Result r = m.Atualizar(
+            descricao: null, naturezaLegal: "OUTRA_MODALIDADE", composicaoVagas: "RETIRA_DE",
+            composicaoOrigem: "AC", regraRemanejamento: "DESTINO_UNICO",
+            remanejamentoDestino: destino, remanejamentoPar: par, remanejamentoFallback: fallback,
+            criteriosCumulativos: null, acaoQuandoIndeferido: null, baseLegal: null);
+
+        r.IsFailure.Should().BeTrue();
+        r.Error!.Code.Should().Be(ModalidadeErrorCodes.EstruturaProtegidaNaoEditavel);
+        m.RemanejamentoArgs.Destino.Should().Be("AC");
+        m.RemanejamentoArgs.Par.Should().BeNull();
+        m.RemanejamentoArgs.Fallback.Should().BeNull();
+    }
+
+    [Fact(DisplayName = "Legal fixa aceita alteração de descrição e base legal com a estrutura reenviada idêntica")]
+    public void Atualizar_LegalFixaSomenteRedacao_Aceita()
+    {
+        // Critérios não vazios: com lista vazia os dois lados podem cair na mesma
+        // instância cacheada e o teste não distinguiria comparação por valor de
+        // comparação por referência.
+        Modalidade m = CotaFederal(criterios: ["RENDA_PER_CAPITA"]);
+
+        Result r = m.Atualizar(
+            descricao: "Cota — baixa renda, preto/pardo/indígena", naturezaLegal: "COTA_RESERVADA",
+            composicaoVagas: "DENTRO_DO_VR", composicaoOrigem: null, regraRemanejamento: "SEGUE_CASCATA",
+            remanejamentoDestino: null, remanejamentoPar: null, remanejamentoFallback: null,
+            criteriosCumulativos: ["RENDA_PER_CAPITA"], acaoQuandoIndeferido: null,
+            baseLegal: "Lei 12.711/2012 (red. Lei 14.723/2023)");
+
+        r.IsSuccess.Should().BeTrue();
+        m.Descricao.Should().Be("Cota — baixa renda, preto/pardo/indígena");
+        m.BaseLegal.Should().Be("Lei 12.711/2012 (red. Lei 14.723/2023)");
+        m.NaturezaLegal.Should().Be(NaturezaLegal.CotaReservada);
+    }
+
+    [Fact(DisplayName = "Modalidade institucional segue alterando a estrutura livremente")]
+    public void Atualizar_Institucional_AlteraEstrutura()
+    {
+        Modalidade m = Criar(
+            codigo: "PSIQ_QUILOMBOLA", natureza: "COTA_RESERVADA",
+            composicao: "DENTRO_DO_VR", regra: "SEGUE_CASCATA").Value!;
+
+        Result r = m.Atualizar(
+            descricao: null, naturezaLegal: "SUPLEMENTAR", composicaoVagas: "SUPLEMENTAR_AO_TOTAL",
+            composicaoOrigem: null, regraRemanejamento: "DESTINO_UNICO",
+            remanejamentoDestino: "AC", remanejamentoPar: null, remanejamentoFallback: null,
+            criteriosCumulativos: null, acaoQuandoIndeferido: null, baseLegal: null);
+
+        r.IsSuccess.Should().BeTrue();
+        m.NaturezaLegal.Should().Be(NaturezaLegal.Suplementar);
+    }
+
+    [Fact(DisplayName = "Token inválido numa legal fixa reporta o erro de domínio, não a proteção")]
+    public void Atualizar_LegalFixaTokenInvalido_ReportaErroDeDominio()
+    {
+        Modalidade m = CotaFederal();
+
+        Result r = m.Atualizar(
+            descricao: null, naturezaLegal: "XPTO", composicaoVagas: "DENTRO_DO_VR",
+            composicaoOrigem: null, regraRemanejamento: "SEGUE_CASCATA",
+            remanejamentoDestino: null, remanejamentoPar: null, remanejamentoFallback: null,
+            criteriosCumulativos: null, acaoQuandoIndeferido: null, baseLegal: null);
+
+        r.IsFailure.Should().BeTrue();
+        r.Error!.Code.Should().Be(ModalidadeErrorCodes.NaturezaInvalida,
+            "não se compara com o cânone aquilo que sequer resolve para um valor de domínio");
+    }
+
+    [Fact(DisplayName = "A factory materializa códigos legais fixos — a reserva é do cadastro, não do domínio")]
+    public void Criar_CodigoLegalFixo_Aceita()
+    {
+        Result<Modalidade> r = Criar(codigo: "LB_PPI", natureza: "COTA_RESERVADA",
+            composicao: "DENTRO_DO_VR", regra: "SEGUE_CASCATA");
+
+        r.IsSuccess.Should().BeTrue("o seed e a reidratação dependem da factory aceitá-los");
     }
 }

--- a/tests/Unifesspa.UniPlus.Configuracao.Domain.UnitTests/ValueObjects/CodigoModalidadeTests.cs
+++ b/tests/Unifesspa.UniPlus.Configuracao.Domain.UnitTests/ValueObjects/CodigoModalidadeTests.cs
@@ -1,0 +1,67 @@
+namespace Unifesspa.UniPlus.Configuracao.Domain.UnitTests.ValueObjects;
+
+using AwesomeAssertions;
+
+using Unifesspa.UniPlus.Configuracao.Domain.ValueObjects;
+
+public sealed class CodigoModalidadeTests
+{
+    [Theory(DisplayName = "Os dez códigos do catálogo legal fixo são reconhecidos como protegidos")]
+    [InlineData("AC")]
+    [InlineData("AC_PCD")]
+    [InlineData("LB_PPI")]
+    [InlineData("LB_Q")]
+    [InlineData("LB_PCD")]
+    [InlineData("LB_EP")]
+    [InlineData("LI_PPI")]
+    [InlineData("LI_Q")]
+    [InlineData("LI_PCD")]
+    [InlineData("LI_EP")]
+    public void EhLegalFixa_CodigoDoCatalogo_Verdadeiro(string codigo)
+    {
+        CodigoModalidade vo = CodigoModalidade.Criar(codigo).Value!;
+
+        vo.EhLegalFixa.Should().BeTrue();
+        CodigoModalidade.EhCodigoLegalFixo(codigo).Should().BeTrue();
+    }
+
+    [Theory(DisplayName = "Código institucional não é protegido")]
+    [InlineData("PSIQ_INDIGENA")]
+    [InlineData("PSVR_AMPLA")]
+    [InlineData("SUP")]
+    [InlineData("LB")]
+    [InlineData("LB_PPI2")]
+    public void EhLegalFixa_CodigoInstitucional_Falso(string codigo)
+    {
+        CodigoModalidade vo = CodigoModalidade.Criar(codigo).Value!;
+
+        vo.EhLegalFixa.Should().BeFalse();
+        CodigoModalidade.EhCodigoLegalFixo(codigo).Should().BeFalse();
+    }
+
+    [Theory(DisplayName = "A reserva enxerga o código com espaços à volta")]
+    [InlineData(" LB_PPI ")]
+    [InlineData("\tAC")]
+    [InlineData("AC_PCD\n")]
+    public void EhCodigoLegalFixo_ComEspacos_Verdadeiro(string codigo) =>
+        CodigoModalidade.EhCodigoLegalFixo(codigo).Should().BeTrue(
+            "o cadastro apara o código antes de persistir — com espaços é o mesmo código");
+
+    [Theory(DisplayName = "Valor nulo ou em branco não é código protegido")]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void EhCodigoLegalFixo_NuloOuBranco_Falso(string? codigo) =>
+        CodigoModalidade.EhCodigoLegalFixo(codigo).Should().BeFalse();
+
+    [Fact(DisplayName = "O catálogo legal fixo tem exatamente dez códigos")]
+    public void CodigosLegaisFixos_TemDezItens() =>
+        CodigoModalidade.CodigosLegaisFixos.Should().HaveCount(10,
+            "as oito modalidades da Lei 12.711/2012, a ampla concorrência e a modalidade "
+            + "de pessoa com deficiência fora da reserva federal");
+
+    [Fact(DisplayName = "A comparação do catálogo é case-sensitive")]
+    public void EhCodigoLegalFixo_Minusculas_Falso() =>
+        CodigoModalidade.EhCodigoLegalFixo("lb_ppi").Should().BeFalse(
+            "o formato canônico do código é maiúsculo — 'lb_ppi' nem sequer é um código válido");
+}

--- a/tests/Unifesspa.UniPlus.Configuracao.IntegrationTests/Modalidades/ModalidadeEndpointTests.cs
+++ b/tests/Unifesspa.UniPlus.Configuracao.IntegrationTests/Modalidades/ModalidadeEndpointTests.cs
@@ -8,6 +8,7 @@ using System.Text.Json;
 
 using AwesomeAssertions;
 
+using Unifesspa.UniPlus.Configuracao.Infrastructure.Persistence.Seed;
 using Unifesspa.UniPlus.Configuracao.IntegrationTests.Infrastructure;
 using Unifesspa.UniPlus.IntegrationTests.Fixtures.Authentication;
 
@@ -167,6 +168,112 @@ public sealed class ModalidadeEndpointTests
 
         HttpResponseMessage segundo = await EnviarPostAdmin(client, new { codigo, naturezaLegal = "AMPLA" });
         segundo.StatusCode.Should().Be(HttpStatusCode.Conflict);
+    }
+
+    [Fact(DisplayName = "POST com código do catálogo legal fixo retorna 409 com o código de erro da reserva")]
+    public async Task Criar_CodigoLegalFixo_Retorna409Reservado()
+    {
+        var body = new { codigo = "LB_PPI", naturezaLegal = "AMPLA" };
+
+        using HttpClient client = _fixture.Factory.CreateClient();
+        HttpResponseMessage response = await EnviarPostAdmin(client, body);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Conflict);
+        (await LerCodigoDeErro(response)).Should().Be(
+            "uniplus.configuracao.modalidade.criacao_bloqueada_codigo_protegido",
+            "a reserva do código é resposta distinta de 'já existe uma modalidade com este código'");
+    }
+
+    [Fact(DisplayName = "DELETE de modalidade legal fixa retorna 409 e a modalidade continua viva")]
+    public async Task Remover_LegalFixa_Retorna409EPermanece()
+    {
+        Guid id = IdSemeado("LB_PPI");
+
+        using HttpClient client = _fixture.Factory.CreateClient();
+        using HttpRequestMessage request = new(
+            HttpMethod.Delete, new Uri($"/api/configuracao/admin/modalidades/{id}", UriKind.Relative));
+        request.Headers.Add("Authorization", $"{TestAuthHandler.AuthorizationScheme} {TestAuthHandler.TokenValue}");
+        request.Headers.Add(TestAuthHandler.RolesHeader, "plataforma-admin");
+
+        HttpResponseMessage response = await client.SendAsync(request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Conflict);
+        (await LerCodigoDeErro(response)).Should().Be(
+            "uniplus.configuracao.modalidade.remocao_bloqueada_codigo_protegido");
+
+        HttpResponseMessage obter = await client.GetAsync(
+            new Uri($"/api/configuracao/modalidades/{id}", UriKind.Relative));
+        obter.StatusCode.Should().Be(HttpStatusCode.OK, "a cota federal continua no catálogo");
+    }
+
+    [Fact(DisplayName = "PUT que altera a estrutura de modalidade legal fixa retorna 422")]
+    public async Task Atualizar_LegalFixaEstrutura_Retorna422()
+    {
+        Guid id = IdSemeado("LI_Q");
+
+        using HttpClient client = _fixture.Factory.CreateClient();
+        HttpResponseMessage response = await EnviarPutAdmin(client, id, new
+        {
+            id,
+            naturezaLegal = "AMPLA",
+            composicaoVagas = "RESIDUAL_DO_VO",
+        });
+
+        response.StatusCode.Should().Be(HttpStatusCode.UnprocessableEntity);
+        (await LerCodigoDeErro(response)).Should().Be(
+            "uniplus.configuracao.modalidade.estrutura_protegida_nao_editavel");
+    }
+
+    [Fact(DisplayName = "PUT que altera só descrição e base legal de modalidade legal fixa retorna 204 e persiste")]
+    public async Task Atualizar_LegalFixaRedacao_Retorna204EPersiste()
+    {
+        Guid id = IdSemeado("LI_EP");
+        string descricao = $"Cota — independente de renda, egresso de escola pública ({Guid.NewGuid():N})";
+        const string BaseLegal = "Lei 12.711/2012, art. 3º (red. Lei 14.723/2023)";
+
+        using HttpClient client = _fixture.Factory.CreateClient();
+        HttpResponseMessage response = await EnviarPutAdmin(client, id, new
+        {
+            id,
+            descricao,
+            naturezaLegal = "COTA_RESERVADA",
+            composicaoVagas = "DENTRO_DO_VR",
+            regraRemanejamento = "SEGUE_CASCATA",
+            baseLegal = BaseLegal,
+        });
+
+        response.StatusCode.Should().Be(HttpStatusCode.NoContent);
+
+        HttpResponseMessage obter = await client.GetAsync(
+            new Uri($"/api/configuracao/modalidades/{id}", UriKind.Relative));
+        using JsonDocument doc = JsonDocument.Parse(await obter.Content.ReadAsStringAsync());
+        JsonElement root = doc.RootElement;
+        root.GetProperty("descricao").GetString().Should().Be(descricao);
+        root.GetProperty("baseLegal").GetString().Should().Be(BaseLegal);
+        root.GetProperty("naturezaLegal").GetString().Should().Be("COTA_RESERVADA",
+            "a estrutura de vagas permanece a da lei");
+        root.GetProperty("composicaoVagas").GetString().Should().Be("DENTRO_DO_VR");
+        root.GetProperty("regraRemanejamento").GetString().Should().Be("SEGUE_CASCATA");
+    }
+
+    private static Guid IdSemeado(string codigo) =>
+        ModalidadeSeed.Itens.Single(i => i.Codigo == codigo).Id;
+
+    private static async Task<string?> LerCodigoDeErro(HttpResponseMessage response)
+    {
+        using JsonDocument doc = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        return doc.RootElement.GetProperty("code").GetString();
+    }
+
+    private static async Task<HttpResponseMessage> EnviarPutAdmin(HttpClient client, Guid id, object body)
+    {
+        using HttpRequestMessage request = new(
+            HttpMethod.Put, new Uri($"/api/configuracao/admin/modalidades/{id}", UriKind.Relative));
+        request.Headers.Add("Authorization", $"{TestAuthHandler.AuthorizationScheme} {TestAuthHandler.TokenValue}");
+        request.Headers.Add(TestAuthHandler.RolesHeader, "plataforma-admin");
+        request.Headers.Add("Idempotency-Key", Guid.NewGuid().ToString());
+        request.Content = JsonContent.Create(body);
+        return await client.SendAsync(request);
     }
 
     private static string CodigoUnico() => $"MOD_{Guid.NewGuid().ToString("N")[..10].ToUpperInvariant()}";

--- a/tests/Unifesspa.UniPlus.Configuracao.IntegrationTests/Modalidades/ModalidadePersistenceTests.cs
+++ b/tests/Unifesspa.UniPlus.Configuracao.IntegrationTests/Modalidades/ModalidadePersistenceTests.cs
@@ -298,6 +298,17 @@ public sealed class ModalidadePersistenceTests
                 "as cotas federais são sub-reservas dentro das vagas reservadas e seguem a cascata legal");
     }
 
+    [Fact(DisplayName = "Seed: o conjunto semeado é exatamente o catálogo legal fixo protegido")]
+    public void Seed_Codigos_CoincidemComOCatalogoProtegido()
+    {
+        string[] semeados = [.. ModalidadeSeed.Itens.Select(i => i.Codigo).Order(StringComparer.Ordinal)];
+        string[] protegidos = [.. CodigoModalidade.CodigosLegaisFixos.Order(StringComparer.Ordinal)];
+
+        semeados.Should().Equal(protegidos,
+            "acrescentar uma linha ao seed sem protegê-la (ou proteger um código que ninguém semeia) "
+            + "deixaria o catálogo legal incoerente");
+    }
+
     [Fact(DisplayName = "Seed: cada item satisfaz as invariantes de Modalidade.Criar (natureza × composição × remanejamento × args)")]
     public void Seed_CadaItem_SatisfazInvariantesDoAgregado()
     {


### PR DESCRIPTION
## Contexto

O seed das dez modalidades legais fixas — as oito da Lei 12.711/2012 (red. Lei 14.723/2023), a ampla concorrência e a modalidade de pessoa com deficiência fora da reserva federal — colocou essas linhas na mesma tabela das modalidades institucionais autoradas por edital. Como o catálogo é CRUD de `plataforma-admin`, elas herdaram edição e remoção livres: nada impedia apagar `LB_PPI`, e sem ela não há como configurar a distribuição de vagas de um edital que aplique a lei.

`AC` estava protegida por acidente (é referenciada por `AC_PCD` como origem e destino, o que bloqueia a remoção). Proteção acidental some assim que a referência some.

## O que muda

| Operação | Numa modalidade legal fixa |
|---|---|
| `POST admin/modalidades` com código reservado | 409 `criacao_bloqueada_codigo_protegido` |
| `PUT` alterando natureza, composição, origem, remanejamento, critérios ou ação no indeferimento | 422 `estrutura_protegida_nao_editavel` |
| `PUT` alterando só descrição e base legal | 204, como antes |
| `DELETE` | 409 `remocao_bloqueada_codigo_protegido` |

As modalidades institucionais seguem com o CRUD inalterado.

A forma segue o que a condição de atendimento reservada já faz: o value object expõe o predicado (`CodigoModalidade.EhLegalFixa`), o agregado recusa a mutação e os handlers recusam remover e cadastrar.

## Decisões

**Conjunto protegido: as dez, como constante de domínio.** Sem flag persistida e sem migration. O enum `ModalidadesFederaisLei12711` não foi reutilizado: vive em `Selecao.Domain`, e `Configuracao.Domain` referenciá-lo inverteria a direção correta (Configuração é o catálogo, Seleção a consumidora) além de violar a regra de dependência entre módulos — e ele não contém `AC_PCD`. A cópia literal da lei é aceitável porque a lei é o contrato comum, mas só enquanto as listas não divergirem: um teste de arquitetura prova que o conjunto exigido em Seleção é subconjunto do catálogo protegido, e um teste de persistência prova que o catálogo protegido é exatamente o conjunto semeado.

**Identidade pelo `Codigo`, não pelo Guid de seed.** O código é a chave natural e já imutável; amarrar a proteção ao identificador determinístico do `HasData` a perderia em qualquer linha recriada. O que é reservado é o código `LB_PPI`, não uma linha específica.

**Allowlist de dois campos na atualização.** Só descrição e base legal são editáveis — a redação da lei muda (a 12.711 já foi alterada pela 14.723/2023), a mecânica de vagas não. Enumerar o que pode mudar, em vez do que não pode, faz um atributo novo do agregado nascer protegido por omissão. Como o `PUT` é substituição integral, corrigir a descrição de uma cota federal exige reenviar a estrutura — omitir a natureza resulta em 422 explícito, não em perda silenciosa como hoje.

**A guarda roda entre a resolução dos campos e as invariantes cruzadas.** Para isso `ValidarComuns` foi cindida em `ResolverCampos` (parse, normalização, tamanhos) e `ValidarCoerencia` (RetiraDe⟺origem, natureza↔regra, argumentos por regra) — a ordem relativa dos erros existentes não muda, porque a resolução já precedia a coerência. O efeito é a resposta certa: alterar só a natureza de uma cota federal responde "esta modalidade não se edita" em vez de "corrija a coerência do payload", que sugeriria que a edição seria possível.

**Reserva também na criação, antes da checagem de unicidade.** O índice único do código é parcial (`WHERE is_deleted = false`): numa base onde uma federal tenha sido removida o código volta a ficar livre, e o cadastro a recriaria com estrutura arbitrária — que a guarda de atualização então congelaria. A reserva é propriedade do código, não do estado do banco, então precede a ida ao banco e aceita o código com espaços à volta, como faz a normalização do cadastro.

## Testes

Verificado empiricamente que os testes provam a regra: com as três guardas neutralizadas, 17 testes falham (9 de domínio, 8 de aplicação).

- Um caso por campo protegido, mutando **um campo de cada vez** — mutar vários de uma vez deixaria passar uma implementação que esquecesse um deles. Os três argumentos de remanejamento (destino, par, fallback) têm casos separados.
- Caminho permitido com critérios cumulativos não vazios, reenviados como lista nova: prova comparação por valor, não por referência.
- Controles positivos: modalidade institucional segue alterando estrutura e sendo removida.
- Precedência documentada: token não parseável numa fixa reporta o erro de domínio, não a proteção.
- Quatro testes de endpoint contra Postgres real cobrem os três códigos de erro novos de ponta a ponta e conferem que o `PUT` permitido de fato persiste — o registro de erros não é exercitado por teste unitário, e um 204 sozinho não distingue "aplicou" de "não fez nada".

Suíte completa verde (23 assemblies), `dotnet format` limpo.

## Fora de escopo

Reparar bases que já tenham divergido do cânone antes desta regra existir — uma federal soft-deletada, ou removida e recriada com outra estrutura. As guardas fecham a porta daqui em diante; consertar dado que já entrou é trabalho de migração com escopo próprio, e não há produção: a migração de seed é de 23/07/2026. Follow-up registrado em #998.

Expor `EhLegalFixa` no contrato de leitura, para o frontend desabilitar os campos na tela, também fica para issue própria.

Closes #973
