### PR TITLE
feat(controllers): implementa convenção automática de rotas

### DIFF
--- a/UniPlus.slnx
+++ b/UniPlus.slnx
@@ -71,6 +71,7 @@
     <Project Path="tests/Unifesspa.UniPlus.Publicacoes.Domain.UnitTests/Unifesspa.UniPlus.Publicacoes.Domain.UnitTests.csproj" />
     <Project Path="tests/Unifesspa.UniPlus.Publicacoes.Application.UnitTests/Unifesspa.UniPlus.Publicacoes.Application.UnitTests.csproj" />
     <Project Path="tests/Unifesspa.UniPlus.Publicacoes.IntegrationTests/Unifesspa.UniPlus.Publicacoes.IntegrationTests.csproj" />
+    <Project Path="tests/Unifesspa.UniPlus.Portal.IntegrationTests/Unifesspa.UniPlus.Portal.IntegrationTests.csproj" />
     <Project Path="tests/Unifesspa.UniPlus.Host.IntegrationTests/Unifesspa.UniPlus.Host.IntegrationTests.csproj" />
   </Folder>
 </Solution>

--- a/docs/adrs/0118-identidade-publica-modulos-api-metadado-assembly.md
+++ b/docs/adrs/0118-identidade-publica-modulos-api-metadado-assembly.md
@@ -1,0 +1,239 @@
+---
+status: "proposed"
+date: "2026-07-29"
+decision-makers:
+  - "Tech Lead (CTIC)"
+consulted:
+  - "Backend (CTIC)"
+informed:
+  - "Equipe Uni+"
+---
+
+# ADR-0118: Identidade pública de módulos de API via metadado de assembly
+
+## Contexto e enunciado do problema
+
+A [ADR-0064](0064-convencao-roteamento-path-based-com-prefixo-modulo.md)
+estabelece que controllers são expostos sob `/api/{modulo}`. Após a mudança de
+topologia registrada na
+[ADR-0097](0097-topologia-de-deploy-em-tres-apis-monolito-modular.md), os
+módulos internos passaram a compartilhar o mesmo processo no Host, enquanto o
+Portal permaneceu executável de forma autônoma. O mesmo nome público de módulo
+também identifica o documento OpenAPI correspondente.
+
+O Host já precisava associar cada controller ao seu módulo para preencher
+`ApiExplorer.GroupName` e isolar os documentos OpenAPI. Essa associação era
+inferida por um mapa de prefixos de namespace. Ao automatizar também o prefixo
+das rotas por `IControllerModelConvention`, reutilizar `GroupName` como entrada
+do roteamento criou uma dependência temporal entre duas conventions distintas.
+No Portal standalone, que não registra a convention de agrupamento do Host,
+`GroupName` permanecia nulo e `/api/portal/ping` deixava de existir.
+
+Derivar o contrato público diretamente do namespace ou do nome do assembly
+também é frágil: ambos são detalhes internos que podem mudar por reorganização
+de código. Além disso, `OrganizacaoInstitucional` é publicado como
+`organizacao`, demonstrando que não existe uma transformação textual geral
+entre o nome técnico e o segmento público.
+
+É necessário definir uma fonte única, explícita e verificável para a identidade
+pública de cada módulo de API, compartilhada por roteamento e OpenAPI, sem
+exigir atributo em cada controller nem manter um catálogo central de módulos na
+infraestrutura compartilhada.
+
+## Drivers da decisão
+
+- Preservar os paths públicos definidos pela ADR-0064 tanto no Host quanto em
+  aplicações standalone.
+- Tratar o nome público do módulo como contrato explícito, não como derivação de
+  namespace, nome de projeto ou nome de assembly.
+- Separar roteamento de `ApiExplorer.GroupName` e da ordem de execução das
+  conventions MVC.
+- Declarar a identidade uma única vez por assembly de API, sem repetição por
+  controller.
+- Manter os componentes compartilhados abertos à extensão: um módulo novo não
+  deve exigir alteração em um catálogo central.
+- Falhar durante a inicialização quando um controller não possuir identidade de
+  módulo, evitando exposição silenciosa fora de `/api/{modulo}`.
+- Reutilizar a mesma identidade no prefixo HTTP e no nome do documento OpenAPI.
+
+## Opções consideradas
+
+- Derivar o módulo do namespace do controller por mapa compartilhado.
+- Derivar o módulo do nome do assembly ou do projeto.
+- Declarar o módulo por atributo em cada controller.
+- Registrar um catálogo central `Assembly → módulo` no Host ou em
+  `Infrastructure.Core`.
+- Declarar a identidade por metadado no assembly de API (escolhida).
+
+## Resultado da decisão
+
+**Escolhida:** "declarar a identidade pública por metadado no assembly de API",
+porque o assembly é a fronteira usada pelo ASP.NET Core para descoberta dos
+controllers, permite uma única declaração verificável por módulo e desacopla o
+contrato público de convenções internas de nomenclatura.
+
+Cada projeto `Unifesspa.UniPlus.*.API` deve possuir um assembly marker que seja
+dono do nome público canônico:
+
+```csharp
+using Unifesspa.UniPlus.Infrastructure.Core.Routing;
+
+[assembly: ApiModule(
+    global::Unifesspa.UniPlus.Portal.API.PortalApiAssemblyMarker.ModuleName)]
+
+namespace Unifesspa.UniPlus.Portal.API;
+
+public sealed class PortalApiAssemblyMarker
+{
+    public const string ModuleName = "portal";
+
+    private PortalApiAssemblyMarker()
+    {
+    }
+}
+```
+
+O atributo `ApiModuleAttribute`:
+
+- tem `AttributeTargets.Assembly`;
+- não permite múltiplas declarações no mesmo assembly;
+- aceita somente segmentos iniciados por letra ASCII minúscula e compostos por
+  letras ASCII minúsculas, dígitos ou hífen.
+
+`ApiModuleMetadata.GetRequiredName(Assembly)` é o resolvedor compartilhado. A
+ausência do atributo é erro de configuração e deve interromper a construção do
+modelo MVC. Não existe fallback para namespace, nome do assembly ou
+`ApiExplorer.GroupName`.
+
+`ModuleRoutePrefixConvention` resolve o módulo diretamente do assembly do
+controller e combina `api/{modulo}` com a rota relativa declarada pelo
+controller. `ModuleApiGroupingConvention`, exclusiva do Host, usa o mesmo
+resolvedor para preencher `ApiExplorer.GroupName`, preservando eventual
+grouping explícito. O registro de OpenAPI de cada módulo utiliza o
+`ModuleName` de seu próprio assembly marker.
+
+Esta ADR emenda a ADR-0064 somente no mecanismo de composição das rotas:
+controllers passam a declarar a rota relativa do recurso, enquanto a convention
+injeta `api/{modulo}`. A forma pública `/api/{modulo}/{recurso}` e seus paths
+existentes permanecem inalterados.
+
+O código compartilhado contém apenas o atributo, o resolvedor e a convention.
+Ele não mantém a lista dos módulos concretos. Adicionar um módulo exige declarar
+sua identidade no próprio projeto de API e registrá-lo no composition root
+correspondente.
+
+Esta decisão se aplica a controllers MVC. Endpoints compartilhados registrados
+como Minimal APIs, como autenticação, perfil e health checks, continuam seguindo
+suas convenções específicas e não recebem automaticamente o prefixo de módulo.
+
+## Consequências
+
+### Positivas
+
+- Host e Portal standalone calculam o mesmo path sem depender de uma convention
+  exclusiva do Host.
+- Namespace, nome do projeto e nome do assembly podem ser refatorados sem
+  alterar involuntariamente o contrato HTTP.
+- Routing e OpenAPI reutilizam uma identidade canônica por módulo.
+- Controllers mantêm apenas rotas relativas de recurso e não repetem o nome do
+  módulo.
+- A infraestrutura compartilhada permanece agnóstica ao roster de módulos.
+- Ausência de metadado falha no startup, em vez de produzir rota sem prefixo.
+- A leitura do atributo ocorre na construção do modelo MVC, sem reflexão por
+  requisição.
+
+### Negativas
+
+- Todo assembly que forneça controllers à aplicação deve declarar
+  `ApiModuleAttribute`; uma biblioteca externa de controllers exige adaptação
+  explícita ou emenda desta ADR.
+- Alterar `ModuleName` é uma mudança de contrato que afeta paths e o nome do
+  documento OpenAPI simultaneamente.
+- O assembly marker passa a acumular também a responsabilidade de expor a
+  identidade pública do módulo.
+
+### Neutras
+
+- O mecanismo usa reflexão para ler um atributo de assembly durante o startup.
+  O custo não participa do processamento de requisições.
+- A ADR-0064 continua sendo a fonte da forma pública
+  `/api/{modulo}/{recurso}`; esta ADR define como `{modulo}` é declarado e
+  resolvido.
+
+## Confirmação
+
+- `ApiModuleAttributeTests` valida o formato permitido e o fail-fast para
+  assemblies sem metadado.
+- `ApiModuleMetadataTests` inclui automaticamente os projetos
+  `Unifesspa.UniPlus.*.API`, exige exatamente um atributo por assembly e nomes
+  públicos sem colisão.
+- O teste de integração do Portal verifica que `GET /api/portal/ping` responde
+  e que `GET /ping` não é exposto.
+- A issue
+  [#835](https://github.com/unifesspa-edu-br/uniplus-api/issues/835) mantém a
+  cobertura exaustiva para impedir que qualquer rota de controller escape do
+  prefixo esperado no Host ou no Portal standalone.
+- A CI executa os projetos `*.ArchTests`, `*.UnitTests` e
+  `*.IntegrationTests`.
+
+## Prós e contras das opções
+
+### Namespace com mapa compartilhado
+
+- Bom, porque não exige novo metadado nos assemblies.
+- Bom, porque centraliza as exceções de nomes públicos.
+- Ruim, porque transforma organização interna de código em contrato HTTP.
+- Ruim, porque toda adição ou renomeação de módulo altera o mapa compartilhado.
+- Ruim, porque um namespace desconhecido pode ser ignorado silenciosamente.
+
+### Nome do assembly ou projeto
+
+- Bom, porque a informação já existe e é facilmente inspecionável.
+- Ruim, porque ainda exige regras de transformação e exceções como
+  `OrganizacaoInstitucional → organizacao`.
+- Ruim, porque acopla o contrato público ao naming técnico e dificulta
+  refatorações.
+
+### Atributo por controller
+
+- Bom, porque torna a identidade explícita no ponto de uso.
+- Ruim, porque repete o mesmo valor em todos os controllers e permite drift
+  dentro do módulo.
+- Ruim, porque mantém a possibilidade de esquecer o atributo em um controller
+  novo.
+
+### Catálogo central `Assembly → módulo`
+
+- Bom, porque representa associações explicitamente e pode validar colisões no
+  startup.
+- Ruim, porque a infraestrutura compartilhada passa a conhecer todos os módulos
+  concretos.
+- Ruim, porque adicionar um módulo exige modificar um registro central, em vez
+  de estender a solução pelo próprio módulo.
+
+### Metadado por assembly
+
+- Bom, porque a identidade fica explícita e próxima da fronteira que possui os
+  controllers.
+- Bom, porque existe uma declaração por módulo e nenhuma por controller.
+- Bom, porque routing e OpenAPI compartilham o mesmo resolvedor.
+- Ruim, porque introduz um atributo próprio e uma leitura por reflexão no
+  startup.
+
+## Mais informações
+
+- [ADR-0030](0030-openapi-3-1-contract-first-microsoft-aspnetcore-openapi.md)
+  — geração e isolamento dos documentos OpenAPI por módulo.
+- [ADR-0036](0036-controllers-mvc-para-negocio-minimal-api-para-shared.md)
+  — fronteira entre controllers MVC e Minimal APIs compartilhadas.
+- [ADR-0064](0064-convencao-roteamento-path-based-com-prefixo-modulo.md)
+  — contrato de paths com prefixo de módulo.
+- [ADR-0097](0097-topologia-de-deploy-em-tres-apis-monolito-modular.md)
+  — co-hosting dos módulos internos e Portal standalone.
+- [PR #1006](https://github.com/unifesspa-edu-br/uniplus-api/pull/1006) —
+  implementação da convention automática de prefixo.
+- [Issue #835](https://github.com/unifesspa-edu-br/uniplus-api/issues/835) —
+  cobertura exaustiva das rotas por módulo.
+- [Microsoft — Work with the application model in ASP.NET Core](https://learn.microsoft.com/en-us/aspnet/core/mvc/controllers/application-model?view=aspnetcore-10.0).
+- [Microsoft — Application Parts in ASP.NET Core](https://learn.microsoft.com/en-us/aspnet/core/mvc/advanced/app-parts?view=aspnetcore-10.0).
+- [Microsoft — Assembly-level attributes in C#](https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/attributes/global).

--- a/docs/adrs/README.md
+++ b/docs/adrs/README.md
@@ -146,12 +146,13 @@ npx markdownlint-cli2 'docs/adrs/**/*.md'
 | [0115](0115-quadro-de-vagas-materializacao-derivada-congelamento-atomico.md) | O quadro de vagas é output derivado da configuração de distribuição, materializado e congelado na mesma operação que os insumos | accepted | 2026-07-16 |
 | [0116](0116-origem-ponto-resolucao-binding-fato-valor-dominio.md) | Fato multi-fonte: origem (renomeia/reclassifica `Natureza`), ponto de resolução, binding e `FatoValorDominio` — refina a ADR-0111; emendada em 2026-07-22: `MODALIDADE` passa a derivado e o binding admite mais de um prefixo por origem | accepted | 2026-07-19 |
 | [0117](0117-politica-de-analise-estatica-e-supressao.md) | Política de análise estática e supressão de diagnósticos: `AnalysisLevel=latest-recommended` com opt-in/opt-out nomeado no `.editorconfig` e critério de supressão por alcance | proposed | 2026-07-22 |
+| [0118](0118-identidade-publica-modulos-api-metadado-assembly.md) | Identidade pública de módulos de API via metadado de assembly | proposed | 2026-07-29 |
 
-> **Nota de numeração:** a sequência de `0001` a `0117` está completa, sem lacunas. Ao adicionar uma ADR nova, use `0118+`.
+> **Nota de numeração:** a sequência de `0001` a `0118` está completa, sem lacunas. Ao adicionar uma ADR nova, use `0119+`.
 
 ## Como adicionar um novo ADR
 
-1. Identifique o próximo número livre: **o maior número da tabela acima + 1** (atualmente `0114`). **Não** use `ls | wc -l` — confira a coluna de número da tabela e use o maior valor + 1.
+1. Identifique o próximo número livre: **o maior número da tabela acima + 1** (atualmente `0118`). **Não** use `ls | wc -l` — confira a coluna de número da tabela e use o maior valor + 1.
 2. Copie [`_template.md`](_template.md).
 3. Renomeie para `NNNN-titulo-em-slug.md` (slug ASCII em minúsculas, hífens como separador).
 4. Preencha frontmatter, contexto, drivers, opções, resultado da decisão (única), consequências.

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.API/ConfiguracaoApiAssemblyMarker.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.API/ConfiguracaoApiAssemblyMarker.cs
@@ -1,3 +1,8 @@
+using Unifesspa.UniPlus.Infrastructure.Core.Routing;
+
+[assembly: ApiModule(
+    global::Unifesspa.UniPlus.Configuracao.API.ConfiguracaoApiAssemblyMarker.ModuleName)]
+
 namespace Unifesspa.UniPlus.Configuracao.API;
 
 /// <summary>
@@ -7,6 +12,8 @@ namespace Unifesspa.UniPlus.Configuracao.API;
 /// </summary>
 public sealed class ConfiguracaoApiAssemblyMarker
 {
+    public const string ModuleName = "configuracao";
+
     private ConfiguracaoApiAssemblyMarker()
     {
     }

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.API/ConfiguracaoModuleRegistration.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.API/ConfiguracaoModuleRegistration.cs
@@ -12,6 +12,7 @@ using Unifesspa.UniPlus.Configuracao.Infrastructure.Persistence;
 using Unifesspa.UniPlus.Infrastructure.Core.DependencyInjection;
 using Unifesspa.UniPlus.Infrastructure.Core.Errors;
 using Unifesspa.UniPlus.Infrastructure.Core.Hateoas;
+using Unifesspa.UniPlus.Infrastructure.Core.Routing;
 
 /// <summary>
 /// Registro self-describing do módulo Configuracao para o composition root do
@@ -39,7 +40,7 @@ public static class ConfiguracaoModuleRegistration
         ArgumentNullException.ThrowIfNull(configuration);
 
         // OpenAPI 3.1 (ADR-0030) — spec em /openapi/configuracao.json.
-        services.AddUniPlusOpenApi("configuracao", configuration);
+        services.AddUniPlusOpenApi(ConfiguracaoApiAssemblyMarker.ModuleName, configuration);
 
         // Erros de domínio do módulo (consumidos por AddDomainErrorMapper, registrado
         // uma vez no host via IEnumerable<IDomainErrorRegistration>).

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.API/Controllers/CampiController.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.API/Controllers/CampiController.cs
@@ -23,7 +23,6 @@ using Unifesspa.UniPlus.Kernel.Results;
 /// <c>plataforma-admin</c> (UNI-REQ #587).
 /// </summary>
 [ApiController]
-[Route("api/configuracao")]
 [SuppressMessage(
     "Performance",
     "CA1515:Consider making public types internal",

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.API/Controllers/CondicoesAtendimentoController.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.API/Controllers/CondicoesAtendimentoController.cs
@@ -23,7 +23,6 @@ using Unifesspa.UniPlus.Kernel.Results;
 /// a <c>plataforma-admin</c> (UNI-REQ-0012).
 /// </summary>
 [ApiController]
-[Route("api/configuracao")]
 [SuppressMessage(
     "Performance",
     "CA1515:Consider making public types internal",

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.API/Controllers/CursosController.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.API/Controllers/CursosController.cs
@@ -23,7 +23,6 @@ using Unifesspa.UniPlus.Kernel.Results;
 /// <c>plataforma-admin</c> (story #588, ADR-0066).
 /// </summary>
 [ApiController]
-[Route("api/configuracao")]
 [SuppressMessage(
     "Performance",
     "CA1515:Consider making public types internal",

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.API/Controllers/FasesCanonicasController.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.API/Controllers/FasesCanonicasController.cs
@@ -23,7 +23,6 @@ using Unifesspa.UniPlus.Kernel.Results;
 /// <c>plataforma-admin</c> (UNI-REQ-0064).
 /// </summary>
 [ApiController]
-[Route("api/configuracao")]
 [SuppressMessage(
     "Performance",
     "CA1515:Consider making public types internal",

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.API/Controllers/FatosCandidatoController.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.API/Controllers/FatosCandidatoController.cs
@@ -18,7 +18,6 @@ using Unifesspa.UniPlus.Infrastructure.Core.Formatting;
 /// isso não há rota admin de escrita.
 /// </summary>
 [ApiController]
-[Route("api/configuracao")]
 [SuppressMessage(
     "Performance",
     "CA1515:Consider making public types internal",

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.API/Controllers/LocaisOfertaController.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.API/Controllers/LocaisOfertaController.cs
@@ -23,7 +23,6 @@ using Unifesspa.UniPlus.Kernel.Results;
 /// <c>plataforma-admin</c> (UNI-REQ #587).
 /// </summary>
 [ApiController]
-[Route("api/configuracao")]
 [SuppressMessage(
     "Performance",
     "CA1515:Consider making public types internal",

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.API/Controllers/ModalidadesController.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.API/Controllers/ModalidadesController.cs
@@ -23,7 +23,6 @@ using Unifesspa.UniPlus.Kernel.Results;
 /// <c>plataforma-admin</c> (UNI-REQ-0011).
 /// </summary>
 [ApiController]
-[Route("api/configuracao")]
 [SuppressMessage(
     "Performance",
     "CA1515:Consider making public types internal",

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.API/Controllers/OfertasCursoController.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.API/Controllers/OfertasCursoController.cs
@@ -23,7 +23,6 @@ using Unifesspa.UniPlus.Kernel.Results;
 /// <c>plataforma-admin</c> (story #588, issue #749, ADR-0066).
 /// </summary>
 [ApiController]
-[Route("api/configuracao")]
 [SuppressMessage(
     "Performance",
     "CA1515:Consider making public types internal",

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.API/Controllers/PesosAreaEnemController.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.API/Controllers/PesosAreaEnemController.cs
@@ -23,7 +23,6 @@ using Unifesspa.UniPlus.Kernel.Results;
 /// <c>plataforma-admin</c> (UNI-REQ-0066).
 /// </summary>
 [ApiController]
-[Route("api/configuracao")]
 [SuppressMessage(
     "Performance",
     "CA1515:Consider making public types internal",

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.API/Controllers/PrecedenciasFaseController.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.API/Controllers/PrecedenciasFaseController.cs
@@ -24,7 +24,6 @@ using Unifesspa.UniPlus.Kernel.Results;
 /// em rota, autenticação, HATEOAS, vendor media type e idempotência.
 /// </summary>
 [ApiController]
-[Route("api/configuracao")]
 [SuppressMessage(
     "Performance",
     "CA1515:Consider making public types internal",

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.API/Controllers/RecursosAcessibilidadeController.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.API/Controllers/RecursosAcessibilidadeController.cs
@@ -23,7 +23,6 @@ using Unifesspa.UniPlus.Kernel.Results;
 /// <c>plataforma-admin</c> (UNI-REQ-0012).
 /// </summary>
 [ApiController]
-[Route("api/configuracao")]
 [SuppressMessage(
     "Performance",
     "CA1515:Consider making public types internal",

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.API/Controllers/ReferenciasReservaDemograficaController.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.API/Controllers/ReferenciasReservaDemograficaController.cs
@@ -23,7 +23,6 @@ using Unifesspa.UniPlus.Kernel.Results;
 /// <c>plataforma-admin</c> (UNI-REQ-0065).
 /// </summary>
 [ApiController]
-[Route("api/configuracao")]
 [SuppressMessage(
     "Performance",
     "CA1515:Consider making public types internal",

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.API/Controllers/TiposBancaController.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.API/Controllers/TiposBancaController.cs
@@ -23,7 +23,6 @@ using Unifesspa.UniPlus.Kernel.Results;
 /// <c>plataforma-admin</c> (UNI-REQ-0064).
 /// </summary>
 [ApiController]
-[Route("api/configuracao")]
 [SuppressMessage(
     "Performance",
     "CA1515:Consider making public types internal",

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.API/Controllers/TiposDeficienciaController.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.API/Controllers/TiposDeficienciaController.cs
@@ -23,7 +23,6 @@ using Unifesspa.UniPlus.Kernel.Results;
 /// <c>plataforma-admin</c> (UNI-REQ-0012).
 /// </summary>
 [ApiController]
-[Route("api/configuracao")]
 [SuppressMessage(
     "Performance",
     "CA1515:Consider making public types internal",

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.API/Controllers/TiposDocumentoController.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.API/Controllers/TiposDocumentoController.cs
@@ -23,7 +23,6 @@ using Unifesspa.UniPlus.Kernel.Results;
 /// <c>plataforma-admin</c> (UNI-REQ-0013).
 /// </summary>
 [ApiController]
-[Route("api/configuracao")]
 [SuppressMessage(
     "Performance",
     "CA1515:Consider making public types internal",

--- a/src/host/Unifesspa.UniPlus.Host/ModuleApiGroupingConvention.cs
+++ b/src/host/Unifesspa.UniPlus.Host/ModuleApiGroupingConvention.cs
@@ -2,10 +2,12 @@ namespace Unifesspa.UniPlus.Host;
 
 using Microsoft.AspNetCore.Mvc.ApplicationModels;
 
+using Unifesspa.UniPlus.Infrastructure.Core.Routing;
+
 /// <summary>
 /// Convention do composition root do monólito modular: atribui a cada
-/// controller o <c>ApiExplorer.GroupName</c> do seu módulo, derivado do
-/// namespace. Sem isso, o Microsoft.AspNetCore.OpenApi inclui todo endpoint com
+/// controller o <c>ApiExplorer.GroupName</c> declarado pelo assembly do módulo.
+/// Sem isso, o Microsoft.AspNetCore.OpenApi inclui todo endpoint com
 /// <c>GroupName == null</c> em TODOS os documentos — no processo único, cada
 /// <c>/openapi/{modulo}.json</c> listaria os endpoints dos 5 módulos.
 /// </summary>
@@ -18,23 +20,11 @@ using Microsoft.AspNetCore.Mvc.ApplicationModels;
 ///
 /// <para>Vive apenas no host: os módulos standalone têm um único documento, sem
 /// possibilidade de vazamento, então não recebem a convention e seus baselines
-/// <c>contracts/openapi.*.json</c> ficam inalterados. O mapa namespace→documento
-/// trata o caso <c>OrganizacaoInstitucional</c> → <c>organizacao</c> (o nome do
-/// documento não é o nome do namespace).</para>
+/// <c>contracts/openapi.*.json</c> ficam inalterados. O metadado por assembly
+/// também evita derivar o contrato público de nomes de namespace.</para>
 /// </remarks>
 internal sealed class ModuleApiGroupingConvention : IApplicationModelConvention
 {
-    // (prefixo de namespace do módulo, nome do documento OpenAPI). O nome do
-    // documento casa o passado a AddUniPlusOpenApi("<doc>", ...) em cada módulo.
-    private static readonly (string NamespacePrefix, string GroupName)[] Mapa =
-    [
-        ("Unifesspa.UniPlus.Configuracao.", "configuracao"),
-        ("Unifesspa.UniPlus.OrganizacaoInstitucional.", "organizacao"),
-        ("Unifesspa.UniPlus.Selecao.", "selecao"),
-        ("Unifesspa.UniPlus.Ingresso.", "ingresso"),
-        ("Unifesspa.UniPlus.Publicacoes.", "publicacoes"),
-    ];
-
     public void Apply(ApplicationModel application)
     {
         ArgumentNullException.ThrowIfNull(application);
@@ -47,20 +37,8 @@ internal sealed class ModuleApiGroupingConvention : IApplicationModelConvention
                 continue;
             }
 
-            string? ns = controller.ControllerType.Namespace;
-            if (ns is null)
-            {
-                continue;
-            }
-
-            foreach ((string prefixo, string grupo) in Mapa)
-            {
-                if (ns.StartsWith(prefixo, StringComparison.Ordinal))
-                {
-                    controller.ApiExplorer.GroupName = grupo;
-                    break;
-                }
-            }
+            controller.ApiExplorer.GroupName = ApiModuleMetadata.GetRequiredName(
+                controller.ControllerType.Assembly);
         }
     }
 }

--- a/src/host/Unifesspa.UniPlus.Host/Program.cs
+++ b/src/host/Unifesspa.UniPlus.Host/Program.cs
@@ -50,7 +50,7 @@ builder.Services.ConfigureHttpJsonOptions(options =>
 builder.Services.AddEndpointsApiExplorer();
 
 // Isola os documentos OpenAPI por módulo no processo único: atribui GroupName
-// por namespace de controller para que cada /openapi/{modulo}.json contenha
+// pelo metadado do assembly para que cada /openapi/{modulo}.json contenha
 // apenas os endpoints do seu módulo (+ compartilhados). Só faz sentido no host
 // (co-hosting); os módulos standalone não recebem e mantêm seus baselines.
 builder.Services.Configure<Microsoft.AspNetCore.Mvc.MvcOptions>(

--- a/src/host/Unifesspa.UniPlus.Host/Program.cs
+++ b/src/host/Unifesspa.UniPlus.Host/Program.cs
@@ -56,6 +56,11 @@ builder.Services.AddEndpointsApiExplorer();
 builder.Services.Configure<Microsoft.AspNetCore.Mvc.MvcOptions>(
     options => options.Conventions.Add(new Unifesspa.UniPlus.Host.ModuleApiGroupingConvention()));
 
+// Resolve os prefixos de endpoints de acordo com seu módulo,
+// evitando que os controllers precisem declarar [Route("api/{module}")].
+builder.Services.Configure<Microsoft.AspNetCore.Mvc.MvcOptions>(
+    options => options.Conventions.Add(new Unifesspa.UniPlus.Infrastructure.Core.Routing.ModuleRoutePrefixConvention()));
+
 // --- Cross-cutting compartilhado (registrado uma vez no host) ---
 builder.Services.AddDomainErrorMapper();
 builder.Services.AddUniPlusEncryption(builder.Configuration);

--- a/src/ingresso/Unifesspa.UniPlus.Ingresso.API/IngressoApiAssemblyMarker.cs
+++ b/src/ingresso/Unifesspa.UniPlus.Ingresso.API/IngressoApiAssemblyMarker.cs
@@ -1,3 +1,8 @@
+using Unifesspa.UniPlus.Infrastructure.Core.Routing;
+
+[assembly: ApiModule(
+    global::Unifesspa.UniPlus.Ingresso.API.IngressoApiAssemblyMarker.ModuleName)]
+
 namespace Unifesspa.UniPlus.Ingresso.API;
 
 /// <summary>
@@ -9,6 +14,8 @@ namespace Unifesspa.UniPlus.Ingresso.API;
 /// </summary>
 public sealed class IngressoApiAssemblyMarker
 {
+    public const string ModuleName = "ingresso";
+
     private IngressoApiAssemblyMarker()
     {
     }

--- a/src/ingresso/Unifesspa.UniPlus.Ingresso.API/IngressoModuleRegistration.cs
+++ b/src/ingresso/Unifesspa.UniPlus.Ingresso.API/IngressoModuleRegistration.cs
@@ -5,6 +5,7 @@ using Microsoft.Extensions.DependencyInjection;
 
 using Unifesspa.UniPlus.Infrastructure.Core.DependencyInjection;
 using Unifesspa.UniPlus.Infrastructure.Core.Errors;
+using Unifesspa.UniPlus.Infrastructure.Core.Routing;
 using Unifesspa.UniPlus.Ingresso.API.Errors;
 using Unifesspa.UniPlus.Ingresso.Infrastructure;
 using Unifesspa.UniPlus.Ingresso.Infrastructure.Persistence;
@@ -38,7 +39,7 @@ public static class IngressoModuleRegistration
         ArgumentNullException.ThrowIfNull(configuration);
 
         // OpenAPI 3.1 (ADR-0030) — spec em /openapi/ingresso.json.
-        services.AddUniPlusOpenApi("ingresso", configuration);
+        services.AddUniPlusOpenApi(IngressoApiAssemblyMarker.ModuleName, configuration);
 
         // Erros de domínio do módulo (consumidos por AddDomainErrorMapper, registrado
         // uma vez no host via IEnumerable<IDomainErrorRegistration>).

--- a/src/organizacao-institucional/Unifesspa.UniPlus.OrganizacaoInstitucional.API/Controllers/InstituicaoController.cs
+++ b/src/organizacao-institucional/Unifesspa.UniPlus.OrganizacaoInstitucional.API/Controllers/InstituicaoController.cs
@@ -23,7 +23,6 @@ using Unifesspa.UniPlus.OrganizacaoInstitucional.Application.Queries.Instituicoe
 /// tempo.
 /// </summary>
 [ApiController]
-[Route("api/organizacao")]
 [SuppressMessage(
     "Performance",
     "CA1515:Consider making public types internal",

--- a/src/organizacao-institucional/Unifesspa.UniPlus.OrganizacaoInstitucional.API/Controllers/UnidadesController.cs
+++ b/src/organizacao-institucional/Unifesspa.UniPlus.OrganizacaoInstitucional.API/Controllers/UnidadesController.cs
@@ -24,11 +24,10 @@ using Unifesspa.UniPlus.OrganizacaoInstitucional.Domain.Enums;
 /// <c>plataforma-admin</c>.
 /// </summary>
 /// <remarks>
-/// Rotas público/admin em caminhos distintos — o controller declara
-/// <c>[Route("api/organizacao")]</c> e cada action especifica seu caminho.
+/// O prefixo da rota é aplicado automaticamente por convenção.
+/// e cada action especifica seu caminho.
 /// </remarks>
 [ApiController]
-[Route("api/organizacao")]
 [SuppressMessage(
     "Performance",
     "CA1515:Consider making public types internal",

--- a/src/organizacao-institucional/Unifesspa.UniPlus.OrganizacaoInstitucional.API/OrganizacaoApiAssemblyMarker.cs
+++ b/src/organizacao-institucional/Unifesspa.UniPlus.OrganizacaoInstitucional.API/OrganizacaoApiAssemblyMarker.cs
@@ -1,3 +1,8 @@
+using Unifesspa.UniPlus.Infrastructure.Core.Routing;
+
+[assembly: ApiModule(
+    global::Unifesspa.UniPlus.OrganizacaoInstitucional.API.OrganizacaoApiAssemblyMarker.ModuleName)]
+
 namespace Unifesspa.UniPlus.OrganizacaoInstitucional.API;
 
 /// <summary>
@@ -9,6 +14,8 @@ namespace Unifesspa.UniPlus.OrganizacaoInstitucional.API;
 /// </summary>
 public sealed class OrganizacaoApiAssemblyMarker
 {
+    public const string ModuleName = "organizacao";
+
     private OrganizacaoApiAssemblyMarker()
     {
     }

--- a/src/organizacao-institucional/Unifesspa.UniPlus.OrganizacaoInstitucional.API/OrganizacaoInstitucionalModuleRegistration.cs
+++ b/src/organizacao-institucional/Unifesspa.UniPlus.OrganizacaoInstitucional.API/OrganizacaoInstitucionalModuleRegistration.cs
@@ -6,6 +6,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Unifesspa.UniPlus.Infrastructure.Core.DependencyInjection;
 using Unifesspa.UniPlus.Infrastructure.Core.Errors;
 using Unifesspa.UniPlus.Infrastructure.Core.Hateoas;
+using Unifesspa.UniPlus.Infrastructure.Core.Routing;
 using Unifesspa.UniPlus.OrganizacaoInstitucional.API.Errors;
 using Unifesspa.UniPlus.OrganizacaoInstitucional.API.Hateoas;
 using Unifesspa.UniPlus.OrganizacaoInstitucional.Application;
@@ -39,7 +40,7 @@ public static class OrganizacaoInstitucionalModuleRegistration
         ArgumentNullException.ThrowIfNull(configuration);
 
         // OpenAPI 3.1 (ADR-0030) — documento nomeado por módulo. Spec em /openapi/organizacao.json.
-        services.AddUniPlusOpenApi("organizacao", configuration);
+        services.AddUniPlusOpenApi(OrganizacaoApiAssemblyMarker.ModuleName, configuration);
 
         // Erros de domínio do módulo (consumidos por AddDomainErrorMapper, registrado
         // uma vez no host via IEnumerable<IDomainErrorRegistration>).

--- a/src/portal/Unifesspa.UniPlus.Portal.API/Controllers/PingController.cs
+++ b/src/portal/Unifesspa.UniPlus.Portal.API/Controllers/PingController.cs
@@ -13,7 +13,7 @@ using Microsoft.AspNetCore.Mvc;
 /// (issue #336).
 /// </summary>
 [ApiController]
-[Route("api/portal/ping")]
+[Route("ping")]
 [AllowAnonymous]
 [SuppressMessage(
     "Performance",

--- a/src/portal/Unifesspa.UniPlus.Portal.API/PortalApiAssemblyMarker.cs
+++ b/src/portal/Unifesspa.UniPlus.Portal.API/PortalApiAssemblyMarker.cs
@@ -1,3 +1,8 @@
+using Unifesspa.UniPlus.Infrastructure.Core.Routing;
+
+[assembly: ApiModule(
+    global::Unifesspa.UniPlus.Portal.API.PortalApiAssemblyMarker.ModuleName)]
+
 namespace Unifesspa.UniPlus.Portal.API;
 
 /// <summary>
@@ -9,6 +14,8 @@ namespace Unifesspa.UniPlus.Portal.API;
 /// </summary>
 public sealed class PortalApiAssemblyMarker
 {
+    public const string ModuleName = "portal";
+
     private PortalApiAssemblyMarker()
     {
     }

--- a/src/portal/Unifesspa.UniPlus.Portal.API/Program.cs
+++ b/src/portal/Unifesspa.UniPlus.Portal.API/Program.cs
@@ -11,6 +11,8 @@ using Unifesspa.UniPlus.Infrastructure.Core.Messaging;
 using Unifesspa.UniPlus.Infrastructure.Core.Middleware;
 using Unifesspa.UniPlus.Infrastructure.Core.Observability;
 using Unifesspa.UniPlus.Infrastructure.Core.Profile;
+using Unifesspa.UniPlus.Infrastructure.Core.Routing;
+using Unifesspa.UniPlus.Portal.API;
 using Unifesspa.UniPlus.Portal.API.Errors;
 using Unifesspa.UniPlus.Portal.Infrastructure;
 using Unifesspa.UniPlus.Portal.Infrastructure.Persistence;
@@ -49,12 +51,12 @@ builder.Services.TryAddSingleton(TimeProvider.System);
 builder.Services.AddEndpointsApiExplorer();
 // OpenAPI 3.1 (ADR-0030) — documento nomeado por módulo + transformers Uni+
 // (info, operation, schema). Spec exposto em /openapi/portal.json.
-builder.Services.AddUniPlusOpenApi("portal", builder.Configuration);
+builder.Services.AddUniPlusOpenApi(PortalApiAssemblyMarker.ModuleName, builder.Configuration);
 
 // Resolve os prefixos de endpoints de acordo com seu módulo,
 // evitando que os controllers precisem declarar [Route("api/{module}")].
 builder.Services.Configure<Microsoft.AspNetCore.Mvc.MvcOptions>(
-    options => options.Conventions.Add(new Unifesspa.UniPlus.Infrastructure.Core.Routing.ModuleRoutePrefixConvention()));
+    options => options.Conventions.Add(new ModuleRoutePrefixConvention()));
 
 builder.Services.AddSingleton<IDomainErrorRegistration, PortalDomainErrorRegistration>();
 builder.Services.AddDomainErrorMapper();

--- a/src/portal/Unifesspa.UniPlus.Portal.API/Program.cs
+++ b/src/portal/Unifesspa.UniPlus.Portal.API/Program.cs
@@ -51,6 +51,11 @@ builder.Services.AddEndpointsApiExplorer();
 // (info, operation, schema). Spec exposto em /openapi/portal.json.
 builder.Services.AddUniPlusOpenApi("portal", builder.Configuration);
 
+// Resolve os prefixos de endpoints de acordo com seu módulo,
+// evitando que os controllers precisem declarar [Route("api/{module}")].
+builder.Services.Configure<Microsoft.AspNetCore.Mvc.MvcOptions>(
+    options => options.Conventions.Add(new Unifesspa.UniPlus.Infrastructure.Core.Routing.ModuleRoutePrefixConvention()));
+
 builder.Services.AddSingleton<IDomainErrorRegistration, PortalDomainErrorRegistration>();
 builder.Services.AddDomainErrorMapper();
 

--- a/src/publicacoes/Unifesspa.UniPlus.Publicacoes.API/Controllers/AtosNormativosController.cs
+++ b/src/publicacoes/Unifesspa.UniPlus.Publicacoes.API/Controllers/AtosNormativosController.cs
@@ -31,7 +31,6 @@ using Unifesspa.UniPlus.Publicacoes.Application.Queries.AtosNormativos;
 /// remoção via HTTP (o ato é prova, o passado documental não se muta).
 /// </remarks>
 [ApiController]
-[Route("api/publicacoes")]
 [SuppressMessage(
     "Performance",
     "CA1515:Consider making public types internal",

--- a/src/publicacoes/Unifesspa.UniPlus.Publicacoes.API/Controllers/TiposAtoController.cs
+++ b/src/publicacoes/Unifesspa.UniPlus.Publicacoes.API/Controllers/TiposAtoController.cs
@@ -29,7 +29,6 @@ using Unifesspa.UniPlus.Publicacoes.Domain.Errors;
 /// (<c>created_by</c>) não é exposta.
 /// </remarks>
 [ApiController]
-[Route("api/publicacoes")]
 [SuppressMessage(
     "Performance",
     "CA1515:Consider making public types internal",

--- a/src/publicacoes/Unifesspa.UniPlus.Publicacoes.API/PublicacoesApiAssemblyMarker.cs
+++ b/src/publicacoes/Unifesspa.UniPlus.Publicacoes.API/PublicacoesApiAssemblyMarker.cs
@@ -1,3 +1,8 @@
+using Unifesspa.UniPlus.Infrastructure.Core.Routing;
+
+[assembly: ApiModule(
+    global::Unifesspa.UniPlus.Publicacoes.API.PublicacoesApiAssemblyMarker.ModuleName)]
+
 namespace Unifesspa.UniPlus.Publicacoes.API;
 
 /// <summary>
@@ -9,6 +14,8 @@ namespace Unifesspa.UniPlus.Publicacoes.API;
 /// </summary>
 public sealed class PublicacoesApiAssemblyMarker
 {
+    public const string ModuleName = "publicacoes";
+
     private PublicacoesApiAssemblyMarker()
     {
     }

--- a/src/publicacoes/Unifesspa.UniPlus.Publicacoes.API/PublicacoesModuleRegistration.cs
+++ b/src/publicacoes/Unifesspa.UniPlus.Publicacoes.API/PublicacoesModuleRegistration.cs
@@ -6,6 +6,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Unifesspa.UniPlus.Infrastructure.Core.DependencyInjection;
 using Unifesspa.UniPlus.Infrastructure.Core.Errors;
 using Unifesspa.UniPlus.Infrastructure.Core.Hateoas;
+using Unifesspa.UniPlus.Infrastructure.Core.Routing;
 using Unifesspa.UniPlus.Publicacoes.API.Errors;
 using Unifesspa.UniPlus.Publicacoes.API.Hateoas;
 using Unifesspa.UniPlus.Publicacoes.Application;
@@ -39,7 +40,7 @@ public static class PublicacoesModuleRegistration
         ArgumentNullException.ThrowIfNull(configuration);
 
         // OpenAPI 3.1 (ADR-0030) — spec em /openapi/publicacoes.json.
-        services.AddUniPlusOpenApi("publicacoes", configuration);
+        services.AddUniPlusOpenApi(PublicacoesApiAssemblyMarker.ModuleName, configuration);
 
         // Erros de domínio do módulo (consumidos por AddDomainErrorMapper, registrado
         // uma vez no host via IEnumerable<IDomainErrorRegistration>).

--- a/src/selecao/Unifesspa.UniPlus.Selecao.API/Controllers/DocumentosEditalController.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.API/Controllers/DocumentosEditalController.cs
@@ -21,7 +21,7 @@ using Unifesspa.UniPlus.Kernel.Results;
 /// registro confirmado.
 /// </summary>
 [ApiController]
-[Route("api/selecao/processos-seletivos/{processoSeletivoId:guid}/documentos-edital")]
+[Route("processos-seletivos/{processoSeletivoId:guid}/documentos-edital")]
 // Mesma justificativa de ProcessoSeletivoController: fluxo administrativo de
 // publicação, sem fallback policy — restrito a plataforma-admin.
 [Authorize(Roles = "plataforma-admin")]

--- a/src/selecao/Unifesspa.UniPlus.Selecao.API/Controllers/ObrigatoriedadeLegalController.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.API/Controllers/ObrigatoriedadeLegalController.cs
@@ -27,7 +27,6 @@ using Unifesspa.UniPlus.Selecao.Domain.Enums;
 /// interina).
 /// </summary>
 [ApiController]
-[Route("api/selecao")]
 [SuppressMessage(
     "Performance",
     "CA1515:Consider making public types internal",

--- a/src/selecao/Unifesspa.UniPlus.Selecao.API/Controllers/ProcessoSeletivoController.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.API/Controllers/ProcessoSeletivoController.cs
@@ -36,7 +36,7 @@ using Unifesspa.UniPlus.Selecao.Domain.ValueObjects;
 /// (<see cref="Publicar"/>, Story #759 T4 #785).
 /// </summary>
 [ApiController]
-[Route("api/selecao/processos-seletivos")]
+[Route("processos-seletivos")]
 // Configuração administrativa: todo o ciclo do processo em rascunho (criar,
 // montar etapas/atendimento e consultar conformidade) é
 // restrito a plataforma-admin — sem [Authorize] os endpoints ficariam anônimos

--- a/src/selecao/Unifesspa.UniPlus.Selecao.API/SelecaoApiAssemblyMarker.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.API/SelecaoApiAssemblyMarker.cs
@@ -1,3 +1,8 @@
+using Unifesspa.UniPlus.Infrastructure.Core.Routing;
+
+[assembly: ApiModule(
+    global::Unifesspa.UniPlus.Selecao.API.SelecaoApiAssemblyMarker.ModuleName)]
+
 namespace Unifesspa.UniPlus.Selecao.API;
 
 /// <summary>
@@ -9,6 +14,8 @@ namespace Unifesspa.UniPlus.Selecao.API;
 /// </summary>
 public sealed class SelecaoApiAssemblyMarker
 {
+    public const string ModuleName = "selecao";
+
     private SelecaoApiAssemblyMarker()
     {
     }

--- a/src/selecao/Unifesspa.UniPlus.Selecao.API/SelecaoModuleRegistration.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.API/SelecaoModuleRegistration.cs
@@ -6,6 +6,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Unifesspa.UniPlus.Infrastructure.Core.DependencyInjection;
 using Unifesspa.UniPlus.Infrastructure.Core.Errors;
 using Unifesspa.UniPlus.Infrastructure.Core.Hateoas;
+using Unifesspa.UniPlus.Infrastructure.Core.Routing;
 using Unifesspa.UniPlus.Selecao.API.Errors;
 using Unifesspa.UniPlus.Selecao.API.Hateoas;
 using Unifesspa.UniPlus.Selecao.Application.DTOs;
@@ -41,7 +42,7 @@ public static class SelecaoModuleRegistration
 
         // OpenAPI 3.1 (ADR-0030) — documento nomeado por módulo + transformers
         // Uni+ (info, operation, schema). Spec exposto em /openapi/selecao.json.
-        services.AddUniPlusOpenApi("selecao", configuration);
+        services.AddUniPlusOpenApi(SelecaoApiAssemblyMarker.ModuleName, configuration);
 
         // Erros de domínio do módulo (consumidos por AddDomainErrorMapper, registrado
         // uma vez no host via IEnumerable<IDomainErrorRegistration>).

--- a/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Routing/ApiModuleAttribute.cs
+++ b/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Routing/ApiModuleAttribute.cs
@@ -1,0 +1,33 @@
+namespace Unifesspa.UniPlus.Infrastructure.Core.Routing;
+
+/// <summary>
+/// Identifica um assembly de API com o nome público do módulo que ele expõe.
+/// Uma única declaração no assembly atende todos os seus controllers.
+/// </summary>
+[AttributeUsage(AttributeTargets.Assembly, AllowMultiple = false)]
+public sealed class ApiModuleAttribute : Attribute
+{
+    public ApiModuleAttribute(string name)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(name);
+
+        if (!IsValidName(name))
+        {
+            throw new ArgumentException(
+                "O nome do módulo deve começar com letra minúscula ASCII e conter "
+                + "somente letras minúsculas ASCII, dígitos ou hífen.",
+                nameof(name));
+        }
+
+        Name = name;
+    }
+
+    public string Name { get; }
+
+    private static bool IsValidName(string name) =>
+        char.IsAsciiLetterLower(name[0])
+        && name.All(static character =>
+            char.IsAsciiLetterLower(character)
+            || char.IsAsciiDigit(character)
+            || character == '-');
+}

--- a/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Routing/ApiModuleMetadata.cs
+++ b/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Routing/ApiModuleMetadata.cs
@@ -1,0 +1,21 @@
+namespace Unifesspa.UniPlus.Infrastructure.Core.Routing;
+
+using System.Reflection;
+
+/// <summary>
+/// Resolve o módulo de um controller pelo metadado declarado em seu assembly,
+/// sem depender do namespace ou do agrupamento do ApiExplorer.
+/// </summary>
+public static class ApiModuleMetadata
+{
+    public static string GetRequiredName(Assembly assembly)
+    {
+        ArgumentNullException.ThrowIfNull(assembly);
+
+        ApiModuleAttribute? metadata = assembly.GetCustomAttribute<ApiModuleAttribute>();
+        return metadata?.Name
+            ?? throw new InvalidOperationException(
+                $"O assembly '{assembly.GetName().Name}' contém controllers, "
+                + $"mas não declara [{nameof(ApiModuleAttribute)}].");
+    }
+}

--- a/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Routing/ModuleRoutePrefixConvention.cs
+++ b/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Routing/ModuleRoutePrefixConvention.cs
@@ -1,0 +1,30 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.ApplicationModels;
+
+namespace Unifesspa.UniPlus.Infrastructure.Core.Routing;
+
+public sealed class ModuleRoutePrefixConvention : IControllerModelConvention
+{
+    public void Apply(ControllerModel controller)
+    {
+        ArgumentNullException.ThrowIfNull(controller);
+        string? groupName = controller.ApiExplorer.GroupName;
+        if (groupName is null)
+        {
+            return;
+        }
+
+        var prefix = new AttributeRouteModel(
+            new RouteAttribute($"api/{groupName}")
+        );
+
+        foreach (SelectorModel selector in controller.Selectors)
+        {
+            selector.AttributeRouteModel = selector.AttributeRouteModel == null
+                ? prefix
+                : AttributeRouteModel.CombineAttributeRouteModel(
+                    prefix,
+                    selector.AttributeRouteModel);
+        }
+    }
+}

--- a/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Routing/ModuleRoutePrefixConvention.cs
+++ b/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Routing/ModuleRoutePrefixConvention.cs
@@ -8,14 +8,11 @@ public sealed class ModuleRoutePrefixConvention : IControllerModelConvention
     public void Apply(ControllerModel controller)
     {
         ArgumentNullException.ThrowIfNull(controller);
-        string? groupName = controller.ApiExplorer.GroupName;
-        if (groupName is null)
-        {
-            return;
-        }
+        string moduleName = ApiModuleMetadata.GetRequiredName(
+            controller.ControllerType.Assembly);
 
         var prefix = new AttributeRouteModel(
-            new RouteAttribute($"api/{groupName}")
+            new RouteAttribute($"api/{moduleName}")
         );
 
         foreach (SelectorModel selector in controller.Selectors)

--- a/tests/Unifesspa.UniPlus.ArchTests/SolutionRules/ApiModuleMetadataTests.cs
+++ b/tests/Unifesspa.UniPlus.ArchTests/SolutionRules/ApiModuleMetadataTests.cs
@@ -1,0 +1,92 @@
+namespace Unifesspa.UniPlus.ArchTests.SolutionRules;
+
+using System.Reflection;
+
+using AwesomeAssertions;
+
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.ApplicationModels;
+
+using Unifesspa.UniPlus.Infrastructure.Core.Routing;
+using Unifesspa.UniPlus.Portal.API.Controllers;
+
+public sealed class ApiModuleMetadataTests
+{
+    private const string UniPlusAssemblyPrefix = "Unifesspa.UniPlus.";
+    private const string ApiAssemblySuffix = ".API";
+
+    private static readonly Assembly[] ApiAssemblies = DiscoverApiAssemblies();
+
+    [Fact]
+    public void ApiAssemblies_DeclareSingleModuleName()
+    {
+        foreach (Assembly assembly in ApiAssemblies)
+        {
+            assembly.GetCustomAttributes<ApiModuleAttribute>()
+                .Should().ContainSingle()
+                .Which.Name.Should().NotBeNullOrWhiteSpace(
+                    $"o assembly {assembly.GetName().Name} deve declarar seu contrato público de módulo");
+        }
+    }
+
+    [Fact]
+    public void ApiAssemblies_ModuleNamesAreUnique()
+    {
+        IEnumerable<string> names = ApiAssemblies
+            .Select(ApiModuleMetadata.GetRequiredName);
+
+        names.Should().OnlyHaveUniqueItems(
+            "dois assemblies de API não podem disputar o mesmo prefixo e documento OpenAPI");
+    }
+
+    [Fact]
+    public void ModuleRoutePrefixConvention_PortalPing_CombinesAssemblyModuleAndControllerRoute()
+    {
+        TypeInfo controllerType = typeof(PingController).GetTypeInfo();
+        RouteAttribute route = controllerType.GetCustomAttribute<RouteAttribute>()
+            ?? throw new InvalidOperationException("PingController deve declarar o recurso relativo.");
+        var controller = new ControllerModel(
+            controllerType,
+            controllerType.GetCustomAttributes(inherit: true).ToArray());
+        controller.Selectors.Add(new SelectorModel
+        {
+            AttributeRouteModel = new AttributeRouteModel(route),
+        });
+
+        new ModuleRoutePrefixConvention().Apply(controller);
+
+        controller.Selectors.Should().ContainSingle()
+            .Which.AttributeRouteModel!.Template.Should().Be("api/portal/ping");
+    }
+
+    [Fact]
+    public void ModuleRoutePrefixConvention_SelectorWithoutRoute_UsesAssemblyModulePrefix()
+    {
+        TypeInfo controllerType = typeof(PingController).GetTypeInfo();
+        var controller = new ControllerModel(controllerType, []);
+        controller.Selectors.Add(new SelectorModel());
+
+        new ModuleRoutePrefixConvention().Apply(controller);
+
+        controller.Selectors.Should().ContainSingle()
+            .Which.AttributeRouteModel!.Template.Should().Be("api/portal");
+    }
+
+    private static Assembly[] DiscoverApiAssemblies()
+    {
+        string searchPattern = $"{UniPlusAssemblyPrefix}*{ApiAssemblySuffix}.dll";
+        Assembly[] assemblies = [.. Directory
+            .EnumerateFiles(AppContext.BaseDirectory, searchPattern, SearchOption.TopDirectoryOnly)
+            .Select(Path.GetFileNameWithoutExtension)
+            .Order(StringComparer.Ordinal)
+            .Select(static name => Assembly.Load(
+                new AssemblyName(name
+                    ?? throw new InvalidOperationException(
+                        "Arquivo de assembly de API sem nome."))))];
+
+        assemblies.Should().NotBeEmpty(
+            "o projeto ArchTests referencia por glob todos os projetos Unifesspa.UniPlus.*.API");
+
+        return assemblies;
+    }
+}

--- a/tests/Unifesspa.UniPlus.ArchTests/Unifesspa.UniPlus.ArchTests.csproj
+++ b/tests/Unifesspa.UniPlus.ArchTests/Unifesspa.UniPlus.ArchTests.csproj
@@ -27,26 +27,26 @@
     <ProjectReference Include="../../src/selecao/Unifesspa.UniPlus.Selecao.Domain/Unifesspa.UniPlus.Selecao.Domain.csproj" />
     <ProjectReference Include="../../src/selecao/Unifesspa.UniPlus.Selecao.Application/Unifesspa.UniPlus.Selecao.Application.csproj" />
     <ProjectReference Include="../../src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/Unifesspa.UniPlus.Selecao.Infrastructure.csproj" />
-    <ProjectReference Include="../../src/selecao/Unifesspa.UniPlus.Selecao.API/Unifesspa.UniPlus.Selecao.API.csproj" />
     <ProjectReference Include="../../src/ingresso/Unifesspa.UniPlus.Ingresso.Domain/Unifesspa.UniPlus.Ingresso.Domain.csproj" />
     <ProjectReference Include="../../src/ingresso/Unifesspa.UniPlus.Ingresso.Infrastructure/Unifesspa.UniPlus.Ingresso.Infrastructure.csproj" />
-    <ProjectReference Include="../../src/ingresso/Unifesspa.UniPlus.Ingresso.API/Unifesspa.UniPlus.Ingresso.API.csproj" />
     <ProjectReference Include="../../src/portal/Unifesspa.UniPlus.Portal.Domain/Unifesspa.UniPlus.Portal.Domain.csproj" />
     <ProjectReference Include="../../src/portal/Unifesspa.UniPlus.Portal.Infrastructure/Unifesspa.UniPlus.Portal.Infrastructure.csproj" />
-    <ProjectReference Include="../../src/portal/Unifesspa.UniPlus.Portal.API/Unifesspa.UniPlus.Portal.API.csproj" />
     <ProjectReference Include="../../src/organizacao-institucional/Unifesspa.UniPlus.OrganizacaoInstitucional.Domain/Unifesspa.UniPlus.OrganizacaoInstitucional.Domain.csproj" />
     <ProjectReference Include="../../src/organizacao-institucional/Unifesspa.UniPlus.OrganizacaoInstitucional.Application/Unifesspa.UniPlus.OrganizacaoInstitucional.Application.csproj" />
     <ProjectReference Include="../../src/organizacao-institucional/Unifesspa.UniPlus.OrganizacaoInstitucional.Infrastructure/Unifesspa.UniPlus.OrganizacaoInstitucional.Infrastructure.csproj" />
-    <ProjectReference Include="../../src/organizacao-institucional/Unifesspa.UniPlus.OrganizacaoInstitucional.API/Unifesspa.UniPlus.OrganizacaoInstitucional.API.csproj" />
     <ProjectReference Include="../../src/configuracao/Unifesspa.UniPlus.Configuracao.Domain/Unifesspa.UniPlus.Configuracao.Domain.csproj" />
     <ProjectReference Include="../../src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Unifesspa.UniPlus.Configuracao.Application.csproj" />
     <ProjectReference Include="../../src/configuracao/Unifesspa.UniPlus.Configuracao.Contracts/Unifesspa.UniPlus.Configuracao.Contracts.csproj" />
     <ProjectReference Include="../../src/configuracao/Unifesspa.UniPlus.Configuracao.Infrastructure/Unifesspa.UniPlus.Configuracao.Infrastructure.csproj" />
-    <ProjectReference Include="../../src/configuracao/Unifesspa.UniPlus.Configuracao.API/Unifesspa.UniPlus.Configuracao.API.csproj" />
     <ProjectReference Include="../../src/publicacoes/Unifesspa.UniPlus.Publicacoes.Domain/Unifesspa.UniPlus.Publicacoes.Domain.csproj" />
     <ProjectReference Include="../../src/publicacoes/Unifesspa.UniPlus.Publicacoes.Application/Unifesspa.UniPlus.Publicacoes.Application.csproj" />
     <ProjectReference Include="../../src/publicacoes/Unifesspa.UniPlus.Publicacoes.Infrastructure/Unifesspa.UniPlus.Publicacoes.Infrastructure.csproj" />
-    <ProjectReference Include="../../src/publicacoes/Unifesspa.UniPlus.Publicacoes.API/Unifesspa.UniPlus.Publicacoes.API.csproj" />
+    <!--
+      O glob é intencional: todo assembly *.API entra automaticamente no output
+      do ArchTests e, portanto, no fitness test de metadados. Um módulo novo não
+      depende de alguém lembrar de atualizar um roster manual no código de teste.
+    -->
+    <ProjectReference Include="../../src/*/Unifesspa.UniPlus.*.API/Unifesspa.UniPlus.*.API.csproj" />
     <ProjectReference Include="../../src/shared/Unifesspa.UniPlus.Governance.Contracts/Unifesspa.UniPlus.Governance.Contracts.csproj" />
     <!-- Host composition root do monólito modular — referenciado pelo fato
          positivo do R8 (host PODE compor todos os módulos). Fica FORA do roster. -->

--- a/tests/Unifesspa.UniPlus.Infrastructure.Core.UnitTests/Routing/ApiModuleAttributeTests.cs
+++ b/tests/Unifesspa.UniPlus.Infrastructure.Core.UnitTests/Routing/ApiModuleAttributeTests.cs
@@ -1,0 +1,41 @@
+namespace Unifesspa.UniPlus.Infrastructure.Core.UnitTests.Routing;
+
+using AwesomeAssertions;
+
+using Unifesspa.UniPlus.Infrastructure.Core.Routing;
+
+public sealed class ApiModuleAttributeTests
+{
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("Portal")]
+    [InlineData("1portal")]
+    [InlineData("portal/api")]
+    [InlineData("portal_api")]
+    public void Constructor_NameInvalid_ThrowsArgumentException(string name)
+    {
+        Action act = () => _ = new ApiModuleAttribute(name);
+
+        act.Should().Throw<ArgumentException>()
+            .WithParameterName(nameof(name));
+    }
+
+    [Fact]
+    public void Constructor_NameValid_PreservesName()
+    {
+        var attribute = new ApiModuleAttribute("portal-candidato");
+
+        attribute.Name.Should().Be("portal-candidato");
+    }
+
+    [Fact]
+    public void GetRequiredName_AssemblyWithoutMetadata_ThrowsInvalidOperationException()
+    {
+        Action act = () => ApiModuleMetadata.GetRequiredName(
+            typeof(ApiModuleAttributeTests).Assembly);
+
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("*não declara*ApiModuleAttribute*");
+    }
+}

--- a/tests/Unifesspa.UniPlus.Portal.IntegrationTests/Infrastructure/PortalApiFactory.cs
+++ b/tests/Unifesspa.UniPlus.Portal.IntegrationTests/Infrastructure/PortalApiFactory.cs
@@ -1,0 +1,24 @@
+namespace Unifesspa.UniPlus.Portal.IntegrationTests.Infrastructure;
+
+using System.Diagnostics.CodeAnalysis;
+
+using Unifesspa.UniPlus.IntegrationTests.Fixtures.Hosting;
+using Unifesspa.UniPlus.Portal.API;
+
+[SuppressMessage(
+    "Performance",
+    "CA1515:Consider making public types internal",
+    Justification = "xUnit IClassFixture<T> exige fixture pública.")]
+public sealed class PortalApiFactory : ApiFactoryBase<PortalApiAssemblyMarker>
+{
+    private const string FakeConnectionString =
+        "Host=integration-not-real;Database=portal;Username=u;Password=p";
+
+    protected override IEnumerable<KeyValuePair<string, string?>> GetConfigurationOverrides() =>
+    [
+        new("ConnectionStrings:PortalDb", FakeConnectionString),
+        new("Kafka:BootstrapServers", string.Empty),
+        new("Auth:Authority", "http://localhost/test-realm"),
+        new("Auth:Audience", "uniplus"),
+    ];
+}

--- a/tests/Unifesspa.UniPlus.Portal.IntegrationTests/Routing/PortalRoutingTests.cs
+++ b/tests/Unifesspa.UniPlus.Portal.IntegrationTests/Routing/PortalRoutingTests.cs
@@ -1,0 +1,37 @@
+namespace Unifesspa.UniPlus.Portal.IntegrationTests.Routing;
+
+using System.Diagnostics.CodeAnalysis;
+using System.Net;
+
+using AwesomeAssertions;
+
+using Infrastructure;
+
+[Trait("Category", "Integration")]
+[SuppressMessage(
+    "Performance",
+    "CA1515:Consider making public types internal",
+    Justification = "xUnit IClassFixture<T> exige tipo de teste público.")]
+public sealed class PortalRoutingTests : IClassFixture<PortalApiFactory>
+{
+    private readonly PortalApiFactory _factory;
+
+    public PortalRoutingTests(PortalApiFactory factory)
+    {
+        _factory = factory;
+    }
+
+    [Fact]
+    public async Task PortalStandalone_PingRoute_UsesModulePrefix()
+    {
+        using HttpClient client = _factory.CreateClient();
+
+        HttpResponseMessage prefixed = await client.GetAsync(
+            new Uri("/api/portal/ping", UriKind.Relative));
+        HttpResponseMessage unprefixed = await client.GetAsync(
+            new Uri("/ping", UriKind.Relative));
+
+        prefixed.StatusCode.Should().Be(HttpStatusCode.OK);
+        unprefixed.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+}

--- a/tests/Unifesspa.UniPlus.Portal.IntegrationTests/Unifesspa.UniPlus.Portal.IntegrationTests.csproj
+++ b/tests/Unifesspa.UniPlus.Portal.IntegrationTests/Unifesspa.UniPlus.Portal.IntegrationTests.csproj
@@ -1,0 +1,25 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio" />
+    <PackageReference Include="AwesomeAssertions" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../src/portal/Unifesspa.UniPlus.Portal.API/Unifesspa.UniPlus.Portal.API.csproj" />
+    <ProjectReference Include="../Unifesspa.UniPlus.IntegrationTests.Fixtures/Unifesspa.UniPlus.IntegrationTests.Fixtures.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+</Project>

--- a/tests/Unifesspa.UniPlus.Portal.IntegrationTests/packages.lock.json
+++ b/tests/Unifesspa.UniPlus.Portal.IntegrationTests/packages.lock.json
@@ -1,0 +1,1585 @@
+{
+  "version": 2,
+  "dependencies": {
+    "net10.0": {
+      "AwesomeAssertions": {
+        "type": "Direct",
+        "requested": "[9.5.0, )",
+        "resolved": "9.5.0",
+        "contentHash": "F92MsjoF8B7IdcWETru4QGZx6VAl38qQPKNGS3kwPwlLB5lb0O4bhFqG8a8sz2estQJWkKmZkVy1r19HTaFcpg=="
+      },
+      "coverlet.collector": {
+        "type": "Direct",
+        "requested": "[8.0.1, )",
+        "resolved": "8.0.1",
+        "contentHash": "heVQl5tKYnnIDYlR1QMVGueYH6iriZTcZB6AjDczQNwZzxkjDIt9C84Pt4cCiZYrbo7jkZOYGWbs6Lo9wAtVLg=="
+      },
+      "Microsoft.AspNetCore.Mvc.Testing": {
+        "type": "Direct",
+        "requested": "[10.0.10, )",
+        "resolved": "10.0.10",
+        "contentHash": "pTWE4RtRbb9sl/U9QjZA5oapEZ01ZEMfRilZvvh55ZW97caTQ2XuAF6sgc+7ojKWBbR2qrcWVo5P80gMPuW/tQ==",
+        "dependencies": {
+          "Microsoft.AspNetCore.TestHost": "10.0.10",
+          "Microsoft.Extensions.DependencyModel": "10.0.10",
+          "Microsoft.Extensions.Hosting": "10.0.10"
+        }
+      },
+      "Microsoft.NET.Test.Sdk": {
+        "type": "Direct",
+        "requested": "[18.8.1, )",
+        "resolved": "18.8.1",
+        "contentHash": "dknJL3/9Y3t4XuCBqnc0PevPxgLsUMmVhjwup/b1HNovA8zWcj3XsfIf7c6p05363DWcqL7X/YhDL9B+Zymv1w==",
+        "dependencies": {
+          "Microsoft.CodeCoverage": "18.8.1",
+          "Microsoft.TestPlatform.TestHost": "18.8.1"
+        }
+      },
+      "xunit": {
+        "type": "Direct",
+        "requested": "[2.9.3, )",
+        "resolved": "2.9.3",
+        "contentHash": "TlXQBinK35LpOPKHAqbLY4xlEen9TBafjs0V5KnA4wZsoQLQJiirCR4CbIXvOH8NzkW4YeJKP5P/Bnrodm0h9Q==",
+        "dependencies": {
+          "xunit.analyzers": "1.18.0",
+          "xunit.assert": "2.9.3",
+          "xunit.core": "[2.9.3]"
+        }
+      },
+      "xunit.runner.visualstudio": {
+        "type": "Direct",
+        "requested": "[3.1.5, )",
+        "resolved": "3.1.5",
+        "contentHash": "tKi7dSTwP4m5m9eXPM2Ime4Kn7xNf4x4zT9sdLO/G4hZVnQCRiMTWoSZqI/pYTVeI27oPPqHBKYI/DjJ9GsYgA=="
+      },
+      "BouncyCastle.Cryptography": {
+        "type": "Transitive",
+        "resolved": "2.6.2",
+        "contentHash": "7oWOcvnntmMKNzDLsdxAYqApt+AjpRpP2CShjMfIa3umZ42UQMvH0tl1qAliYPNYO6vTdcGMqnRrCPmsfzTI1w=="
+      },
+      "CommunityToolkit.HighPerformance": {
+        "type": "Transitive",
+        "resolved": "8.4.0",
+        "contentHash": "flxspiBs0G/0GMp7IK2J2ijV9bTG6hEwFc/z6ekHqB6nwRJ4Ry2yLdx+TkbCUYFCl4XhABkAwomeKbT6zM2Zlg=="
+      },
+      "Confluent.SchemaRegistry.Serdes.Json": {
+        "type": "Transitive",
+        "resolved": "2.14.0",
+        "contentHash": "rymTRDrwEIzfFCDEcoV6ZvDatlVrwmMWXT93sERMLHZiEOhOCR53Jiwa9bk/OyjIRqRxiIFHOwys2qJgfN6rQQ==",
+        "dependencies": {
+          "Confluent.Kafka": "2.14.0",
+          "Confluent.SchemaRegistry": "2.14.0",
+          "NJsonSchema.NewtonsoftJson": "11.0.2"
+        }
+      },
+      "DistributedLock.Core": {
+        "type": "Transitive",
+        "resolved": "1.0.8",
+        "contentHash": "LAOsY8WxX8JU/n3lfXFz+f2pfnv0+4bHkCrOO3bwa28u9HrS3DlxSG6jf+u76SqesKs+KehZi0CndkfaUXBKvg=="
+      },
+      "DistributedLock.Postgres": {
+        "type": "Transitive",
+        "resolved": "1.3.0",
+        "contentHash": "CyjXmbhFgG30qPg4DwGnsmZO63y5DBRo+PI2xW0NwtFrsYsMVt/T1RcEUlb36JMKhDkf+euhnkanv/nU+W35qA==",
+        "dependencies": {
+          "DistributedLock.Core": "[1.0.8, 1.1.0)",
+          "Npgsql": "8.0.6"
+        }
+      },
+      "Docker.DotNet.Enhanced": {
+        "type": "Transitive",
+        "resolved": "4.3.3",
+        "contentHash": "nGicLwvd42FhRk+khY5uS6cx49ErNdwYKnYBg0F4m4BDKLp/R77AVmmN9xAiqI3W/wN5ZCHkdUhgxf5ORkZuFQ==",
+        "dependencies": {
+          "Docker.DotNet.Enhanced.Handler.Abstractions": "4.3.3",
+          "Docker.DotNet.Enhanced.LegacyHttp": "4.3.3",
+          "Docker.DotNet.Enhanced.NPipe": "4.3.3",
+          "Docker.DotNet.Enhanced.NativeHttp": "4.3.3",
+          "Docker.DotNet.Enhanced.Unix": "4.3.3",
+          "Microsoft.Extensions.Logging.Abstractions": "8.0.3"
+        }
+      },
+      "Docker.DotNet.Enhanced.Handler.Abstractions": {
+        "type": "Transitive",
+        "resolved": "4.3.3",
+        "contentHash": "9Cp8hOgtynixcDoAs9lnEaQosluojSYmiW3fsLsLIVfZjlq/fznSIZNUhnmyT4Xo1Iyuok/y49WL/25O47u0Pw==",
+        "dependencies": {
+          "Microsoft.Extensions.Logging.Abstractions": "8.0.3"
+        }
+      },
+      "Docker.DotNet.Enhanced.LegacyHttp": {
+        "type": "Transitive",
+        "resolved": "4.3.3",
+        "contentHash": "7j3M16emv9PAQN7VwFn23xLYNj8GJmwPOcogveHkaWnOCqiC+anRaNKQwqIBNApM1AuwZKivehTKTPmmrjUUnw==",
+        "dependencies": {
+          "Docker.DotNet.Enhanced.Handler.Abstractions": "4.3.3"
+        }
+      },
+      "Docker.DotNet.Enhanced.NativeHttp": {
+        "type": "Transitive",
+        "resolved": "4.3.3",
+        "contentHash": "iNzK+jRFeEMobSA7l/h4ARwCKOOefOWtVN5/RB0ft6/6H6IQXvVUuOgGyZAjYLBT7TsyClRYno2B904f3dtBuQ==",
+        "dependencies": {
+          "Docker.DotNet.Enhanced.Handler.Abstractions": "4.3.3"
+        }
+      },
+      "Docker.DotNet.Enhanced.NPipe": {
+        "type": "Transitive",
+        "resolved": "4.3.3",
+        "contentHash": "ZTLYufuEfY0e6qLOgeH9QgXx2KYuoABRVaY5A8rsggyLgYqbDj9rCRfVAhHPCUv83S7pVxDHy+Tvm/BnxjWVpg==",
+        "dependencies": {
+          "Docker.DotNet.Enhanced.Handler.Abstractions": "4.3.3"
+        }
+      },
+      "Docker.DotNet.Enhanced.Unix": {
+        "type": "Transitive",
+        "resolved": "4.3.3",
+        "contentHash": "ypo8qNbmvHw1t9VfpRTMogCw2vht6VjkXzlGYUUeP2H2bf83USURdla1maW1njn2oq2rfLUFOGMfmt+A37QU2w==",
+        "dependencies": {
+          "Docker.DotNet.Enhanced.Handler.Abstractions": "4.3.3"
+        }
+      },
+      "Docker.DotNet.Enhanced.X509": {
+        "type": "Transitive",
+        "resolved": "4.3.3",
+        "contentHash": "oBDibWezEv4hgj3RIQxI3DVcxkNV1MdrD0d/jhjUu+h3DL+qc0wlkQva15kkwMatXmC/hWp1VP0DMoFXe+BmEw==",
+        "dependencies": {
+          "Docker.DotNet.Enhanced.Handler.Abstractions": "4.3.3"
+        }
+      },
+      "FastExpressionCompiler": {
+        "type": "Transitive",
+        "resolved": "5.3.0",
+        "contentHash": "XRmGW48Gdm7B70WUtTJJUnmuc8jRDmOhhjG/a3rix/nXChnrkETaSvA0j2VrcsH4MNeYLe60LA5o5JABmbneag=="
+      },
+      "Google.Protobuf": {
+        "type": "Transitive",
+        "resolved": "3.30.1",
+        "contentHash": "HeWXDQBabQn/sCGicbeLJ0HMunknfC4FdLrOQOsaMJHcpqx3HVIpyyJqTrqJlWnza870twhOb+rBcaTiC/TlNA=="
+      },
+      "Grpc.Core.Api": {
+        "type": "Transitive",
+        "resolved": "2.70.0",
+        "contentHash": "66UotvWcSIq41oiQhLWcQACyKPM4umxXNiht5DQTLZJfNwEswWOcS7Z0xIEHyNIBE7ZpjotH22bEjTkvhPxmVw=="
+      },
+      "Grpc.Net.Client": {
+        "type": "Transitive",
+        "resolved": "2.70.0",
+        "contentHash": "xNv0FFCVJa5S1beUtye82WFCxKThuE1jbN8DO1x1Rj8VSIWXLBUmfSID5a1fGzsU2R/EMfwPoWclJ2RMfQuGXw==",
+        "dependencies": {
+          "Grpc.Net.Common": "2.70.0",
+          "Microsoft.Extensions.Logging.Abstractions": "6.0.0"
+        }
+      },
+      "Grpc.Net.Common": {
+        "type": "Transitive",
+        "resolved": "2.70.0",
+        "contentHash": "rBdEUMyCwa+iB8mqC6JKyPbj3SBHHkReJj/yy/XKJI63GcG6w9DJMMGTVcYHqq4Ci2W4m0HT4jt2pFfFscar8g==",
+        "dependencies": {
+          "Grpc.Core.Api": "2.70.0"
+        }
+      },
+      "Humanizer.Core": {
+        "type": "Transitive",
+        "resolved": "2.14.1",
+        "contentHash": "lQKvtaTDOXnoVJ20ibTuSIOf2i0uO0MPbDhd1jm238I+U/2ZnRENj0cktKZhtchBMtCUSRQ5v4xBCUbKNmyVMw=="
+      },
+      "ImTools": {
+        "type": "Transitive",
+        "resolved": "4.0.0",
+        "contentHash": "dms0JfLKC9AQbQX/EdpRjn59EjEvaCxIgv1z9YxbEQb5SiOVoo7vlIKdEySeEwUkWhN05rZnNpUpG+aw5VqPVQ=="
+      },
+      "JasperFx": {
+        "type": "Transitive",
+        "resolved": "1.31.0",
+        "contentHash": "4ixFajJnNJf9Unuc49rq8pKtHYMdUVepE1tX921F48u6BAbf9BNuGdijDioehYLGl/yhsF2yjRrQXpsN9FMZIg==",
+        "dependencies": {
+          "FastExpressionCompiler": "5.3.0",
+          "ImTools": "4.0.0",
+          "Microsoft.Bcl.TimeProvider": "10.0.0",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Hosting": "10.0.0",
+          "Microsoft.Extensions.ObjectPool": "10.0.0",
+          "Polly.Core": "8.6.5",
+          "Spectre.Console": "0.55.0"
+        }
+      },
+      "JasperFx.Events": {
+        "type": "Transitive",
+        "resolved": "1.36.0",
+        "contentHash": "xLThG3rvcv8NNkNuCU334Ut+9qODX8tTBqe8J9IAP7auyq4qv/TYmqmKYnkDAJVIW6xl6LECVDFgJMD3YZTbow==",
+        "dependencies": {
+          "JasperFx": "1.31.0"
+        }
+      },
+      "JasperFx.RuntimeCompiler": {
+        "type": "Transitive",
+        "resolved": "4.5.0",
+        "contentHash": "SGJlU1kD8lX8A5p0hBWTPDV7dvPzoUB37IZjprWgA+L5yZZNyBElpn6UPNo7ZuXLKKwlSSt8BWTr99vxpxT3JA==",
+        "dependencies": {
+          "JasperFx": "1.28.0",
+          "Microsoft.CodeAnalysis": "5.0.0",
+          "Microsoft.CodeAnalysis.CSharp": "5.0.0",
+          "Microsoft.CodeAnalysis.Scripting": "5.0.0",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.0"
+        }
+      },
+      "JasperFx.SourceGeneration": {
+        "type": "Transitive",
+        "resolved": "1.1.0",
+        "contentHash": "yIOaiA/OrlXQLGPjxFDubHnOU8MCzPTz465xBGRITMm4fDf7DbWKogb2SZC2jYLWEj27q3smTz1Z7lU4h1KkOQ=="
+      },
+      "librdkafka.redist": {
+        "type": "Transitive",
+        "resolved": "2.15.0",
+        "contentHash": "DzG2YcqWPT3Ly91aeDYsgsVcJXlOMiK9oqyRdPvQz9ZMbcV8Ob0rQA6fNUQ4sarmzFk4phqwPlVQxtZDGLP69w=="
+      },
+      "Microsoft.AspNetCore.TestHost": {
+        "type": "Transitive",
+        "resolved": "10.0.10",
+        "contentHash": "Kks+OpQlP/eWQhnTjkiv0H9kc9Uqa7ieAzNV62yJpZ8Ips/WwpfpwrwZUKzV83CBJaBl5OI7J2XxVVTC8vah/Q=="
+      },
+      "Microsoft.Bcl.AsyncInterfaces": {
+        "type": "Transitive",
+        "resolved": "9.0.0",
+        "contentHash": "owmu2Cr3IQ8yQiBleBHlGk8dSQ12oaF2e7TpzwJKEl4m84kkZJjEY1n33L67Y3zM5jPOjmmbdHjbfiL0RqcMRQ=="
+      },
+      "Microsoft.Bcl.TimeProvider": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "bUubrBD6tRJE3V1kvRloYc6NymH3R5oFKjAS9e0ELNx6u0ZR+zjps9dDQyjgqN/rArzl7f+21KGszj3YRN7F2Q=="
+      },
+      "Microsoft.Build.Framework": {
+        "type": "Transitive",
+        "resolved": "18.0.2",
+        "contentHash": "sOSb+0J4G/jCBW/YqmRuL0eOMXgfw1KQLdC9TkbvfA5xs7uNm+PBQXJCOzSJGXtZcZrtXozcwxPmUiRUbmd7FA=="
+      },
+      "Microsoft.CodeAnalysis": {
+        "type": "Transitive",
+        "resolved": "5.0.0",
+        "contentHash": "X7vItpZDkGm4NS2wp4P1S07Z1e61LaBWDW5tPXE1c6z5/x9KbF2RymhAPoYg7Qoiyk7odEZ6EjBEJ47p3dBpYQ==",
+        "dependencies": {
+          "Humanizer.Core": "2.14.1",
+          "Microsoft.Bcl.AsyncInterfaces": "9.0.0",
+          "Microsoft.CodeAnalysis.Analyzers": "3.11.0",
+          "Microsoft.CodeAnalysis.CSharp.Workspaces": "[5.0.0]",
+          "Microsoft.CodeAnalysis.VisualBasic.Workspaces": "[5.0.0]",
+          "System.Composition": "9.0.0"
+        }
+      },
+      "Microsoft.CodeAnalysis.Analyzers": {
+        "type": "Transitive",
+        "resolved": "3.11.0",
+        "contentHash": "v/EW3UE8/lbEYHoC2Qq7AR/DnmvpgdtAMndfQNmpuIMx/Mto8L5JnuCfdBYtgvalQOtfNCnxFejxuRrryvUTsg=="
+      },
+      "Microsoft.CodeAnalysis.Common": {
+        "type": "Transitive",
+        "resolved": "5.0.0",
+        "contentHash": "ZXRAdvH6GiDeHRyd3q/km8Z44RoM6FBWHd+gen/la81mVnAdHTEsEkO5J0TCNXBymAcx5UYKt5TvgKBhaLJEow==",
+        "dependencies": {
+          "Microsoft.CodeAnalysis.Analyzers": "3.11.0"
+        }
+      },
+      "Microsoft.CodeAnalysis.CSharp": {
+        "type": "Transitive",
+        "resolved": "5.0.0",
+        "contentHash": "5DSyJ9bk+ATuDy7fp2Zt0mJStDVKbBoiz1DyfAwSa+k4H4IwykAUcV3URelw5b8/iVbfSaOwkwmPUZH6opZKCw==",
+        "dependencies": {
+          "Microsoft.CodeAnalysis.Analyzers": "3.11.0",
+          "Microsoft.CodeAnalysis.Common": "[5.0.0]"
+        }
+      },
+      "Microsoft.CodeAnalysis.CSharp.Scripting": {
+        "type": "Transitive",
+        "resolved": "5.0.0",
+        "contentHash": "1sGloRYbG3743ut/+vuXy9/WaRQTm7mDtp71rBaVSmKpFntvo5Hcro1ubg6/3SeeLtiFYJl7V3Dk0Fo3CGlnHA==",
+        "dependencies": {
+          "Microsoft.CodeAnalysis.Analyzers": "3.11.0",
+          "Microsoft.CodeAnalysis.CSharp": "[5.0.0]",
+          "Microsoft.CodeAnalysis.Common": "[5.0.0]",
+          "Microsoft.CodeAnalysis.Scripting.Common": "[5.0.0]"
+        }
+      },
+      "Microsoft.CodeAnalysis.CSharp.Workspaces": {
+        "type": "Transitive",
+        "resolved": "5.0.0",
+        "contentHash": "Al/Q8B+yO8odSqGVpSvrShMFDvlQdIBU//F3E6Rb0YdiLSALE9wh/pvozPNnfmh5HDnvU+mkmSjpz4hQO++jaA==",
+        "dependencies": {
+          "Humanizer.Core": "2.14.1",
+          "Microsoft.CodeAnalysis.Analyzers": "3.11.0",
+          "Microsoft.CodeAnalysis.CSharp": "[5.0.0]",
+          "Microsoft.CodeAnalysis.Common": "[5.0.0]",
+          "Microsoft.CodeAnalysis.Workspaces.Common": "[5.0.0]",
+          "System.Composition": "9.0.0"
+        }
+      },
+      "Microsoft.CodeAnalysis.Scripting": {
+        "type": "Transitive",
+        "resolved": "5.0.0",
+        "contentHash": "/KgZdm6kRTrR/O2jqXxU5GWREYhtVmqcNWczyPt8hsQkFGFK/C6CrLWfG44FCUn0aPHGDRBHYjXlGosQ/H8oXw==",
+        "dependencies": {
+          "Microsoft.CodeAnalysis.Analyzers": "3.11.0",
+          "Microsoft.CodeAnalysis.CSharp.Scripting": "[5.0.0]"
+        }
+      },
+      "Microsoft.CodeAnalysis.Scripting.Common": {
+        "type": "Transitive",
+        "resolved": "5.0.0",
+        "contentHash": "XTulByMNxqXGCgMeODUoG2h4oK4/nLv1BcawRVcjv+UZHMpoaymtdaq3cJqlNrEvYEcbU48g5swJ3RhY1m3fBg==",
+        "dependencies": {
+          "Microsoft.CodeAnalysis.Analyzers": "3.11.0",
+          "Microsoft.CodeAnalysis.Common": "[5.0.0]"
+        }
+      },
+      "Microsoft.CodeAnalysis.VisualBasic": {
+        "type": "Transitive",
+        "resolved": "5.0.0",
+        "contentHash": "sUBWvHs2HgHGA+b716dgjS7JiXGen5ntyohAurPLR1ZiZzFp3FlnVA7GrMTqVGdVJTVqiC3c4K8k1bk0gj6IPg==",
+        "dependencies": {
+          "Microsoft.CodeAnalysis.Analyzers": "3.11.0",
+          "Microsoft.CodeAnalysis.Common": "[5.0.0]"
+        }
+      },
+      "Microsoft.CodeAnalysis.VisualBasic.Workspaces": {
+        "type": "Transitive",
+        "resolved": "5.0.0",
+        "contentHash": "Nom4UuZVEZGaV6Qa+joJR/BawXZMtflvQJFKc0SaUc3LrZr/8LmRY5cn8mbvLOWIVfwWkQz+cVE6eQKu9qa65g==",
+        "dependencies": {
+          "Humanizer.Core": "2.14.1",
+          "Microsoft.CodeAnalysis.Analyzers": "3.11.0",
+          "Microsoft.CodeAnalysis.Common": "[5.0.0]",
+          "Microsoft.CodeAnalysis.VisualBasic": "[5.0.0]",
+          "Microsoft.CodeAnalysis.Workspaces.Common": "[5.0.0]",
+          "System.Composition": "9.0.0"
+        }
+      },
+      "Microsoft.CodeAnalysis.Workspaces.Common": {
+        "type": "Transitive",
+        "resolved": "5.0.0",
+        "contentHash": "ZbUmIvT6lqTNKiv06Jl5wf0MTMi1vQ1oH7ou4CLcs2C/no/L7EhP3T8y3XXvn9VbqMcJaJnEsNA1jwYUMgc5jg==",
+        "dependencies": {
+          "Humanizer.Core": "2.14.1",
+          "Microsoft.CodeAnalysis.Analyzers": "3.11.0",
+          "Microsoft.CodeAnalysis.Common": "[5.0.0]",
+          "System.Composition": "9.0.0"
+        }
+      },
+      "Microsoft.CodeAnalysis.Workspaces.MSBuild": {
+        "type": "Transitive",
+        "resolved": "5.0.0",
+        "contentHash": "/G+LVoAGMz6Ae8nm+PGLxSw+F5RjYx/J7irbTO5uKAPw1bxHyQJLc/YOnpDxt+EpPtYxvC9wvBsg/kETZp1F9Q==",
+        "dependencies": {
+          "Humanizer.Core": "2.14.1",
+          "Microsoft.Build.Framework": "17.11.31",
+          "Microsoft.CodeAnalysis.Analyzers": "3.11.0",
+          "Microsoft.CodeAnalysis.Workspaces.Common": "[5.0.0]",
+          "Microsoft.Extensions.DependencyInjection": "9.0.0",
+          "Microsoft.Extensions.Logging": "9.0.0",
+          "Microsoft.Extensions.Logging.Abstractions": "9.0.0",
+          "Microsoft.Extensions.Options": "9.0.0",
+          "Microsoft.Extensions.Primitives": "9.0.0",
+          "Microsoft.VisualStudio.SolutionPersistence": "1.0.52",
+          "Newtonsoft.Json": "13.0.3",
+          "System.Composition": "9.0.0"
+        }
+      },
+      "Microsoft.CodeCoverage": {
+        "type": "Transitive",
+        "resolved": "18.8.1",
+        "contentHash": "Eclse/ZZjr4lmWzZFNN9h/OluhKL+SK/QbUyKUewgX139aGeyMEO/DkMPwuFs2MixvanTnz6891rF8UHDg+W4Q=="
+      },
+      "Microsoft.EntityFrameworkCore.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.10",
+        "contentHash": "bOzrFCl6uZCjaSh2bG1ToRQRdx+iXvxosCg9hFyG9OWeAzOFI4xev9OqKeWfKf/kAHyox2JnbcvLVf2ceA7sqA=="
+      },
+      "Microsoft.EntityFrameworkCore.Analyzers": {
+        "type": "Transitive",
+        "resolved": "10.0.10",
+        "contentHash": "2gLDordUCGf3aNOOuqtTbP5mxhiP9nk6TnvGiE3RnqT891O+Zf/qKu1PIREubs1M16A0SImr4vULBfU5BTDs1Q=="
+      },
+      "Microsoft.Extensions.Caching.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.10",
+        "contentHash": "4ZFBNE+jzR+CrWWlhOesnmywCW7pYKT0dxyAQRdL11yJwxe4jvcAu31eorFtEkoFeCDcUTeNssgPv2yaRRptaQ==",
+        "dependencies": {
+          "Microsoft.Extensions.Primitives": "10.0.10"
+        }
+      },
+      "Microsoft.Extensions.Caching.Memory": {
+        "type": "Transitive",
+        "resolved": "10.0.10",
+        "contentHash": "N1w5H7uK6gCTnCBZAWzE0/EQYSPysij/uYwDqntqBVvBa6bjMmBKitsnEFd6yh/SX3wLm67nO6+OnZ84K+gZWg==",
+        "dependencies": {
+          "Microsoft.Extensions.Caching.Abstractions": "10.0.10",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.10",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.10",
+          "Microsoft.Extensions.Options": "10.0.10",
+          "Microsoft.Extensions.Primitives": "10.0.10"
+        }
+      },
+      "Microsoft.Extensions.Configuration": {
+        "type": "Transitive",
+        "resolved": "10.0.10",
+        "contentHash": "plJWK2zpWuuyxI8F8s2scx6Je7N1Ajjs6HvYUGKwRnDMWIVIz9FHwAkiT7ASgrvAOd10T0FPVlh9BzAJJME+jg==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.10",
+          "Microsoft.Extensions.Primitives": "10.0.10"
+        }
+      },
+      "Microsoft.Extensions.Configuration.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.10",
+        "contentHash": "5Vnd2I75DmZCVEjSynIdJ/0EGafgnLQwgR3t2C2/fkjx/nRG+cLwxLLdInoHeCEpkD5K4Ov/g9ZCRYrl4TRsaA==",
+        "dependencies": {
+          "Microsoft.Extensions.Primitives": "10.0.10"
+        }
+      },
+      "Microsoft.Extensions.Configuration.Binder": {
+        "type": "Transitive",
+        "resolved": "10.0.10",
+        "contentHash": "GqmN2o1CkJvk7uWp+p4CwBYW0w/zfoEbvsiFDbO2G8l1Uz+mrDAbAcZiXhU2lufKPby1cjAUdd5GTWpebYOkOA==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.10",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.10"
+        }
+      },
+      "Microsoft.Extensions.Configuration.CommandLine": {
+        "type": "Transitive",
+        "resolved": "10.0.10",
+        "contentHash": "33cBeR2HRbzHUTtmcmLdNOApneNGcymwwL4arHuotgVK9Frba8kcDTrvVTj7cSCmF1R9OiSbZH0KxNOwab3HUg==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.10",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.10"
+        }
+      },
+      "Microsoft.Extensions.Configuration.EnvironmentVariables": {
+        "type": "Transitive",
+        "resolved": "10.0.10",
+        "contentHash": "KRfFSSCV58vEdU7mPED/YMzeovIWF5P0g8s9K8n9HEfy0/WzMq37SrPdXdFN5/dFT/rPMHpF7AvpoXHckbcBFg==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.10",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.10"
+        }
+      },
+      "Microsoft.Extensions.Configuration.FileExtensions": {
+        "type": "Transitive",
+        "resolved": "10.0.10",
+        "contentHash": "ZOhZYwvbXGTgGVRwswIirofEMVHuWdxjdh0JeUZXwaF9cgcjXdz/t0ELtgaevw7ezTyv47yPNCgGreWtLkn3IQ==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.10",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.10",
+          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.10",
+          "Microsoft.Extensions.FileProviders.Physical": "10.0.10",
+          "Microsoft.Extensions.Primitives": "10.0.10"
+        }
+      },
+      "Microsoft.Extensions.Configuration.Json": {
+        "type": "Transitive",
+        "resolved": "10.0.10",
+        "contentHash": "uvJ6sHwjgrkMEJOgiC76G0mcZGXerwyyWkwX34EOjCbxKG6TCtfAoqDKAMsCvEBf9HxjlGQEgqsSMOGCmGBf+A==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.10",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.10",
+          "Microsoft.Extensions.Configuration.FileExtensions": "10.0.10",
+          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.10"
+        }
+      },
+      "Microsoft.Extensions.Configuration.UserSecrets": {
+        "type": "Transitive",
+        "resolved": "10.0.10",
+        "contentHash": "1s1sKFTk/Foam64JY6+m/diH8drL3Wx6V3gtSd5v1IEZtszZYyc1pW8uRnMblzpNiR0l0t8gGk7tXj3xHzFgdg==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.10",
+          "Microsoft.Extensions.Configuration.Json": "10.0.10",
+          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.10",
+          "Microsoft.Extensions.FileProviders.Physical": "10.0.10"
+        }
+      },
+      "Microsoft.Extensions.DependencyInjection": {
+        "type": "Transitive",
+        "resolved": "10.0.10",
+        "contentHash": "ANyvsgkNBRvcJh2XLgn8veGmajf+8m0AbKK+HPWdRL1yraSNVVSmQhFntLtdz/C795jxqqup+k05cs/3jZQPOA==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.10"
+        }
+      },
+      "Microsoft.Extensions.DependencyInjection.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.10",
+        "contentHash": "z/2xXlFw2aLGjHyEm6E0tQ+In6VfzQzTrtArbQ2c0TQE16ZbyDCMGPvaUT9I0s8rgy9sRWlU2P9waW37qV04qA=="
+      },
+      "Microsoft.Extensions.DependencyModel": {
+        "type": "Transitive",
+        "resolved": "10.0.10",
+        "contentHash": "rfZA1RjR021RPqSmIPovfz2aOd79TGqJ9BengbjnzIISOVwjLmuSDnhCMmiY/1c6iYvGolQ1iNGzkav0u11XEA=="
+      },
+      "Microsoft.Extensions.Diagnostics": {
+        "type": "Transitive",
+        "resolved": "10.0.10",
+        "contentHash": "Kr/e7lUf4+N8tacbqJ2Ctwe/HarKdAc9ZkgKVVqvtJDBKbez+T/KnUwu82KSlnBp/SrpBcxc7u7xkE2oUZT/5Q==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.10",
+          "Microsoft.Extensions.Diagnostics.Abstractions": "10.0.10",
+          "Microsoft.Extensions.Options.ConfigurationExtensions": "10.0.10"
+        }
+      },
+      "Microsoft.Extensions.Diagnostics.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.10",
+        "contentHash": "9uWiKpeOVac355STyChWR/pliFX/5CeLqChW9kKsaxyDH4EUTZxMkT4Jwp/J/peLm0GBFmSX5c0WCse3yCnq1Q==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.10",
+          "Microsoft.Extensions.Options": "10.0.10"
+        }
+      },
+      "Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "jAhZbzDa117otUBMuQQ6JzSfuDbBBrfOs5jw5l7l9hKpzt+LjYKVjSauXG2yV9u7BqUSLUtKLwcerDQDeQ+0Xw=="
+      },
+      "Microsoft.Extensions.FileProviders.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.10",
+        "contentHash": "c5zqFCY9DiIpMovLd7/d/CTiEtrMOuQ639dhv3PABtKQIKNQikSHwQt8+N679uii9q+B55lgK28Uv64FOwEu8w==",
+        "dependencies": {
+          "Microsoft.Extensions.Primitives": "10.0.10"
+        }
+      },
+      "Microsoft.Extensions.FileProviders.Physical": {
+        "type": "Transitive",
+        "resolved": "10.0.10",
+        "contentHash": "jhJAyo38kSrH3ARvWUk0h8itogVnQu2DCZuPo+s0Z+tXes0ugTxMPaHYzap85785eHQmPFqD9TYERqBbtGxn/w==",
+        "dependencies": {
+          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.10",
+          "Microsoft.Extensions.FileSystemGlobbing": "10.0.10",
+          "Microsoft.Extensions.Primitives": "10.0.10"
+        }
+      },
+      "Microsoft.Extensions.FileSystemGlobbing": {
+        "type": "Transitive",
+        "resolved": "10.0.10",
+        "contentHash": "jSOCVxEwCd4Aq925kJVz1kSO1EpX2OHYKL04qVREXkDU7Ce3pVDdHPYm+fEy8y/th2kJf/DAstRHpJAqoNWP8w=="
+      },
+      "Microsoft.Extensions.Hosting": {
+        "type": "Transitive",
+        "resolved": "10.0.10",
+        "contentHash": "tL9FkfV64GPUDSPvwrgyw42LVzsnVAnyrqJEuZVJbODgrQ3eL63zmzEcVWoCHzfgqUhWggzbgAyUCnz/zfI3Pg==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.10",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.10",
+          "Microsoft.Extensions.Configuration.Binder": "10.0.10",
+          "Microsoft.Extensions.Configuration.CommandLine": "10.0.10",
+          "Microsoft.Extensions.Configuration.EnvironmentVariables": "10.0.10",
+          "Microsoft.Extensions.Configuration.FileExtensions": "10.0.10",
+          "Microsoft.Extensions.Configuration.Json": "10.0.10",
+          "Microsoft.Extensions.Configuration.UserSecrets": "10.0.10",
+          "Microsoft.Extensions.DependencyInjection": "10.0.10",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.10",
+          "Microsoft.Extensions.Diagnostics": "10.0.10",
+          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.10",
+          "Microsoft.Extensions.FileProviders.Physical": "10.0.10",
+          "Microsoft.Extensions.Hosting.Abstractions": "10.0.10",
+          "Microsoft.Extensions.Logging": "10.0.10",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.10",
+          "Microsoft.Extensions.Logging.Configuration": "10.0.10",
+          "Microsoft.Extensions.Logging.Console": "10.0.10",
+          "Microsoft.Extensions.Logging.Debug": "10.0.10",
+          "Microsoft.Extensions.Logging.EventLog": "10.0.10",
+          "Microsoft.Extensions.Logging.EventSource": "10.0.10",
+          "Microsoft.Extensions.Options": "10.0.10"
+        }
+      },
+      "Microsoft.Extensions.Hosting.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.10",
+        "contentHash": "5LugpYGHk+mkn0a8IZgcyfBca8PCTAU9RQFoMrTdtOOidq88M2SI5f3px6ugnzgxC+eTkvYYJi8pzlUnG5xdAQ==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.10",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.10",
+          "Microsoft.Extensions.Diagnostics.Abstractions": "10.0.10",
+          "Microsoft.Extensions.FileProviders.Abstractions": "10.0.10",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.10"
+        }
+      },
+      "Microsoft.Extensions.Logging": {
+        "type": "Transitive",
+        "resolved": "10.0.10",
+        "contentHash": "Tf6z5HsL0VDYRTfvsoNrTGHGheCwkTsZBA2FFh5ATJUbkAwug+FFNISJK2gjpUNemlAOoWllAK52HOWCjto3EQ==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection": "10.0.10",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.10",
+          "Microsoft.Extensions.Options": "10.0.10"
+        }
+      },
+      "Microsoft.Extensions.Logging.Configuration": {
+        "type": "Transitive",
+        "resolved": "10.0.10",
+        "contentHash": "cLrqxkuEfcilZ8SjK+9KAnpLk9lOoMPaOokF+wRUYie+iUEcdX4/p/+gJkt0BYgWLthjpBUCkVTBI6Kxg0nsOw==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.10",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.10",
+          "Microsoft.Extensions.Configuration.Binder": "10.0.10",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.10",
+          "Microsoft.Extensions.Logging": "10.0.10",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.10",
+          "Microsoft.Extensions.Options": "10.0.10",
+          "Microsoft.Extensions.Options.ConfigurationExtensions": "10.0.10"
+        }
+      },
+      "Microsoft.Extensions.Logging.Console": {
+        "type": "Transitive",
+        "resolved": "10.0.10",
+        "contentHash": "VIlNzPwPS0GeQVSmCqqo36ugryX3LpE9ul6gEkks5VLET3weH/XMLeWmclwfoGn4Nxi2mwVibB+OZBVJ9tDqvg==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.10",
+          "Microsoft.Extensions.Logging": "10.0.10",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.10",
+          "Microsoft.Extensions.Logging.Configuration": "10.0.10",
+          "Microsoft.Extensions.Options": "10.0.10"
+        }
+      },
+      "Microsoft.Extensions.Logging.Debug": {
+        "type": "Transitive",
+        "resolved": "10.0.10",
+        "contentHash": "8+TZBnV5fgBXoVNJ5ROSErUwYogk4hOgV7c2HWK1u5cqKGmiUTUn7+KqZ35iQu8e/B7Ykccyz5OTjdXcidNZ9g==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.10",
+          "Microsoft.Extensions.Logging": "10.0.10",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.10"
+        }
+      },
+      "Microsoft.Extensions.Logging.EventLog": {
+        "type": "Transitive",
+        "resolved": "10.0.10",
+        "contentHash": "0RE4951AzQ+YD4gVrvbq0BhdsiBgSDo44yM7+QBZ2mrmMJeNjY+teCIYfUjqDPVYnKs0HR6SkkhgrX1YgXZq3Q==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.10",
+          "Microsoft.Extensions.Logging": "10.0.10",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.10",
+          "Microsoft.Extensions.Options": "10.0.10",
+          "System.Diagnostics.EventLog": "10.0.10"
+        }
+      },
+      "Microsoft.Extensions.Logging.EventSource": {
+        "type": "Transitive",
+        "resolved": "10.0.10",
+        "contentHash": "85SAPwXhJtdBInzN2k7SChiFiBGh3KOWay5AfoY+GREF6P7oZA98+ST2p7Z9384iLKYjkZSKIZ/FqIO5aojtNw==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.10",
+          "Microsoft.Extensions.Logging": "10.0.10",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.10",
+          "Microsoft.Extensions.Options": "10.0.10",
+          "Microsoft.Extensions.Primitives": "10.0.10"
+        }
+      },
+      "Microsoft.Extensions.ObjectPool": {
+        "type": "Transitive",
+        "resolved": "10.0.2",
+        "contentHash": "kpCp4m7nwJVBcRKWXYHdVK/W0dkKyyFOjCmKVdO+zKThWvUxP1V+jVEP9FGpqRu4GPl9041SEXu2f+U/l825nQ=="
+      },
+      "Microsoft.Extensions.Options": {
+        "type": "Transitive",
+        "resolved": "10.0.10",
+        "contentHash": "srnhnk7nE8krBiIXp71LvBmKBtraBONWSRzdjJgRv1Ko9Mp8IVNqv4vIS9hGeVteBig8aQkva9ZG+sC+o5sVcA==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.10",
+          "Microsoft.Extensions.Primitives": "10.0.10"
+        }
+      },
+      "Microsoft.Extensions.Options.ConfigurationExtensions": {
+        "type": "Transitive",
+        "resolved": "10.0.10",
+        "contentHash": "tnBmu/LwF25ZQK+HBNCu2xrwnkKoB/XEbJyooGGoYxHrhvxbSKi7eOFiJ4AXBy/QU4vtCvCJfoi8k9Ej72qzOQ==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.10",
+          "Microsoft.Extensions.Configuration.Binder": "10.0.10",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.10",
+          "Microsoft.Extensions.Options": "10.0.10",
+          "Microsoft.Extensions.Primitives": "10.0.10"
+        }
+      },
+      "Microsoft.Extensions.Primitives": {
+        "type": "Transitive",
+        "resolved": "10.0.10",
+        "contentHash": "5wu/GrYVd8mG2DVUw3vFJzF+O336TyTGg/Kmcgw9bfwYhCoFiV5lR5QeEmKecJyrW4W54nMfD3p3589E8a7czQ=="
+      },
+      "Microsoft.IdentityModel.Abstractions": {
+        "type": "Transitive",
+        "resolved": "8.0.1",
+        "contentHash": "OtlIWcyX01olfdevPKZdIPfBEvbcioDyBiE/Z2lHsopsMD7twcKtlN9kMevHmI5IIPhFpfwCIiR6qHQz1WHUIw=="
+      },
+      "Microsoft.IdentityModel.JsonWebTokens": {
+        "type": "Transitive",
+        "resolved": "8.0.1",
+        "contentHash": "s6++gF9x0rQApQzOBbSyp4jUaAlwm+DroKfL8gdOHxs83k8SJfUXhuc46rDB3rNXBQ1MVRxqKUrqFhO/M0E97g==",
+        "dependencies": {
+          "Microsoft.IdentityModel.Tokens": "8.0.1"
+        }
+      },
+      "Microsoft.IdentityModel.Logging": {
+        "type": "Transitive",
+        "resolved": "8.0.1",
+        "contentHash": "UCPF2exZqBXe7v/6sGNiM6zCQOUXXQ9+v5VTb9gPB8ZSUPnX53BxlN78v2jsbIvK9Dq4GovQxo23x8JgWvm/Qg==",
+        "dependencies": {
+          "Microsoft.IdentityModel.Abstractions": "8.0.1"
+        }
+      },
+      "Microsoft.IdentityModel.Protocols": {
+        "type": "Transitive",
+        "resolved": "8.0.1",
+        "contentHash": "uA2vpKqU3I2mBBEaeJAWPTjT9v1TZrGWKdgK6G5qJd03CLx83kdiqO9cmiK8/n1erkHzFBwU/RphP83aAe3i3g==",
+        "dependencies": {
+          "Microsoft.IdentityModel.Tokens": "8.0.1"
+        }
+      },
+      "Microsoft.IdentityModel.Protocols.OpenIdConnect": {
+        "type": "Transitive",
+        "resolved": "8.0.1",
+        "contentHash": "AQDbfpL+yzuuGhO/mQhKNsp44pm5Jv8/BI4KiFXR7beVGZoSH35zMV3PrmcfvSTsyI6qrcR898NzUauD6SRigg==",
+        "dependencies": {
+          "Microsoft.IdentityModel.Protocols": "8.0.1",
+          "System.IdentityModel.Tokens.Jwt": "8.0.1"
+        }
+      },
+      "Microsoft.IdentityModel.Tokens": {
+        "type": "Transitive",
+        "resolved": "8.0.1",
+        "contentHash": "kDimB6Dkd3nkW2oZPDkMkVHfQt3IDqO5gL0oa8WVy3OP4uE8Ij+8TXnqg9TOd9ufjsY3IDiGz7pCUbnfL18tjg==",
+        "dependencies": {
+          "Microsoft.IdentityModel.Logging": "8.0.1"
+        }
+      },
+      "Microsoft.TestPlatform.ObjectModel": {
+        "type": "Transitive",
+        "resolved": "18.8.1",
+        "contentHash": "qLbktNB1+b1XZLNJBTzaWVVJAd6PEzD7cgD406geMb6PcFZhp3EDNa1tctWx1+mtMU6MP/6ozVvFPC9vs2a9rw=="
+      },
+      "Microsoft.TestPlatform.TestHost": {
+        "type": "Transitive",
+        "resolved": "18.8.1",
+        "contentHash": "FaQHPDTUOcE+SFTjssNPfrub2lT9Zyon4J2W/KLHt/efLJACb1TCeWXyOgh0D/4Q1e4n+S3E6mOKud+9nLZlEA==",
+        "dependencies": {
+          "Microsoft.TestPlatform.ObjectModel": "18.8.1"
+        }
+      },
+      "Microsoft.VisualStudio.SolutionPersistence": {
+        "type": "Transitive",
+        "resolved": "1.0.52",
+        "contentHash": "oNv2JtYXhpdJrX63nibx1JT3uCESOBQ1LAk7Dtz/sr0+laW0KRM6eKp4CZ3MHDR2siIkKsY8MmUkeP5DKkQQ5w=="
+      },
+      "Mono.TextTemplating": {
+        "type": "Transitive",
+        "resolved": "3.0.0",
+        "contentHash": "YqueG52R/Xej4VVbKuRIodjiAhV0HR/XVbLbNrJhCZnzjnSjgMJ/dCdV0akQQxavX6hp/LC6rqLGLcXeQYU7XA==",
+        "dependencies": {
+          "System.CodeDom": "6.0.0"
+        }
+      },
+      "MR.EntityFrameworkCore.KeysetPagination.Analyzers": {
+        "type": "Transitive",
+        "resolved": "1.6.0",
+        "contentHash": "uMUw8PKG8C5chT3Yu5bPIsSZIBSLhvSwVOM02jQ8P6ZOwaDg/l+AsYHccom1lG9/ye85N0ZPbHTcbpXHs42O0A=="
+      },
+      "Namotion.Reflection": {
+        "type": "Transitive",
+        "resolved": "3.1.1",
+        "contentHash": "Qn0wM7u9TpSpja2x8UVexr2bLHb1DGMNhD2TCz3woklxaY1oH+Sitrw9fg/4YbNoNtczeH2jf+yPdXMQlgvFlQ=="
+      },
+      "NetTopologySuite": {
+        "type": "Transitive",
+        "resolved": "2.5.0",
+        "contentHash": "5/+2O2ADomEdUn09mlSigACdqvAf0m/pVPGtIPEPQWnyrVykYY0NlfXLIdkMgi41kvH9kNrPqYaFBTZtHYH7Xw=="
+      },
+      "NetTopologySuite.IO.PostGis": {
+        "type": "Transitive",
+        "resolved": "2.1.0",
+        "contentHash": "3W8XTFz8iP6GQ5jDXK1/LANHiU+988k1kmmuPWNKcJLpmSg6CvFpbTpz+s4+LBzkAp64wHGOldSlkSuzYfrIKA==",
+        "dependencies": {
+          "NetTopologySuite": "[2.0.0, 3.0.0-A)"
+        }
+      },
+      "NewId": {
+        "type": "Transitive",
+        "resolved": "4.0.1",
+        "contentHash": "jegBasNndmG21G3BmT51suFDCIz/sLN81j+IxmkZ4iWoaDi8LygeHiyNnYbXz5OQh9nCRJFIx1+PJrlYi1Gc9Q=="
+      },
+      "Newtonsoft.Json": {
+        "type": "Transitive",
+        "resolved": "13.0.3",
+        "contentHash": "HrC5BXdl00IP9zeV+0Z848QWPAoCr9P3bDEZguI+gkLcBKAOxix/tLEAAHC+UvDNPv4a2d18lOReHMOagPa+zQ=="
+      },
+      "NJsonSchema": {
+        "type": "Transitive",
+        "resolved": "11.0.2",
+        "contentHash": "BOgw+TOd1w7BSRIEWwkiSgHlKWC2eu0DHsSsb1LIwlC1Hq26A0ARZiMjsCsqfXqXdr7hLf1m4M84Z7LW1wmCGA==",
+        "dependencies": {
+          "NJsonSchema.Annotations": "11.0.2",
+          "Namotion.Reflection": "3.1.1",
+          "Newtonsoft.Json": "13.0.3"
+        }
+      },
+      "NJsonSchema.Annotations": {
+        "type": "Transitive",
+        "resolved": "11.0.2",
+        "contentHash": "VbA0fmxVyqloGXYz863g6QHyojM1tgejwPQr9LjXdubs9YJt5YfRPCQOV/hnzpP2Bqd7nZFpDn9MCImmLAmqCw=="
+      },
+      "NJsonSchema.NewtonsoftJson": {
+        "type": "Transitive",
+        "resolved": "11.0.2",
+        "contentHash": "tTVG8h7qfw6anxlhXGx3oUz7f3ig+t9jO3yrho73ypvMZ7DCyFtiaF5gG3GqBDZXM49ONogDmTZ+8HTG6AKaNQ==",
+        "dependencies": {
+          "NJsonSchema": "11.0.2",
+          "Newtonsoft.Json": "13.0.3"
+        }
+      },
+      "Npgsql.NetTopologySuite": {
+        "type": "Transitive",
+        "resolved": "9.0.4",
+        "contentHash": "7AwBLPz8EPmgAXveZ55K0Tz/9bNb8j4VI4pkTOQjyHrce8wWfAA9pefm3REidy+Kt2UFiAWef34YVi7sb/kB4A==",
+        "dependencies": {
+          "NetTopologySuite": "2.5.0",
+          "NetTopologySuite.IO.PostGIS": "2.1.0",
+          "Npgsql": "9.0.4"
+        }
+      },
+      "OpenTelemetry": {
+        "type": "Transitive",
+        "resolved": "1.17.0",
+        "contentHash": "rMLOTftlMlTm7+MSrvXDHnJRjVkROFNKXHZrYjOsX+LankaFG7QSflx7qRRGjoqZoirohnxmJQ7GEb9occO4Gg==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.EnvironmentVariables": "10.0.0",
+          "Microsoft.Extensions.Diagnostics.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Logging.Configuration": "10.0.0",
+          "OpenTelemetry.Api.ProviderBuilderExtensions": "1.17.0"
+        }
+      },
+      "OpenTelemetry.Api": {
+        "type": "Transitive",
+        "resolved": "1.17.0",
+        "contentHash": "mSBxzomZgHIJu9CyVNqyDu/n2JHEtqVgfcCD1Br0cV5iLYogjZOMqhlVLt99PEp+0KGBNUR3GXgeOdN2GR3F9g=="
+      },
+      "OpenTelemetry.Api.ProviderBuilderExtensions": {
+        "type": "Transitive",
+        "resolved": "1.17.0",
+        "contentHash": "Xgc3Qf9B9TFMFpx6exTdGqMWuYIT2miNzkdMPutVvT9YuMFaEovXWke1Gb6z8NxYaQbbGF38vYLuSg1JCeui5Q==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.0",
+          "OpenTelemetry.Api": "1.17.0"
+        }
+      },
+      "Pipelines.Sockets.Unofficial": {
+        "type": "Transitive",
+        "resolved": "2.2.8",
+        "contentHash": "zG2FApP5zxSx6OcdJQLbZDk2AVlN2BNQD6MorwIfV6gVj0RRxWPEp2LXAxqDGZqeNV1Zp0BNPcNaey/GXmTdvQ=="
+      },
+      "Polly.Core": {
+        "type": "Transitive",
+        "resolved": "8.6.5",
+        "contentHash": "t+sUVrIwvo7UmsgHGgOG9F0GDZSRIm47u2ylH17Gvcv1q5hNEwgD5GoBlFyc0kh/pebmPyrAgvGsR/65ZBaXlg=="
+      },
+      "Serilog": {
+        "type": "Transitive",
+        "resolved": "4.3.0",
+        "contentHash": "+cDryFR0GRhsGOnZSKwaDzRRl4MupvJ42FhCE4zhQRVanX0Jpg6WuCBk59OVhVDPmab1bB+nRykAnykYELA9qQ=="
+      },
+      "Serilog.Extensions.Hosting": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "E7juuIc+gzoGxgzFooFgAV8g9BfiSXNKsUok9NmEpyAXg2odkcPsMa/Yo4axkJRlh0se7mkYQ1GXDaBemR+b6w==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Hosting.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.0",
+          "Serilog": "4.3.0",
+          "Serilog.Extensions.Logging": "10.0.0"
+        }
+      },
+      "Serilog.Extensions.Logging": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "vx0kABKl2dWbBhhqAfTOk53/i8aV/5VaT3a6il9gn72Wqs2pM7EK2OB6No6xdqK2IaY6Zf9gdjLuK9BVa2rT+Q==",
+        "dependencies": {
+          "Microsoft.Extensions.Logging": "10.0.0",
+          "Serilog": "4.2.0"
+        }
+      },
+      "Serilog.Formatting.Compact": {
+        "type": "Transitive",
+        "resolved": "3.0.0",
+        "contentHash": "wQsv14w9cqlfB5FX2MZpNsTawckN4a8dryuNGbebB/3Nh1pXnROHZov3swtu3Nj5oNG7Ba+xdu7Et/ulAUPanQ==",
+        "dependencies": {
+          "Serilog": "4.0.0"
+        }
+      },
+      "Serilog.Settings.Configuration": {
+        "type": "Transitive",
+        "resolved": "10.0.0",
+        "contentHash": "LNq+ibS1sbhTqPV1FIE69/9AJJbfaOhnaqkzcjFy95o+4U+STsta9mi97f1smgXsWYKICDeGUf8xUGzd/52/uA==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration.Binder": "10.0.0",
+          "Microsoft.Extensions.DependencyModel": "10.0.0",
+          "Serilog": "4.3.0"
+        }
+      },
+      "Serilog.Sinks.Console": {
+        "type": "Transitive",
+        "resolved": "6.1.1",
+        "contentHash": "8jbqgjUyZlfCuSTaJk6lOca465OndqOz3KZP6Cryt/IqZYybyBu7GP0fE/AXBzrrQB3EBmQntBFAvMVz1COvAA==",
+        "dependencies": {
+          "Serilog": "4.0.0"
+        }
+      },
+      "Serilog.Sinks.Debug": {
+        "type": "Transitive",
+        "resolved": "3.0.0",
+        "contentHash": "4BzXcdrgRX7wde9PmHuYd9U6YqycCC28hhpKonK7hx0wb19eiuRj16fPcPSVp0o/Y1ipJuNLYQ00R3q2Zs8FDA==",
+        "dependencies": {
+          "Serilog": "4.0.0"
+        }
+      },
+      "Serilog.Sinks.File": {
+        "type": "Transitive",
+        "resolved": "7.0.0",
+        "contentHash": "fKL7mXv7qaiNBUC71ssvn/dU0k9t0o45+qm2XgKAlSt19xF+ijjxyA3R6HmCgfKEKwfcfkwWjayuQtRueZFkYw==",
+        "dependencies": {
+          "Serilog": "4.2.0"
+        }
+      },
+      "SharpZipLib": {
+        "type": "Transitive",
+        "resolved": "1.4.2",
+        "contentHash": "yjj+3zgz8zgXpiiC3ZdF/iyTBbz2fFvMxZFEBPUcwZjIvXOf37Ylm+K58hqMfIBt5JgU/Z2uoUS67JmTLe973A=="
+      },
+      "Spectre.Console": {
+        "type": "Transitive",
+        "resolved": "0.55.0",
+        "contentHash": "2TVhUHFsDux0Z+y2Hv4bFsOMuON4SuotEEKkMparFkp5Rm259naaaEQrN4Sv6C1cbsiGKPjfkJDGgUp+hZPjTw==",
+        "dependencies": {
+          "Spectre.Console.Ansi": "0.55.0"
+        }
+      },
+      "Spectre.Console.Ansi": {
+        "type": "Transitive",
+        "resolved": "0.55.0",
+        "contentHash": "GIfgOvuF8MpU52bprhwtDEtx0gmVIGOepM8bw0lH/TSMD0rg1Xp+5Y53kPG8rFVdcpbNANlhDQ5mEVVPO3/2Tg=="
+      },
+      "SSH.NET": {
+        "type": "Transitive",
+        "resolved": "2025.1.0",
+        "contentHash": "jrnbtf0ItVaXAe6jE8X/kSLa6uC+0C+7W1vepcnRQB/rD88qy4IxG7Lf1FIbWmkoc4iVXv0pKrz+Wc6J4ngmHw==",
+        "dependencies": {
+          "BouncyCastle.Cryptography": "2.6.2",
+          "Microsoft.Extensions.Logging.Abstractions": "8.0.3"
+        }
+      },
+      "System.CodeDom": {
+        "type": "Transitive",
+        "resolved": "8.0.0",
+        "contentHash": "WTlRjL6KWIMr/pAaq3rYqh0TJlzpouaQ/W1eelssHgtlwHAH25jXTkUphTYx9HaIIf7XA6qs/0+YhtLEQRkJ+Q=="
+      },
+      "System.Composition": {
+        "type": "Transitive",
+        "resolved": "9.0.0",
+        "contentHash": "3Djj70fFTraOarSKmRnmRy/zm4YurICm+kiCtI0dYRqGJnLX6nJ+G3WYuFJ173cAPax/gh96REcbNiVqcrypFQ==",
+        "dependencies": {
+          "System.Composition.AttributedModel": "9.0.0",
+          "System.Composition.Convention": "9.0.0",
+          "System.Composition.Hosting": "9.0.0",
+          "System.Composition.Runtime": "9.0.0",
+          "System.Composition.TypedParts": "9.0.0"
+        }
+      },
+      "System.Composition.AttributedModel": {
+        "type": "Transitive",
+        "resolved": "9.0.0",
+        "contentHash": "iri00l/zIX9g4lHMY+Nz0qV1n40+jFYAmgsaiNn16xvt2RDwlqByNG4wgblagnDYxm3YSQQ0jLlC/7Xlk9CzyA=="
+      },
+      "System.Composition.Convention": {
+        "type": "Transitive",
+        "resolved": "9.0.0",
+        "contentHash": "+vuqVP6xpi582XIjJi6OCsIxuoTZfR0M7WWufk3uGDeCl3wGW6KnpylUJ3iiXdPByPE0vR5TjJgR6hDLez4FQg==",
+        "dependencies": {
+          "System.Composition.AttributedModel": "9.0.0"
+        }
+      },
+      "System.Composition.Hosting": {
+        "type": "Transitive",
+        "resolved": "9.0.0",
+        "contentHash": "OFqSeFeJYr7kHxDfaViGM1ymk7d4JxK//VSoNF9Ux0gpqkLsauDZpu89kTHHNdCWfSljbFcvAafGyBoY094btQ==",
+        "dependencies": {
+          "System.Composition.Runtime": "9.0.0"
+        }
+      },
+      "System.Composition.Runtime": {
+        "type": "Transitive",
+        "resolved": "9.0.0",
+        "contentHash": "w1HOlQY1zsOWYussjFGZCEYF2UZXgvoYnS94NIu2CBnAGMbXFAX8PY8c92KwUItPmowal68jnVLBCzdrWLeEKA=="
+      },
+      "System.Composition.TypedParts": {
+        "type": "Transitive",
+        "resolved": "9.0.0",
+        "contentHash": "aRZlojCCGEHDKqh43jaDgaVpYETsgd7Nx4g1zwLKMtv4iTo0627715ajEFNpEEBTgLmvZuv8K0EVxc3sM4NWJA==",
+        "dependencies": {
+          "System.Composition.AttributedModel": "9.0.0",
+          "System.Composition.Hosting": "9.0.0",
+          "System.Composition.Runtime": "9.0.0"
+        }
+      },
+      "System.Diagnostics.EventLog": {
+        "type": "Transitive",
+        "resolved": "10.0.10",
+        "contentHash": "OvGz3PrzuAI/Sj7LTcXcCe3FClRI1IyRMZjNONcZtFh+Ww7nAtSh4kh08r8KVe/xxkXJPjR0Y1jF7H+N42d4xQ=="
+      },
+      "System.IdentityModel.Tokens.Jwt": {
+        "type": "Transitive",
+        "resolved": "8.0.1",
+        "contentHash": "GJw3bYkWpOgvN3tJo5X4lYUeIFA2HD293FPUhKmp7qxS+g5ywAb34Dnd3cDAFLkcMohy5XTpoaZ4uAHuw0uSPQ==",
+        "dependencies": {
+          "Microsoft.IdentityModel.JsonWebTokens": "8.0.1",
+          "Microsoft.IdentityModel.Tokens": "8.0.1"
+        }
+      },
+      "System.IO.Hashing": {
+        "type": "Transitive",
+        "resolved": "10.0.2",
+        "contentHash": "AKJknIFi9O3+rGExxTry188JPvUoZAPcCtS2qdqyFhIzsxQ1Ap94BeGDG0VzVEHakhmRxmJtVih6TsHoghIt/g=="
+      },
+      "System.Reactive": {
+        "type": "Transitive",
+        "resolved": "6.0.1",
+        "contentHash": "rHaWtKDwCi9qJ3ObKo8LHPMuuwv33YbmQi7TcUK1C264V3MFnOr5Im7QgCTdLniztP3GJyeiSg5x8NqYJFqRmg=="
+      },
+      "Weasel.Core": {
+        "type": "Transitive",
+        "resolved": "8.15.1",
+        "contentHash": "+X2GRJCVeC6VjA+REbtb9ULtAvVG4DT8Py0tffIRTPsA9IdY89fLu09MFkcnywgTzQK3JB4hKC7t8d9xwdp6jg==",
+        "dependencies": {
+          "JasperFx": "1.26.0"
+        }
+      },
+      "Weasel.EntityFrameworkCore": {
+        "type": "Transitive",
+        "resolved": "8.15.1",
+        "contentHash": "cTyg51eVPWduD1fbGgtvB3rDOiiVODGka9idHUbS4IUeHg0rK5bcNk67D2K0sxLkoq/bsOO2r46U1CtR9Jt1Gg==",
+        "dependencies": {
+          "Microsoft.EntityFrameworkCore.Relational": "10.0.0",
+          "Weasel.Core": "8.15.1"
+        }
+      },
+      "Weasel.Postgresql": {
+        "type": "Transitive",
+        "resolved": "8.15.1",
+        "contentHash": "YD/3CWlqCCX5dBVMZmIYvR8/flwcgDHPQq4EtUHJOlFnPrmQX4Lfd5rmFCIW3n/3F53qxMXl2HaJnxGI1Twtsw==",
+        "dependencies": {
+          "DistributedLock.Postgres": "1.3.0",
+          "Npgsql": "9.0.4",
+          "Npgsql.NetTopologySuite": "9.0.4",
+          "Weasel.Core": "8.15.1"
+        }
+      },
+      "WolverineFx.RDBMS": {
+        "type": "Transitive",
+        "resolved": "5.40.0",
+        "contentHash": "ZZaNnOQNP+DZ0444jSztqUIJBJ97fIaXWll2ouxgVTtKY89wlNoA0k/TyDvvF5+SSW1In4/bbFMzSRH479Rw4A==",
+        "dependencies": {
+          "Weasel.Core": "8.15.1",
+          "WolverineFx": "5.40.0"
+        }
+      },
+      "xunit.abstractions": {
+        "type": "Transitive",
+        "resolved": "2.0.3",
+        "contentHash": "pot1I4YOxlWjIb5jmwvvQNbTrZ3lJQ+jUGkGjWE3hEFM0l5gOnBWS+H3qsex68s5cO52g+44vpGzhAt+42vwKg=="
+      },
+      "xunit.analyzers": {
+        "type": "Transitive",
+        "resolved": "1.18.0",
+        "contentHash": "OtFMHN8yqIcYP9wcVIgJrq01AfTxijjAqVDy/WeQVSyrDC1RzBWeQPztL49DN2syXRah8TYnfvk035s7L95EZQ=="
+      },
+      "xunit.assert": {
+        "type": "Transitive",
+        "resolved": "2.9.3",
+        "contentHash": "/Kq28fCE7MjOV42YLVRAJzRF0WmEqsmflm0cfpMjGtzQ2lR5mYVj1/i0Y8uDAOLczkL3/jArrwehfMD0YogMAA=="
+      },
+      "xunit.core": {
+        "type": "Transitive",
+        "resolved": "2.9.3",
+        "contentHash": "BiAEvqGvyme19wE0wTKdADH+NloYqikiU0mcnmiNyXaF9HyHmE6sr/3DC5vnBkgsWaE6yPyWszKSPSApWdRVeQ==",
+        "dependencies": {
+          "xunit.extensibility.core": "[2.9.3]",
+          "xunit.extensibility.execution": "[2.9.3]"
+        }
+      },
+      "xunit.extensibility.core": {
+        "type": "Transitive",
+        "resolved": "2.9.3",
+        "contentHash": "kf3si0YTn2a8J8eZNb+zFpwfoyvIrQ7ivNk5ZYA5yuYk1bEtMe4DxJ2CF/qsRgmEnDr7MnW1mxylBaHTZ4qErA==",
+        "dependencies": {
+          "xunit.abstractions": "2.0.3"
+        }
+      },
+      "xunit.extensibility.execution": {
+        "type": "Transitive",
+        "resolved": "2.9.3",
+        "contentHash": "yMb6vMESlSrE3Wfj7V6cjQ3S4TXdXpRqYeNEI3zsX31uTsGMJjEw6oD5F5u1cHnMptjhEECnmZSsPxB6ChZHDQ==",
+        "dependencies": {
+          "xunit.extensibility.core": "[2.9.3]"
+        }
+      },
+      "unifesspa.uniplus.application.abstractions": {
+        "type": "Project",
+        "dependencies": {
+          "FluentValidation": "[12.1.1, )",
+          "Microsoft.Extensions.Logging.Abstractions": "[10.0.7, )",
+          "Unifesspa.UniPlus.Governance.Contracts": "[1.0.0, )",
+          "Unifesspa.UniPlus.Kernel": "[1.0.0, )"
+        }
+      },
+      "unifesspa.uniplus.governance.contracts": {
+        "type": "Project",
+        "dependencies": {
+          "Unifesspa.UniPlus.Kernel": "[1.0.0, )"
+        }
+      },
+      "unifesspa.uniplus.infrastructure.core": {
+        "type": "Project",
+        "dependencies": {
+          "Apache.Avro": "[1.12.1, )",
+          "Confluent.Kafka": "[2.15.0, )",
+          "Confluent.SchemaRegistry": "[2.15.0, )",
+          "Confluent.SchemaRegistry.Serdes.Avro": "[2.15.0, )",
+          "EFCore.NamingConventions": "[10.0.1, )",
+          "FluentValidation": "[12.1.1, )",
+          "MR.EntityFrameworkCore.KeysetPagination": "[1.6.0, )",
+          "Microsoft.AspNetCore.Authentication.JwtBearer": "[10.0.7, )",
+          "Microsoft.AspNetCore.OpenApi": "[10.0.7, )",
+          "Microsoft.EntityFrameworkCore": "[10.0.10, )",
+          "Microsoft.EntityFrameworkCore.Relational": "[10.0.10, )",
+          "Microsoft.OpenApi": "[2.7.5, )",
+          "Minio": "[7.0.0, )",
+          "Npgsql": "[10.0.3, )",
+          "Npgsql.EntityFrameworkCore.PostgreSQL": "[10.0.3, )",
+          "OpenTelemetry.Exporter.OpenTelemetryProtocol": "[1.17.0, )",
+          "OpenTelemetry.Extensions.Hosting": "[1.17.0, )",
+          "OpenTelemetry.Instrumentation.AspNetCore": "[1.17.0, )",
+          "OpenTelemetry.Instrumentation.EntityFrameworkCore": "[1.15.1-beta.1, )",
+          "OpenTelemetry.Instrumentation.Http": "[1.17.0, )",
+          "OpenTelemetry.Instrumentation.Runtime": "[1.17.0, )",
+          "Serilog.AspNetCore": "[10.0.0, )",
+          "Serilog.Sinks.OpenTelemetry": "[4.2.0, )",
+          "StackExchange.Redis": "[2.12.14, )",
+          "Unifesspa.UniPlus.Application.Abstractions": "[1.0.0, )",
+          "Unifesspa.UniPlus.Governance.Contracts": "[1.0.0, )",
+          "Unifesspa.UniPlus.Kernel": "[1.0.0, )",
+          "VaultSharp": "[1.17.5.1, )",
+          "WolverineFx": "[5.40.0, )",
+          "WolverineFx.EntityFrameworkCore": "[5.40.0, )",
+          "WolverineFx.FluentValidation": "[5.40.0, )",
+          "WolverineFx.Kafka": "[5.40.0, )",
+          "WolverineFx.Postgresql": "[5.40.0, )"
+        }
+      },
+      "unifesspa.uniplus.integrationtests.fixtures": {
+        "type": "Project",
+        "dependencies": {
+          "Microsoft.AspNetCore.Authentication.JwtBearer": "[10.0.7, )",
+          "Microsoft.AspNetCore.Mvc.Testing": "[10.0.10, )",
+          "Testcontainers": "[4.13.0, )",
+          "Unifesspa.UniPlus.Infrastructure.Core": "[1.0.0, )",
+          "WolverineFx": "[5.40.0, )",
+          "xunit": "[2.9.3, )"
+        }
+      },
+      "unifesspa.uniplus.kernel": {
+        "type": "Project"
+      },
+      "unifesspa.uniplus.portal.api": {
+        "type": "Project",
+        "dependencies": {
+          "FluentValidation": "[12.1.1, )",
+          "Microsoft.AspNetCore.OpenApi": "[10.0.7, )",
+          "Serilog.AspNetCore": "[10.0.0, )",
+          "Unifesspa.UniPlus.Portal.Infrastructure": "[1.0.0, )"
+        }
+      },
+      "unifesspa.uniplus.portal.domain": {
+        "type": "Project",
+        "dependencies": {
+          "Unifesspa.UniPlus.Kernel": "[1.0.0, )"
+        }
+      },
+      "unifesspa.uniplus.portal.infrastructure": {
+        "type": "Project",
+        "dependencies": {
+          "Microsoft.EntityFrameworkCore": "[10.0.10, )",
+          "Microsoft.EntityFrameworkCore.Relational": "[10.0.10, )",
+          "Npgsql.EntityFrameworkCore.PostgreSQL": "[10.0.3, )",
+          "Unifesspa.UniPlus.Infrastructure.Core": "[1.0.0, )",
+          "Unifesspa.UniPlus.Portal.Domain": "[1.0.0, )"
+        }
+      },
+      "Apache.Avro": {
+        "type": "CentralTransitive",
+        "requested": "[1.12.1, )",
+        "resolved": "1.12.1",
+        "contentHash": "OTn0ShyXdMnbJ/1LLNOjvQhwE6Q8LiNtM9B/k51UJa7viuotKhDEnmLIof87XfjUt2UJZFhjF366+B3cKs3k4g==",
+        "dependencies": {
+          "Newtonsoft.Json": "13.0.1",
+          "System.CodeDom": "8.0.0"
+        }
+      },
+      "Confluent.Kafka": {
+        "type": "CentralTransitive",
+        "requested": "[2.15.0, )",
+        "resolved": "2.15.0",
+        "contentHash": "/BOEnIKAq1AHq6vPl+0RBDiKwI6L6tJaYBo1qH+OAUP5MFy0i0MhSfgtqKW9/M8J9dQPfb/izWU+R0Uc6DyW2w==",
+        "dependencies": {
+          "librdkafka.redist": "2.15.0"
+        }
+      },
+      "Confluent.SchemaRegistry": {
+        "type": "CentralTransitive",
+        "requested": "[2.15.0, )",
+        "resolved": "2.15.0",
+        "contentHash": "sfd/lVraEozhEl6aNrE+qjP7KbSZVVc/zzdX//WqavUyqpzC8MvNFZ6e+fzPQmKI1KnGZMF4/9kUY66owUsbFQ==",
+        "dependencies": {
+          "Confluent.Kafka": "2.15.0",
+          "Microsoft.Extensions.Caching.Memory": "8.0.1",
+          "Newtonsoft.Json": "13.0.1"
+        }
+      },
+      "Confluent.SchemaRegistry.Serdes.Avro": {
+        "type": "CentralTransitive",
+        "requested": "[2.15.0, )",
+        "resolved": "2.15.0",
+        "contentHash": "50C2ENd0o4Wuanoo7NKyX3d+IxzgLecOw8AE2UVTXi//ZQ/Hj+bWl+Io5kuQrnhLclPjX05tpkfsmx2EDFVVVw==",
+        "dependencies": {
+          "Apache.Avro": "1.12.1",
+          "Confluent.Kafka": "2.15.0",
+          "Confluent.SchemaRegistry": "2.15.0"
+        }
+      },
+      "EFCore.NamingConventions": {
+        "type": "CentralTransitive",
+        "requested": "[10.0.1, )",
+        "resolved": "10.0.1",
+        "contentHash": "Xs5k8XfNKPkkQSkGmZkmDI1je0prLTdxse+s8PgTFZxyBrlrTLzTBUTVJtQKSsbvu4y+luAv8DdtO5SALJE++A==",
+        "dependencies": {
+          "Microsoft.EntityFrameworkCore": "[10.0.1, 11.0.0)",
+          "Microsoft.EntityFrameworkCore.Relational": "[10.0.1, 11.0.0)",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.1"
+        }
+      },
+      "FluentValidation": {
+        "type": "CentralTransitive",
+        "requested": "[12.1.1, )",
+        "resolved": "12.1.1",
+        "contentHash": "EPpkIe1yh1a0OXyC100oOA8WMbZvqUu5plwhvYcb7oSELfyUZzfxV48BLhvs3kKo4NwG7MGLNgy1RJiYtT8Dpw=="
+      },
+      "Microsoft.AspNetCore.Authentication.JwtBearer": {
+        "type": "CentralTransitive",
+        "requested": "[10.0.7, )",
+        "resolved": "10.0.7",
+        "contentHash": "g8klpd7OFJfJOq1EJKcBO8C8I8Dp0QUWoKDPUvvJYe+xunVyBHq6YxfF2CAc6+rkniV25iaWl+6RK87c25n4lA==",
+        "dependencies": {
+          "Microsoft.IdentityModel.Protocols.OpenIdConnect": "8.0.1"
+        }
+      },
+      "Microsoft.AspNetCore.OpenApi": {
+        "type": "CentralTransitive",
+        "requested": "[10.0.7, )",
+        "resolved": "10.0.7",
+        "contentHash": "vKiAcGXG0BwNVw3bOjjWRLnp9tR18dR7MiwpvC94h0yFS+zfnzGHzS/JmmgwUdRixrGxrlIMRAWrVc+2DfAGlg==",
+        "dependencies": {
+          "Microsoft.OpenApi": "2.0.0"
+        }
+      },
+      "Microsoft.EntityFrameworkCore": {
+        "type": "CentralTransitive",
+        "requested": "[10.0.10, )",
+        "resolved": "10.0.10",
+        "contentHash": "a0V7zj/VbYP6dTdWpUgE/r2PuLKtUGe2aJ0lVKkn/wP9ZhaxUz2kQydVfvOjCv2SKxlrqdBfHhPD4Cvlf+4ffA==",
+        "dependencies": {
+          "Microsoft.EntityFrameworkCore.Abstractions": "10.0.10",
+          "Microsoft.EntityFrameworkCore.Analyzers": "10.0.10",
+          "Microsoft.Extensions.Caching.Memory": "10.0.10",
+          "Microsoft.Extensions.Logging": "10.0.10"
+        }
+      },
+      "Microsoft.EntityFrameworkCore.Design": {
+        "type": "CentralTransitive",
+        "requested": "[10.0.7, )",
+        "resolved": "10.0.2",
+        "contentHash": "tBwpyZ75SqcRjmZyhLYJVGKyfz1Z1dmsYtvJGZ2QLSI1tOHgMuLPTovunHA1JF9a0EWJs+WB6tVWmqo3DTL/MQ==",
+        "dependencies": {
+          "Humanizer.Core": "2.14.1",
+          "Microsoft.Build.Framework": "18.0.2",
+          "Microsoft.CodeAnalysis.CSharp": "5.0.0",
+          "Microsoft.CodeAnalysis.CSharp.Workspaces": "5.0.0",
+          "Microsoft.CodeAnalysis.Workspaces.MSBuild": "5.0.0",
+          "Microsoft.EntityFrameworkCore.Relational": "10.0.2",
+          "Microsoft.Extensions.Caching.Memory": "10.0.2",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.2",
+          "Microsoft.Extensions.DependencyModel": "10.0.2",
+          "Microsoft.Extensions.Logging": "10.0.2",
+          "Mono.TextTemplating": "3.0.0",
+          "Newtonsoft.Json": "13.0.3"
+        }
+      },
+      "Microsoft.EntityFrameworkCore.Relational": {
+        "type": "CentralTransitive",
+        "requested": "[10.0.10, )",
+        "resolved": "10.0.10",
+        "contentHash": "wNonj40aZxia+GtuBiiD6ZqVh4h6y5Nje1bGdmzZ8/ui0QRsAN+S0SIrLHFCEGbG9cDbeaE40sh+Lr7o9rRs6g==",
+        "dependencies": {
+          "Microsoft.EntityFrameworkCore": "10.0.10",
+          "Microsoft.Extensions.Caching.Memory": "10.0.10",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.10",
+          "Microsoft.Extensions.Logging": "10.0.10"
+        }
+      },
+      "Microsoft.Extensions.Logging.Abstractions": {
+        "type": "CentralTransitive",
+        "requested": "[10.0.7, )",
+        "resolved": "10.0.10",
+        "contentHash": "zkFxGYUvdxAvIKTyXHrmW+Sux53D4SezD9dMyZ6hrwwzPQJNuwCRy1f5W7AvYTqacEGhWF2XderRQG1OvbV8og==",
+        "dependencies": {
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.10"
+        }
+      },
+      "Microsoft.OpenApi": {
+        "type": "CentralTransitive",
+        "requested": "[2.7.5, )",
+        "resolved": "2.7.5",
+        "contentHash": "0FA67RSnRM4tcBKqiqVu/HPdZ9+QOKbmeRjxRUGTCjPU4C0bmUhd97Dso7Yild5P7nOV6GxJ2xrK0Kv/O9xp0w=="
+      },
+      "Minio": {
+        "type": "CentralTransitive",
+        "requested": "[7.0.0, )",
+        "resolved": "7.0.0",
+        "contentHash": "GiCD0koYBM8/VCXRkrfSzOtySEmrA2ngceJuxRO5H+/uGodiTX+XPaUHQq9/1DpaeBxWnkmrgqu52dwuZqIYgw==",
+        "dependencies": {
+          "CommunityToolkit.HighPerformance": "8.4.0",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "9.0.4",
+          "Microsoft.Extensions.Logging": "9.0.4",
+          "System.IO.Hashing": "9.0.4",
+          "System.Reactive": "6.0.1"
+        }
+      },
+      "MR.EntityFrameworkCore.KeysetPagination": {
+        "type": "CentralTransitive",
+        "requested": "[1.6.0, )",
+        "resolved": "1.6.0",
+        "contentHash": "ExtupgJJ4Jq5HzZSbQAKf3oIQxk0jDGNsAriCDE3JcNom6wSBVUCqK9JiBjY5i+w4T+HBjOUMxGrTUke18FPKg==",
+        "dependencies": {
+          "MR.EntityFrameworkCore.KeysetPagination.Analyzers": "1.6.0",
+          "Microsoft.EntityFrameworkCore": "10.0.0"
+        }
+      },
+      "Npgsql": {
+        "type": "CentralTransitive",
+        "requested": "[10.0.3, )",
+        "resolved": "10.0.3",
+        "contentHash": "7nb5YzXuvWWJxB0J8DiyL3we+X4FOctZrt0fIBnucOIaIevFEEwGQVZKtiu9olXdlNAK1eNgqSral6r/jlhI4w==",
+        "dependencies": {
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.0"
+        }
+      },
+      "Npgsql.EntityFrameworkCore.PostgreSQL": {
+        "type": "CentralTransitive",
+        "requested": "[10.0.3, )",
+        "resolved": "10.0.3",
+        "contentHash": "IPGrrZnRkuW7OlHDhUESZz4G5DLkW7Nej/O3Cx+0iTsgyU5XJxBgpsvTHLloo3WWuAKKbDHXBvWPVkX1deRh1Q==",
+        "dependencies": {
+          "Microsoft.EntityFrameworkCore": "[10.0.4, 11.0.0)",
+          "Microsoft.EntityFrameworkCore.Relational": "[10.0.4, 11.0.0)",
+          "Npgsql": "10.0.3"
+        }
+      },
+      "OpenTelemetry.Exporter.OpenTelemetryProtocol": {
+        "type": "CentralTransitive",
+        "requested": "[1.17.0, )",
+        "resolved": "1.17.0",
+        "contentHash": "R1omQOrQpGlS0Cp5UIr/TAiuEA48JrPlgr1NPV5gESiTU7HhWU+ILe2EBSYb1fKdsSavZ7nZkHcUxAzofPqr2A==",
+        "dependencies": {
+          "OpenTelemetry": "1.17.0"
+        }
+      },
+      "OpenTelemetry.Extensions.Hosting": {
+        "type": "CentralTransitive",
+        "requested": "[1.17.0, )",
+        "resolved": "1.17.0",
+        "contentHash": "t1OwL/4qgboGMobYVT+UV5zgWnFqCp4Pw8lcsmzh8m2K8PQsTKkyxrC32tqYTMYny3GOW4q5cltE3dTVzLmRew==",
+        "dependencies": {
+          "Microsoft.Extensions.Hosting.Abstractions": "10.0.0",
+          "OpenTelemetry": "1.17.0"
+        }
+      },
+      "OpenTelemetry.Instrumentation.AspNetCore": {
+        "type": "CentralTransitive",
+        "requested": "[1.17.0, )",
+        "resolved": "1.17.0",
+        "contentHash": "rGbmk1vuy1kvgZmE0ps7Vb99YZvDap6AalrrF60FwnNit1uW/PbeFZj1cpb0T8MPkYmjhBrRJ1/JB6QqXkRjHA==",
+        "dependencies": {
+          "OpenTelemetry.Api.ProviderBuilderExtensions": "[1.17.0, 2.0.0)"
+        }
+      },
+      "OpenTelemetry.Instrumentation.EntityFrameworkCore": {
+        "type": "CentralTransitive",
+        "requested": "[1.15.1-beta.1, )",
+        "resolved": "1.15.1-beta.1",
+        "contentHash": "NmtYLk3HJUUkV0g2VnFLs67/PGIVbI8JXtu0g4f9bk2ZaInp211/AL2+Qcbgkb9ih/uOi8loN6E1Aw2o0YIWag==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.0",
+          "Microsoft.Extensions.Options": "10.0.0",
+          "OpenTelemetry.Api.ProviderBuilderExtensions": "[1.15.3, 2.0.0)"
+        }
+      },
+      "OpenTelemetry.Instrumentation.Http": {
+        "type": "CentralTransitive",
+        "requested": "[1.17.0, )",
+        "resolved": "1.17.0",
+        "contentHash": "uTwVtxIJ/xB96wGYTaDsbkJVeCFdUxTwvrlDUn2YJixy0UuKc8DvQMzwKNJMTzNFiiyYO9c40id6tUHTmWs33A==",
+        "dependencies": {
+          "Microsoft.Extensions.Configuration": "10.0.0",
+          "Microsoft.Extensions.Options": "10.0.0",
+          "OpenTelemetry.Api.ProviderBuilderExtensions": "[1.17.0, 2.0.0)"
+        }
+      },
+      "OpenTelemetry.Instrumentation.Runtime": {
+        "type": "CentralTransitive",
+        "requested": "[1.17.0, )",
+        "resolved": "1.17.0",
+        "contentHash": "HyYenisDn/xdtyVXdjImsCl+RNC2gq01N0rvSR7tsYAylXR2sxX/YgMsyTajMXA27+r1vB7lNU8cWRhV0fwL+Q==",
+        "dependencies": {
+          "OpenTelemetry.Api": "[1.17.0, 2.0.0)"
+        }
+      },
+      "Serilog.AspNetCore": {
+        "type": "CentralTransitive",
+        "requested": "[10.0.0, )",
+        "resolved": "10.0.0",
+        "contentHash": "a/cNa1mY4On1oJlfGG1wAvxjp5g7OEzk/Jf/nm7NF9cWoE7KlZw1GldrifUBWm9oKibHkR7Lg/l5jy3y7ACR8w==",
+        "dependencies": {
+          "Serilog": "4.3.0",
+          "Serilog.Extensions.Hosting": "10.0.0",
+          "Serilog.Formatting.Compact": "3.0.0",
+          "Serilog.Settings.Configuration": "10.0.0",
+          "Serilog.Sinks.Console": "6.1.1",
+          "Serilog.Sinks.Debug": "3.0.0",
+          "Serilog.Sinks.File": "7.0.0"
+        }
+      },
+      "Serilog.Sinks.OpenTelemetry": {
+        "type": "CentralTransitive",
+        "requested": "[4.2.0, )",
+        "resolved": "4.2.0",
+        "contentHash": "PzMCyE5G19tjr5IZEi5qg+4UU5QrxBEoBEMu/hhYybTrGKXqUDiSGWKZNUDBgelaVKqLADlsmlJVyKce5SyPrg==",
+        "dependencies": {
+          "Google.Protobuf": "3.30.1",
+          "Grpc.Net.Client": "2.70.0",
+          "Serilog": "4.2.0"
+        }
+      },
+      "StackExchange.Redis": {
+        "type": "CentralTransitive",
+        "requested": "[2.12.14, )",
+        "resolved": "2.12.14",
+        "contentHash": "QiAQg40OP4Owem6/PjIbjEKq2+uIeQYeZ1TCMUnx/QvKugOPxOfC96wjlnBjWHi4Wq9pv9+fDlXGT06XkRZ6Ig==",
+        "dependencies": {
+          "Microsoft.Extensions.Logging.Abstractions": "8.0.0",
+          "Pipelines.Sockets.Unofficial": "2.2.8",
+          "System.IO.Hashing": "10.0.2"
+        }
+      },
+      "Testcontainers": {
+        "type": "CentralTransitive",
+        "requested": "[4.13.0, )",
+        "resolved": "4.13.0",
+        "contentHash": "j8vi9jPBNSwaraGGx8w+2gtZyWrlbKxdhiGMS3nektg+KiwjFWx9ghCjs57EoQfvI+IAbzti0oQJupQChwgMog==",
+        "dependencies": {
+          "Docker.DotNet.Enhanced": "4.3.3",
+          "Docker.DotNet.Enhanced.X509": "4.3.3",
+          "Microsoft.Extensions.Logging.Abstractions": "8.0.3",
+          "SSH.NET": "2025.1.0",
+          "SharpZipLib": "1.4.2"
+        }
+      },
+      "VaultSharp": {
+        "type": "CentralTransitive",
+        "requested": "[1.17.5.1, )",
+        "resolved": "1.17.5.1",
+        "contentHash": "1O/F+AQCkyK4K709pBDYEbDDfJ12OlaE5lnOs9dffq+KxqrnPxh8FIdQtEst9yBJmC7I0BptftzTJyRSwhZR/A=="
+      },
+      "WolverineFx": {
+        "type": "CentralTransitive",
+        "requested": "[5.40.0, )",
+        "resolved": "5.40.0",
+        "contentHash": "4by7jva0Vi75rH330utnHHSCyfBKH2uDzB4r+Ea++5UGKUm4x6FnUBSkviPMiHYfDvxo5JxM5ovNdjunTMgzvQ==",
+        "dependencies": {
+          "JasperFx": "1.31.0",
+          "JasperFx.Events": "1.36.0",
+          "JasperFx.RuntimeCompiler": "4.5.0",
+          "JasperFx.SourceGeneration": "1.1.0",
+          "Microsoft.Extensions.Caching.Memory": "10.0.0",
+          "Microsoft.Extensions.Configuration": "10.0.0",
+          "Microsoft.Extensions.Configuration.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Configuration.Binder": "10.0.0",
+          "Microsoft.Extensions.Configuration.Json": "10.0.0",
+          "Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions": "10.0.0",
+          "Microsoft.Extensions.Hosting": "10.0.0",
+          "Microsoft.Extensions.Hosting.Abstractions": "10.0.0",
+          "Microsoft.Extensions.ObjectPool": "10.0.2",
+          "NewId": "4.0.1",
+          "Newtonsoft.Json": "13.0.3"
+        }
+      },
+      "WolverineFx.EntityFrameworkCore": {
+        "type": "CentralTransitive",
+        "requested": "[5.40.0, )",
+        "resolved": "5.40.0",
+        "contentHash": "RBs3NUkvpAxAWAL2ps/+oR7oof6UHSImqrNWDXJXkbswbsOQeZQ4xEkqPhnZ9XACYVqqeJEzShyVsdW5XPErKw==",
+        "dependencies": {
+          "Microsoft.EntityFrameworkCore": "10.0.2",
+          "Microsoft.EntityFrameworkCore.Design": "10.0.2",
+          "Microsoft.EntityFrameworkCore.Relational": "10.0.2",
+          "Weasel.EntityFrameworkCore": "8.15.1",
+          "WolverineFx.RDBMS": "5.40.0"
+        }
+      },
+      "WolverineFx.FluentValidation": {
+        "type": "CentralTransitive",
+        "requested": "[5.40.0, )",
+        "resolved": "5.40.0",
+        "contentHash": "bHLaiHUr6WWLPbEWhTE65CZslmHJkYuFOiX8Y74lKQJwoblXWHGibrd6RyECeJBPdp+WjZEPntEaVIs34FY94Q==",
+        "dependencies": {
+          "FluentValidation": "12.0.0",
+          "WolverineFx": "5.40.0"
+        }
+      },
+      "WolverineFx.Kafka": {
+        "type": "CentralTransitive",
+        "requested": "[5.40.0, )",
+        "resolved": "5.40.0",
+        "contentHash": "74Yrgt3PWlmrk5exFQLbm1JvGb5aj82N9IwO9U3/o3eCmk3U7JzMpRn1mIIMhnyECB2xQoWyEUdR36Hfi0oDUA==",
+        "dependencies": {
+          "Confluent.SchemaRegistry.Serdes.Avro": "2.14.0",
+          "Confluent.SchemaRegistry.Serdes.Json": "2.14.0",
+          "WolverineFx": "5.40.0"
+        }
+      },
+      "WolverineFx.Postgresql": {
+        "type": "CentralTransitive",
+        "requested": "[5.40.0, )",
+        "resolved": "5.40.0",
+        "contentHash": "HNNNARfocZJP0t2B5R2fbUcRJ75bRZ3KVPdB5A3xTLVgoVsXCah/0IMamCggo/aws5DvRnqpD9UJWvdIkLa8bg==",
+        "dependencies": {
+          "Weasel.Postgresql": "8.15.1",
+          "WolverineFx.RDBMS": "5.40.0"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Closes #834
Closes #836
Closes #837

## Resumo

- Implementa uma convenção automática de prefixo por `IControllerModelConvention`.
- Declara a identidade pública de cada módulo por metadado no assembly de API.
- Compartilha a mesma identidade entre roteamento, agrupamento no ApiExplorer e documentos OpenAPI.
- Preserva o contrato `/api/{modulo}/{recurso}` no Host e no Portal standalone.

## Principais mudanças

- Adiciona `ApiModuleAttribute`, `ApiModuleMetadata` e `ModuleRoutePrefixConvention` à infraestrutura compartilhada.
- Remove dos controllers a repetição do prefixo do módulo, mantendo somente as rotas relativas dos recursos.
- Faz `ModuleApiGroupingConvention` usar o mesmo resolvedor de identidade empregado pelo roteamento.
- Declara `ModuleName` nos assembly markers de Configuração, Ingresso, Organização Institucional, Portal, Publicações e Seleção.
- Reutiliza `ModuleName` no registro dos documentos OpenAPI.
- Falha durante a construção do modelo MVC quando um assembly com controllers não possui identidade de módulo.
- Documenta a decisão na ADR-0118.

## Compatibilidade de rotas

- Host: mantém os prefixos públicos existentes dos módulos.
- Portal standalone: mantém `GET /api/portal/ping` e não expõe `GET /ping`.
- OpenAPI: mantém a identidade canônica de cada módulo alinhada ao prefixo HTTP.

## Testes e validações

- [x] Build sem erros e sem warnings
- [x] Formatação validada
- [x] Testes unitários e de arquitetura
- [x] Testes de integração, incluindo o roteamento do Portal standalone
- [x] Lint das ADRs e dos contratos OpenAPI
- [x] Verificação de dependências proibidas
- [x] CodeQL e Trivy
- [x] Testes E2E não aplicáveis a esta alteração de backend

## Checklist

- [x] Código segue Clean Architecture e SOLID
- [x] Sem exposição de PII
- [x] Documentação atualizada
- [x] Rotas públicas existentes preservadas
- [x] Identidade de módulo compartilhada entre roteamento e OpenAPI