### PR TITLE
test(routing): torna cobertura de prefixos exaustiva por módulo no mo…

### DIFF
--- a/tests/Unifesspa.UniPlus.Host.IntegrationTests/RoteamentoSemColisaoTests.cs
+++ b/tests/Unifesspa.UniPlus.Host.IntegrationTests/RoteamentoSemColisaoTests.cs
@@ -2,14 +2,17 @@ namespace Unifesspa.UniPlus.Host.IntegrationTests;
 
 using System.Diagnostics.CodeAnalysis;
 using System.Net;
+using System.Reflection;
 
 using AwesomeAssertions;
 
 using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc.Controllers;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.DependencyInjection;
 
 using Unifesspa.UniPlus.Host.IntegrationTests.Infrastructure;
+using Unifesspa.UniPlus.Infrastructure.Core.Routing;
 using Unifesspa.UniPlus.IntegrationTests.Fixtures.Hosting;
 
 /// <summary>
@@ -69,22 +72,20 @@ public sealed class RoteamentoSemColisaoTests
             + "o prefixo api/<modulo>/ deve garantir templates únicos por (método, caminho)");
     }
 
-    [Theory(DisplayName = "Cada módulo expõe rotas sob seu prefixo api/{modulo}/")]
-    [InlineData("api/configuracao/")]
-    [InlineData("api/organizacao/")]
-    [InlineData("api/selecao/")]
-    public void RotasDeModulo_SaoNamespacedPorPrefixo(string prefixo)
+    [Fact(DisplayName = "Cada módulo expõe rotas sob seu prefixo api/{modulo}/")]
+    public void RotasDeModulo_SaoNamespacedPorPrefixo()
     {
         EndpointDataSource dataSource =
             _fixture.Factory.Services.GetRequiredService<EndpointDataSource>();
 
-        IEnumerable<string> templates = dataSource.Endpoints
+        RouteEndpoint[] endpoints = dataSource.Endpoints
             .OfType<RouteEndpoint>()
-            .Select(e => e.RoutePattern.RawText ?? string.Empty);
+            .Where(e => e.Metadata.GetMetadata<ControllerActionDescriptor>() != null)
+            .ToArray();
 
-        templates.Should().Contain(
-            t => t.StartsWith(prefixo, StringComparison.Ordinal),
-            $"o módulo deve expor seus controllers sob {prefixo} no monólito co-hospedado");
+        endpoints.Should().NotBeEmpty();
+
+        endpoints.Should().OnlyContain(e => HasExpectedRoutePrefix(e));
     }
 
     [Fact(DisplayName = "Smoke: pipeline HTTP vivo (/health/live 200) e rotas de módulo resolvem (200)")]
@@ -105,5 +106,25 @@ public sealed class RoteamentoSemColisaoTests
         HttpResponseMessage unidades = await client.GetAsync(
             new Uri("/api/organizacao/unidades", UriKind.Relative));
         unidades.StatusCode.Should().Be(HttpStatusCode.OK);
+    }
+
+    private static bool HasExpectedRoutePrefix(RouteEndpoint endpoint)
+    {
+        ControllerActionDescriptor? actionDescriptor =
+            endpoint.Metadata.GetMetadata<ControllerActionDescriptor>();
+
+        Assembly? assembly = actionDescriptor?
+            .ControllerTypeInfo
+            .Assembly;
+        if (assembly is null) return false;
+
+        string moduleName = ApiModuleMetadata.GetRequiredName(assembly);
+        string prefix = $"api/{moduleName}";
+
+        string template = endpoint.RoutePattern.RawText ?? string.Empty;
+
+        return template == prefix || template.StartsWith(
+                   $"{prefix}/",
+                   StringComparison.Ordinal);
     }
 }

--- a/tests/Unifesspa.UniPlus.Portal.IntegrationTests/Routing/PortalRoutingTests.cs
+++ b/tests/Unifesspa.UniPlus.Portal.IntegrationTests/Routing/PortalRoutingTests.cs
@@ -2,10 +2,17 @@ namespace Unifesspa.UniPlus.Portal.IntegrationTests.Routing;
 
 using System.Diagnostics.CodeAnalysis;
 using System.Net;
+using System.Reflection;
 
 using AwesomeAssertions;
 
 using Infrastructure;
+
+using Microsoft.AspNetCore.Mvc.Controllers;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.DependencyInjection;
+
+using Unifesspa.UniPlus.Infrastructure.Core.Routing;
 
 [Trait("Category", "Integration")]
 [SuppressMessage(
@@ -33,5 +40,41 @@ public sealed class PortalRoutingTests : IClassFixture<PortalApiFactory>
 
         prefixed.StatusCode.Should().Be(HttpStatusCode.OK);
         unprefixed.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [Fact(DisplayName = "Cada módulo expõe rotas sob seu prefixo api/{modulo}/")]
+    public void RotasDeModulo_SaoNamespacedPorPrefixo()
+    {
+        EndpointDataSource dataSource =
+            _factory.Services.GetRequiredService<EndpointDataSource>();
+
+        RouteEndpoint[] endpoints = dataSource.Endpoints
+            .OfType<RouteEndpoint>()
+            .Where(e => e.Metadata.GetMetadata<ControllerActionDescriptor>() != null)
+            .ToArray();
+
+        endpoints.Should().NotBeEmpty();
+
+        endpoints.Should().OnlyContain(e => HasExpectedRoutePrefix(e));
+    }
+
+    private static bool HasExpectedRoutePrefix(RouteEndpoint endpoint)
+    {
+        ControllerActionDescriptor? actionDescriptor =
+            endpoint.Metadata.GetMetadata<ControllerActionDescriptor>();
+
+        Assembly? assembly = actionDescriptor?
+            .ControllerTypeInfo
+            .Assembly;
+        if (assembly is null) return false;
+
+        string moduleName = ApiModuleMetadata.GetRequiredName(assembly);
+        string prefix = $"api/{moduleName}";
+
+        string template = endpoint.RoutePattern.RawText ?? string.Empty;
+
+        return template == prefix || template.StartsWith(
+                    $"{prefix}/",
+                    StringComparison.Ordinal);
     }
 }


### PR DESCRIPTION
Closes #838 
Closes #835 
## Contexto

Fortalece a cobertura dos testes de roteamento para garantir que controllers de módulos co-hospedados e do Portal standalone não sejam expostos fora do prefixo esperado.

Atualmente, `RoteamentoSemColisaoTests.RotasDeModulo_SaoNamespacedPorPrefixo` valida apenas a existência de pelo menos uma rota com o prefixo correto (`.Should().Contain(...)`), o que não impede que outras rotas do mesmo módulo sejam registradas fora de `api/{modulo}`.

## O que foi alterado

* Tornado o teste `RoteamentoSemColisaoTests.RotasDeModulo_SaoNamespacedPorPrefixo` exaustivo.

  * Em vez de verificar apenas a existência de uma rota válida, o teste passa a garantir que **todas** as rotas dos módulos cobertos respeitem o prefixo `api/{modulo}`.
* Expandida a cobertura do Host para todos os módulos, garantindo que mesmo novos módulos sejam cobertos pelos testes.
* Adicionada cobertura equivalente para o Portal em seu pipeline standalone.

  * Garante que todos os controllers permaneçam sob o prefixo `api/portal`.
  * Preserva o contrato de `GET /api/portal/ping`.
  * Garante que `GET /ping` não seja exposto acidentalmente.

## Critérios de aceite atendidos

- [x] O teste do Host falha se qualquer rota dos módulos cobertos não respeitar o prefixo `api/{modulo}`.
- [x] A cobertura do Portal standalone falha se qualquer rota de controller não respeitar o prefixo `api/portal`.
- [x] `GET /api/portal/ping` permanece registrado e `GET /ping` não é exposto.
- [x] Os testes passam com a convenção automática da Story **story(routing): convenção automática de prefixo `api/{modulo}` via `IControllerModelConvention` (#834)** aplicada.
- [x] A cobertura inclui Seleção, Configuração, Organização Institucional e o Portal standalone.

## Testes

- [x] Testes unitários passando
- [x] Testes de integração passando (se aplicável)
- [ ] Testes E2E passando (se aplicável)

## Checklist

- [x] Build sem erros e sem warnings
- [x] Código segue Clean Architecture e SOLID
- [ ] Sem exposição de PII (CPF, renda, dados sensíveis)
- [ ] Strings user-facing em pt-BR
- [ ] Soft delete utilizado (sem DELETE físico)
- [ ] Documentação atualizada (se aplicável)
