### PR TITLE
refactor(shared): Remove resíduos técnicos do antigo módulo Geo

### DIFF
--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.API/Unifesspa.UniPlus.Configuracao.API.csproj
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.API/Unifesspa.UniPlus.Configuracao.API.csproj
@@ -4,7 +4,7 @@
     Módulo interno do monólito modular: class library (não executável). Roda
     apenas dentro da API UniPlus (composition root); não carrega Program/appsettings
     próprios — elimina a colisão de appsettings no publish do host. Deploy: somente
-    Geo, Portal e UniPlus são executáveis. FrameworkReference dá acesso ao ASP.NET
+    Portal e UniPlus são executáveis. FrameworkReference dá acesso ao ASP.NET
     Core (controllers, OpenAPI, DI) numa library.
   -->
   <ItemGroup>

--- a/src/host/Unifesspa.UniPlus.Host/Program.cs
+++ b/src/host/Unifesspa.UniPlus.Host/Program.cs
@@ -22,8 +22,8 @@ using Unifesspa.UniPlus.Selecao.Infrastructure.Messaging;
 
 // Composition root do monólito modular. Compõe os 5 módulos internos
 // (Selecao, Ingresso, Configuracao, OrganizacaoInstitucional) num processo único,
-// apontando todos para o banco `uniplus` (schema-por-módulo). Geo e Portal seguem
-// deploys separados. Este assembly é o único que depende de múltiplos módulos
+// apontando todos para o banco `uniplus` (schema-por-módulo). Portal segue
+// deploy separado. Este assembly é o único que depende de múltiplos módulos
 // (composition root) — isento do fitness R8.
 WebApplicationBuilder builder = WebApplication.CreateBuilder(args);
 

--- a/src/host/Unifesspa.UniPlus.Host/Program.cs
+++ b/src/host/Unifesspa.UniPlus.Host/Program.cs
@@ -21,7 +21,7 @@ using Unifesspa.UniPlus.Selecao.Application.Commands.ProcessosSeletivos;
 using Unifesspa.UniPlus.Selecao.Infrastructure.Messaging;
 
 // Composition root do monólito modular. Compõe os 5 módulos internos
-// (Selecao, Ingresso, Configuracao, OrganizacaoInstitucional) num processo único,
+// (Selecao, Ingresso, Configuracao, OrganizacaoInstitucional e Publicações) num processo único,
 // apontando todos para o banco `uniplus` (schema-por-módulo). Portal segue
 // deploy separado. Este assembly é o único que depende de múltiplos módulos
 // (composition root) — isento do fitness R8.

--- a/src/host/Unifesspa.UniPlus.Host/Unifesspa.UniPlus.Host.csproj
+++ b/src/host/Unifesspa.UniPlus.Host/Unifesspa.UniPlus.Host.csproj
@@ -9,7 +9,7 @@
 
   <!--
     Composition root do monólito modular. Referencia os 5 módulos internos
-    (Selecao, Ingresso, Configuracao, OrganizacaoInstitucional) e os compõe num
+    (Selecao, Ingresso, Configuracao, OrganizacaoInstitucional e Publicações) e os compõe num
     processo único. Portal permanece deploy separado. Este assembly é o
     único autorizado a depender de múltiplos módulos — fica FORA do ModulesRoster
     do fitness R8 (CrossModuleReadIsolationTests).

--- a/src/host/Unifesspa.UniPlus.Host/Unifesspa.UniPlus.Host.csproj
+++ b/src/host/Unifesspa.UniPlus.Host/Unifesspa.UniPlus.Host.csproj
@@ -10,7 +10,7 @@
   <!--
     Composition root do monólito modular. Referencia os 5 módulos internos
     (Selecao, Ingresso, Configuracao, OrganizacaoInstitucional) e os compõe num
-    processo único. Geo e Portal permanecem deploys separados. Este assembly é o
+    processo único. Portal permanece deploy separado. Este assembly é o
     único autorizado a depender de múltiplos módulos — fica FORA do ModulesRoster
     do fitness R8 (CrossModuleReadIsolationTests).
   -->

--- a/src/ingresso/Unifesspa.UniPlus.Ingresso.API/Unifesspa.UniPlus.Ingresso.API.csproj
+++ b/src/ingresso/Unifesspa.UniPlus.Ingresso.API/Unifesspa.UniPlus.Ingresso.API.csproj
@@ -3,7 +3,7 @@
   <!--
     Módulo interno do monólito modular: class library (não executável). Roda apenas
     dentro da API UniPlus; não carrega Program/appsettings próprios. Deploy: somente
-    Geo, Portal e UniPlus são executáveis.
+    Portal e UniPlus são executáveis.
   -->
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />

--- a/src/organizacao-institucional/Unifesspa.UniPlus.OrganizacaoInstitucional.API/Unifesspa.UniPlus.OrganizacaoInstitucional.API.csproj
+++ b/src/organizacao-institucional/Unifesspa.UniPlus.OrganizacaoInstitucional.API/Unifesspa.UniPlus.OrganizacaoInstitucional.API.csproj
@@ -3,7 +3,7 @@
   <!--
     Módulo interno do monólito modular: class library (não executável). Roda apenas
     dentro da API UniPlus; não carrega Program/appsettings próprios. Deploy: somente
-    Geo, Portal e UniPlus são executáveis. FrameworkReference dá acesso ao ASP.NET
+    Portal e UniPlus são executáveis. FrameworkReference dá acesso ao ASP.NET
     Core (controllers, OpenAPI, DI) numa library.
   -->
   <ItemGroup>

--- a/src/publicacoes/Unifesspa.UniPlus.Publicacoes.API/Unifesspa.UniPlus.Publicacoes.API.csproj
+++ b/src/publicacoes/Unifesspa.UniPlus.Publicacoes.API/Unifesspa.UniPlus.Publicacoes.API.csproj
@@ -3,7 +3,7 @@
   <!--
     Módulo interno do monólito modular: class library (não executável). Roda apenas
     dentro da API UniPlus; não carrega Program/appsettings próprios. Deploy: somente
-    Geo, Portal e UniPlus são executáveis.
+    Portal e UniPlus são executáveis.
   -->
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />

--- a/src/selecao/Unifesspa.UniPlus.Selecao.API/Unifesspa.UniPlus.Selecao.API.csproj
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.API/Unifesspa.UniPlus.Selecao.API.csproj
@@ -3,7 +3,7 @@
   <!--
     Módulo interno do monólito modular: class library (não executável). Roda apenas
     dentro da API UniPlus; não carrega Program/appsettings próprios. Deploy: somente
-    Geo, Portal e UniPlus são executáveis. WolverineFx.Kafka permanece — o wiring de
+    Portal e UniPlus são executáveis. WolverineFx.Kafka permanece — o wiring de
     mensageria (SelecaoMessagingRegistration) é consumido pelo host.
   -->
   <ItemGroup>

--- a/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Observability/UniPlusServiceNames.cs
+++ b/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Observability/UniPlusServiceNames.cs
@@ -34,7 +34,4 @@ public static class UniPlusServiceNames
 
     /// <summary>Módulo Configuracao — API que hospeda catálogos cross-cutting área-scoped (Modalidade, NecessidadeEspecial, …).</summary>
     public const string Configuracao = "uniplus-configuracao";
-
-    /// <summary>Módulo Geo — API de localidades, endereçamento e georreferência nacional (PostGIS).</summary>
-    public const string Geo = "uniplus-geo";
 }

--- a/src/shared/Unifesspa.UniPlus.Infrastructure.Core/OpenApi/UniPlusInfoTransformer.cs
+++ b/src/shared/Unifesspa.UniPlus.Infrastructure.Core/OpenApi/UniPlusInfoTransformer.cs
@@ -34,7 +34,6 @@ public sealed class UniPlusInfoTransformer : IOpenApiDocumentTransformer
             "ingresso" => "Uni+ — Módulo Ingresso",
             "organizacao" => "Uni+ — Módulo Organização Institucional",
             "portal" => "Uni+ — Módulo Portal",
-            "geo" => "Uni+ — Módulo Geo",
             _ => $"Uni+ — {context.DocumentName}",
         };
 

--- a/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Persistence/UniPlusDbContextOptionsExtensions.cs
+++ b/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Persistence/UniPlusDbContextOptionsExtensions.cs
@@ -58,7 +58,6 @@ public static class UniPlusDbContextOptionsExtensions
         this DbContextOptionsBuilder options,
         IServiceProvider serviceProvider,
         string connectionStringName,
-        Action<NpgsqlDbContextOptionsBuilder>? configurarNpgsql = null,
         string? schema = null)
         where TContext : DbContext
     {
@@ -103,9 +102,6 @@ public static class UniPlusDbContextOptionsExtensions
             {
                 npgsqlOptions.MigrationsHistoryTable("__EFMigrationsHistory", schema);
             }
-
-            // Composição opcional do provider (ex.: UseNetTopologySuite no Geo).
-            configurarNpgsql?.Invoke(npgsqlOptions);
         });
 
         // snake_case automático em tabelas, colunas, índices e FKs (ADR-0054).
@@ -147,7 +143,6 @@ public static class UniPlusDbContextOptionsExtensions
     /// gere o mapeamento <c>geography(Point,4326)</c>. Default <c>null</c>.
     /// </param>
     public static DbContextOptions<TContext> BuildDesignTimeOptions<TContext>(
-        Action<NpgsqlDbContextOptionsBuilder>? configurarNpgsql = null,
         string? schema = null)
         where TContext : DbContext
     {
@@ -165,8 +160,6 @@ public static class UniPlusDbContextOptionsExtensions
                     {
                         npgsqlOptions.MigrationsHistoryTable("__EFMigrationsHistory", schema);
                     }
-
-                    configurarNpgsql?.Invoke(npgsqlOptions);
                 })
             .UseSnakeCaseNamingConvention()
             .Options;

--- a/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Persistence/UniPlusDbContextOptionsExtensions.cs
+++ b/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Persistence/UniPlusDbContextOptionsExtensions.cs
@@ -7,8 +7,6 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 
-using Npgsql.EntityFrameworkCore.PostgreSQL.Infrastructure;
-
 /// <summary>
 /// Helpers de configuração de <see cref="DbContext"/> consumidos pelos 3
 /// módulos (Selecao, Ingresso, Portal). Centraliza invariantes da camada de
@@ -46,14 +44,6 @@ public static class UniPlusDbContextOptionsExtensions
     /// <c>InMemoryCollection</c> ganham o override automaticamente, sem
     /// re-registrar o DbContext.</para>
     /// </remarks>
-    /// <param name="configurarNpgsql">
-    /// Hook opcional para compor o bloco <c>UseNpgsql</c> com extensões do
-    /// provider Npgsql (ex.: <c>o =&gt; o.UseNetTopologySuite()</c> no módulo Geo,
-    /// ADR-0091). Executado <em>depois</em> de <c>MigrationsAssembly</c> e
-    /// <c>MigrationsHistoryTable</c>, dentro do mesmo callback. Default
-    /// <c>null</c> — não-invasivo: módulos que não passam o hook mantêm o
-    /// comportamento atual inalterado.
-    /// </param>
     public static DbContextOptionsBuilder UseUniPlusNpgsqlConventions<TContext>(
         this DbContextOptionsBuilder options,
         IServiceProvider serviceProvider,
@@ -136,12 +126,6 @@ public static class UniPlusDbContextOptionsExtensions
     /// ao banco durante <c>migrations add</c>. <c>database update</c> rodado
     /// localmente sobrescreve via <c>--connection</c>.
     /// </remarks>
-    /// <param name="configurarNpgsql">
-    /// Hook opcional idêntico ao de <see cref="UseUniPlusNpgsqlConventions{TContext}"/>
-    /// — garante paridade runtime↔design-time. O módulo Geo passa
-    /// <c>o =&gt; o.UseNetTopologySuite()</c> para que <c>dotnet ef migrations</c>
-    /// gere o mapeamento <c>geography(Point,4326)</c>. Default <c>null</c>.
-    /// </param>
     public static DbContextOptions<TContext> BuildDesignTimeOptions<TContext>(
         string? schema = null)
         where TContext : DbContext


### PR DESCRIPTION
## Resumo

<!-- 1-3 bullet points descrevendo o que este PR faz -->

Esse PR remove os resíduos executáveis e extensões públicas que sobraram no shared após a extração do Geo para o repositório dedicado.

> Obs.: `EnderecoGeo*`, `ReferenciaCidadeGeo`, `ReferenciaEnderecoGeo`, campos de proveniência ou recursos Docker do serviço externo considerara-se fora do escopo desse PR. Portanto, permaneceram inalterados.

Closes #1009

## Mudanças

<!-- Lista detalhada das mudanças por categoria -->

### Novos arquivos
<!-- - `path/to/file` — descrição -->

N/D.

### Modificados
<!-- - `path/to/file` — o que mudou -->

Atualiza os comentários realizando a remoção de qualquer menção ao antigo módulo `Geo`.

- `src/configuracao/Unifesspa.UniPlus.Configuracao.API/Unifesspa.UniPlus.Configuracao.API.csproj`;
- `src/host/Unifesspa.UniPlus.Host/Program.cs`;
- `src/host/Unifesspa.UniPlus.Host/Unifesspa.UniPlus.Host.csproj`;
- `src/ingresso/Unifesspa.UniPlus.Ingresso.API/Unifesspa.UniPlus.Ingresso.API.csproj`;
- `src/organizacao-institucional/Unifesspa.UniPlus.OrganizacaoInstitucional.API/Unifesspa.UniPlus.OrganizacaoInstitucional.API.csproj`;
- `src/publicacoes/Unifesspa.UniPlus.Publicacoes.API/Unifesspa.UniPlus.Publicacoes.API.csproj`;
- `src/selecao/Unifesspa.UniPlus.Selecao.API/Unifesspa.UniPlus.Selecao.API.csproj`.

Remove `UniPlusServiceNames.Geo`.

- `src/shared/Unifesspa.UniPlus.Infrastructure.Core/Observability/UniPlusServiceNames.cs`.

Remove o branch `"geo"` de `UniPlusInfoTransformer`.

- `src/shared/Unifesspa.UniPlus.Infrastructure.Core/OpenApi/UniPlusInfoTransformer.cs`.

Remove o hook opcional `configurarNpgsql`.

- `src/shared/Unifesspa.UniPlus.Infrastructure.Core/Persistence/UniPlusDbContextOptionsExtensions.cs`.

## Testes

- [X] Testes unitários passando
- [X] Testes de integração passando (se aplicável)
- [X] Testes E2E passando (se aplicável)
- [X] Código e comentários residuais removidos nos pontos confirmados pela análise.
- [X] Testes de UniPlusInfoTransformer e UniPlusDbContextOptionsExtensions atualizados.
- [X] Nenhum contrato OpenAPI ou snapshot consumidor alterado.
- [X] Testes unitários focados verdes e cobertura ≥ 80% para código novo aplicável.
- [X] dotnet build UniPlus.slnx verde local e em CI.
- [X] dotnet format --verify-no-changes --exclude-diagnostics CA1515 --exclude "**/Migrations/**" verde.
- [X] Cenários BDD desta Task validados.
- [ ] PR aberto, revisado por outro membro CTIC e mergeado (Closes #N).

## Checklist

- [X] Build sem erros e sem warnings
- [ ] Código segue Clean Architecture e SOLID - Não se aplica.
- [ ] Sem exposição de PII (CPF, renda, dados sensíveis) - Não se aplica.
- [ ] Strings user-facing em pt-BR - Não se aplica.
- [ ] Soft delete utilizado (sem DELETE físico) - Não se aplica.
- [X] Documentação atualizada (se aplicável) - Atualiza somente comentários. Documentação será atualizada com a Issue #1010.
