### PR TITLE
feat(configuracao): adiciona cadastro de calendário de dias úteis

### DIFF
--- a/contracts/openapi.configuracao.json
+++ b/contracts/openapi.configuracao.json
@@ -89,6 +89,474 @@
         }
       }
     },
+    "/api/configuracao/calendarios-dias-uteis": {
+      "get": {
+        "tags": [
+          "CalendariosDiasUteis"
+        ],
+        "parameters": [
+          {
+            "name": "cursor",
+            "in": "query",
+            "description": "Cursor opaco AES-GCM emitido pelo servidor no header Link da p\u00E1gina anterior. Ausente na primeira p\u00E1gina. Cliente trata como string opaca \u2014 n\u00E3o decodificar (ADR-0026, ADR-0031).",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "description": "Tamanho m\u00E1ximo da janela de resultados. Limites configurados em CursorPaginationOptions; valores fora do range retornam 422 com code uniplus.pagination.limit_invalido (ADR-0026).",
+            "schema": {
+              "type": "integer",
+              "format": "int32"
+            }
+          },
+          {
+            "name": "direction",
+            "in": "query",
+            "description": "Dire\u00E7\u00E3o de navega\u00E7\u00E3o keyset (ADR-0089): \u0027next\u0027 (default) avan\u00E7a, \u0027prev\u0027 retrocede. Normalmente o cliente apenas segue o cursor opaco do rel=\u0022prev\u0022/rel=\u0022next\u0022 do header Link \u2014 que j\u00E1 inclui o direction correto.",
+            "schema": {
+              "enum": [
+                "next",
+                "prev"
+              ],
+              "type": "string",
+              "default": "next"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "headers": {
+              "Link": {
+                "description": "Links de navega\u00E7\u00E3o da pagina\u00E7\u00E3o (RFC 5988/8288). rel=\u0022self\u0022 sempre presente; rel=\u0022prev\u0022/rel=\u0022next\u0022 quando h\u00E1 p\u00E1gina anterior/pr\u00F3xima (ADR-0089). Cada link carrega o cursor opaco no par\u00E2metro \u0060cursor\u0060 e o \u0060direction\u0060 correspondente (ADR-0026).",
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "X-Page-Size": {
+                "description": "Quantidade de itens retornados na p\u00E1gina atual (sempre menor ou igual ao limit efetivo).",
+                "schema": {
+                  "type": "integer",
+                  "format": "int32"
+                }
+              }
+            },
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/CalendarioDiasUteisResumoDto"
+                  }
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/CalendarioDiasUteisResumoDto"
+                  }
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/CalendarioDiasUteisResumoDto"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "406": {
+            "description": "Not Acceptable",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "410": {
+            "description": "Gone",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        },
+        "x-uniplus-paginated": true
+      }
+    },
+    "/api/configuracao/calendarios-dias-uteis/{id}": {
+      "get": {
+        "tags": [
+          "CalendariosDiasUteis"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/CalendarioDiasUteisDto"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CalendarioDiasUteisDto"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CalendarioDiasUteisDto"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "406": {
+            "description": "Not Acceptable",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/configuracao/admin/calendarios-dias-uteis": {
+      "post": {
+        "tags": [
+          "CalendariosDiasUteis"
+        ],
+        "parameters": [
+          {
+            "name": "Idempotency-Key",
+            "in": "header",
+            "description": "Chave opaca (1-255 ASCII printable, sem \u0027,\u0027 ou \u0027;\u0027) para retry seguro do comando. Replay com mesma key \u002B mesmo body retorna response cacheada (ADR-0027).",
+            "required": true,
+            "schema": {
+              "maxLength": 255,
+              "minLength": 1,
+              "pattern": "^[\\x21-\\x2B\\x2D-\\x3A\\x3C-\\x7E]\u002B$",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CriarCalendarioDiasUteisCommand"
+              }
+            },
+            "text/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CriarCalendarioDiasUteisCommand"
+              }
+            },
+            "application/*\u002Bjson": {
+              "schema": {
+                "$ref": "#/components/schemas/CriarCalendarioDiasUteisCommand"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "description": "Created",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string",
+                  "format": "uuid"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "type": "string",
+                  "format": "uuid"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "type": "string",
+                  "format": "uuid"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Requisi\u00E7\u00E3o concorrente com a mesma Idempotency-Key ainda em processamento (uniplus.idempotency.processing_conflict). Repetir depois \u2014 a opera\u00E7\u00E3o anterior ainda n\u00E3o concluiu.",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "413": {
+            "description": "Corpo acima do limite dos endpoints idempotentes (uniplus.idempotency.body_muito_grande). O limite \u00E9 do filtro, n\u00E3o do servidor.",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        },
+        "x-uniplus-idempotent": true
+      }
+    },
+    "/api/configuracao/admin/calendarios-dias-uteis/{id}/vigente": {
+      "post": {
+        "tags": [
+          "CalendariosDiasUteis"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "Idempotency-Key",
+            "in": "header",
+            "description": "Chave opaca (1-255 ASCII printable, sem \u0027,\u0027 ou \u0027;\u0027) para retry seguro do comando. Replay com mesma key \u002B mesmo body retorna response cacheada (ADR-0027).",
+            "required": true,
+            "schema": {
+              "maxLength": 255,
+              "minLength": 1,
+              "pattern": "^[\\x21-\\x2B\\x2D-\\x3A\\x3C-\\x7E]\u002B$",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "No Content"
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Conflict",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Idempotency-Key ausente ou malformada (uniplus.idempotency.key_ausente, uniplus.idempotency.key_malformada), ou corpo JSON inv\u00E1lido."
+          },
+          "413": {
+            "description": "Corpo acima do limite dos endpoints idempotentes (uniplus.idempotency.body_muito_grande). O limite \u00E9 do filtro, n\u00E3o do servidor.",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Mesma Idempotency-Key reusada com corpo diferente (uniplus.idempotency.body_mismatch) \u2014 a chave identifica a requisi\u00E7\u00E3o pelo hash do corpo."
+          }
+        },
+        "x-uniplus-idempotent": true
+      }
+    },
+    "/api/configuracao/admin/calendarios-dias-uteis/{id}": {
+      "delete": {
+        "tags": [
+          "CalendariosDiasUteis"
+        ],
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "No Content"
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Conflict",
+            "content": {
+              "application/problem\u002Bjson": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/configuracao/campi": {
       "get": {
         "tags": [
@@ -7787,6 +8255,81 @@
           }
         }
       },
+      "CalendarioDiasUteisDto": {
+        "required": [
+          "id",
+          "versaoDataset",
+          "vigente",
+          "diasNaoUteis",
+          "criadoEm"
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "versaoDataset": {
+            "type": "string"
+          },
+          "vigente": {
+            "type": "boolean"
+          },
+          "diasNaoUteis": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/DiaNaoUtilDto"
+            }
+          },
+          "criadoEm": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "_links": {
+            "type": [
+              "null",
+              "object"
+            ],
+            "additionalProperties": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "CalendarioDiasUteisResumoDto": {
+        "required": [
+          "id",
+          "versaoDataset",
+          "vigente",
+          "criadoEm"
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "versaoDataset": {
+            "type": "string"
+          },
+          "vigente": {
+            "type": "boolean"
+          },
+          "criadoEm": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "_links": {
+            "type": [
+              "null",
+              "object"
+            ],
+            "additionalProperties": {
+              "type": "string"
+            }
+          }
+        }
+      },
       "CampusDto": {
         "required": [
           "id",
@@ -7940,6 +8483,24 @@
             ],
             "additionalProperties": {
               "type": "string"
+            }
+          }
+        }
+      },
+      "CriarCalendarioDiasUteisCommand": {
+        "required": [
+          "versaoDataset",
+          "diasNaoUteis"
+        ],
+        "type": "object",
+        "properties": {
+          "versaoDataset": {
+            "type": "string"
+          },
+          "diasNaoUteis": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/DiaNaoUtilCommandItem"
             }
           }
         }
@@ -8593,6 +9154,65 @@
             "additionalProperties": {
               "type": "string"
             }
+          }
+        }
+      },
+      "DiaNaoUtilCommandItem": {
+        "required": [
+          "abrangencia",
+          "municipioIbge",
+          "data",
+          "descricao"
+        ],
+        "type": "object",
+        "properties": {
+          "abrangencia": {
+            "type": "string"
+          },
+          "municipioIbge": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "data": {
+            "type": "string",
+            "format": "date"
+          },
+          "descricao": {
+            "type": "string"
+          }
+        }
+      },
+      "DiaNaoUtilDto": {
+        "required": [
+          "id",
+          "abrangencia",
+          "municipioIbge",
+          "data",
+          "descricao"
+        ],
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "abrangencia": {
+            "type": "string"
+          },
+          "municipioIbge": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "data": {
+            "type": "string",
+            "format": "date"
+          },
+          "descricao": {
+            "type": "string"
           }
         }
       },
@@ -9728,6 +10348,9 @@
     },
     {
       "name": "Profile"
+    },
+    {
+      "name": "CalendariosDiasUteis"
     },
     {
       "name": "Campi"

--- a/contracts/openapi.configuracao.json
+++ b/contracts/openapi.configuracao.json
@@ -9181,6 +9181,12 @@
           },
           "descricao": {
             "type": "string"
+          },
+          "uf": {
+            "type": [
+              "null",
+              "string"
+            ]
           }
         }
       },
@@ -9189,6 +9195,7 @@
           "id",
           "abrangencia",
           "municipioIbge",
+          "uf",
           "data",
           "descricao"
         ],
@@ -9202,6 +9209,12 @@
             "type": "string"
           },
           "municipioIbge": {
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          "uf": {
             "type": [
               "null",
               "string"

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.API/ConfiguracaoModuleRegistration.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.API/ConfiguracaoModuleRegistration.cs
@@ -61,6 +61,8 @@ public static class ConfiguracaoModuleRegistration
         services.AddSingleton<IResourceLinksBuilder<CursoDto>, CursoLinksBuilder>();
         services.AddSingleton<IResourceLinksBuilder<OfertaCursoDto>, OfertaCursoLinksBuilder>();
         services.AddSingleton<IResourceLinksBuilder<PrecedenciaFaseDto>, PrecedenciaFaseLinksBuilder>();
+        services.AddSingleton<IResourceLinksBuilder<CalendarioDiasUteisDto>, CalendarioDiasUteisLinksBuilder>();
+        services.AddSingleton<IResourceLinksBuilder<CalendarioDiasUteisResumoDto>, CalendarioDiasUteisResumoLinksBuilder>();
 
         // Idempotency-Key (ADR-0027) sobre o DbContext do módulo.
         services.AddIdempotency<ConfiguracaoDbContext, ConfiguracaoApiAssemblyMarker>(configuration);

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.API/Controllers/CalendariosDiasUteisController.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.API/Controllers/CalendariosDiasUteisController.cs
@@ -1,0 +1,171 @@
+namespace Unifesspa.UniPlus.Configuracao.API.Controllers;
+
+using System.Diagnostics.CodeAnalysis;
+
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+using Unifesspa.UniPlus.Application.Abstractions.Messaging;
+using Unifesspa.UniPlus.Configuracao.Application.Commands.CalendariosDiasUteis;
+using Unifesspa.UniPlus.Configuracao.Application.DTOs;
+using Unifesspa.UniPlus.Configuracao.Application.Queries.CalendariosDiasUteis;
+using Unifesspa.UniPlus.Infrastructure.Core.Errors;
+using Unifesspa.UniPlus.Infrastructure.Core.Formatting;
+using Unifesspa.UniPlus.Infrastructure.Core.Hateoas;
+using Unifesspa.UniPlus.Infrastructure.Core.Idempotency;
+using Unifesspa.UniPlus.Infrastructure.Core.Pagination;
+using Unifesspa.UniPlus.Kernel.Results;
+
+/// <summary>
+/// Endpoints públicos de leitura (<c>GET /api/configuracao/calendarios-dias-uteis</c>,
+/// <c>GET /api/configuracao/calendarios-dias-uteis/{id}</c>) e endpoints admin
+/// (<c>POST/DELETE /api/configuracao/admin/calendarios-dias-uteis</c>,
+/// <c>POST .../{id}/vigente</c>) restritos a <c>plataforma-admin</c> (UNI-REQ-0080).
+/// </summary>
+[ApiController]
+[SuppressMessage(
+    "Performance",
+    "CA1515:Consider making public types internal",
+    Justification = "ASP.NET Core ControllerFeatureProvider só descobre controllers public.")]
+public sealed class CalendariosDiasUteisController : ControllerBase
+{
+    private const string ResourceTag = "calendarios-dias-uteis";
+
+    private readonly ICommandBus _commandBus;
+    private readonly IQueryBus _queryBus;
+    private readonly IDomainErrorMapper _mapper;
+    private readonly IResourceLinksBuilder<CalendarioDiasUteisResumoDto> _resumoLinksBuilder;
+    private readonly IResourceLinksBuilder<CalendarioDiasUteisDto> _linksBuilder;
+
+    public CalendariosDiasUteisController(
+        ICommandBus commandBus,
+        IQueryBus queryBus,
+        IDomainErrorMapper mapper,
+        IResourceLinksBuilder<CalendarioDiasUteisResumoDto> resumoLinksBuilder,
+        IResourceLinksBuilder<CalendarioDiasUteisDto> linksBuilder)
+    {
+        _commandBus = commandBus;
+        _queryBus = queryBus;
+        _mapper = mapper;
+        _resumoLinksBuilder = resumoLinksBuilder;
+        _linksBuilder = linksBuilder;
+    }
+
+    /// <summary>
+    /// Lista os datasets de calendário de dias úteis vivos, paginados por cursor
+    /// opaco bidirecional (ADR-0026 + ADR-0089). Não inclui os dias não úteis —
+    /// use <see cref="ObterPorId"/> para o dataset completo.
+    /// </summary>
+    [HttpGet("calendarios-dias-uteis")]
+    [AllowAnonymous]
+    [VendorMediaType(Resource = "calendario-dias-uteis", Versions = [1])]
+    [ProducesResponseType(typeof(IEnumerable<CalendarioDiasUteisResumoDto>), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status406NotAcceptable)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status410Gone)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status422UnprocessableEntity)]
+    public async Task<IActionResult> Listar(
+        [FromCursor(ResourceTag)] PageRequest page,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(page);
+
+        ListarCalendariosDiasUteisResult resultado = await _queryBus
+            .Send(new ListarCalendariosDiasUteisQuery(page.AfterId, page.Limit, page.Direction), cancellationToken)
+            .ConfigureAwait(false);
+
+        CalendarioDiasUteisResumoDto[] comLinks =
+            [.. resultado.Items.Select(c => c with { Links = _resumoLinksBuilder.Build(c) })];
+
+        return await this.OkPaginatedAsync(
+            comLinks, resultado.AnteriorAfterId, resultado.ProximoAfterId, page, ResourceTag,
+            cancellationToken: cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <summary>Obtém um dataset pelo Id, com a lista completa de dias não úteis. Retorna 404 quando inexistente.</summary>
+    [HttpGet("calendarios-dias-uteis/{id:guid}")]
+    [AllowAnonymous]
+    [VendorMediaType(Resource = "calendario-dias-uteis", Versions = [1])]
+    [ProducesResponseType(typeof(CalendarioDiasUteisDto), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status406NotAcceptable)]
+    public async Task<IActionResult> ObterPorId(Guid id, CancellationToken cancellationToken)
+    {
+        CalendarioDiasUteisDto? calendario = await _queryBus
+            .Send(new ObterCalendarioDiasUteisPorIdQuery(id), cancellationToken)
+            .ConfigureAwait(false);
+
+        if (calendario is null)
+        {
+            return NotFound();
+        }
+
+        CalendarioDiasUteisDto comLinks = calendario with { Links = _linksBuilder.Build(calendario) };
+        return Ok(comLinks);
+    }
+
+    /// <summary>Cria um novo dataset (nasce não vigente). Restrito a <c>plataforma-admin</c>. Idempotency-Key obrigatório (ADR-0027).</summary>
+    [HttpPost("admin/calendarios-dias-uteis")]
+    [Authorize(Roles = "plataforma-admin")]
+    [RequiresIdempotencyKey]
+    [ProducesResponseType(typeof(Guid), StatusCodes.Status201Created)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status403Forbidden)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status422UnprocessableEntity)]
+    public async Task<IActionResult> Criar(
+        [FromBody] CriarCalendarioDiasUteisCommand command,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(command);
+
+        Result<Guid> resultado = await _commandBus
+            .Send(command, cancellationToken)
+            .ConfigureAwait(false);
+
+        if (resultado.IsSuccess)
+        {
+            return CreatedAtAction(
+                nameof(ObterPorId),
+                new { id = resultado.Value },
+                resultado.Value);
+        }
+
+        return resultado.ToActionResult(_mapper);
+    }
+
+    /// <summary>Torna o dataset o vigente, desmarcando o anterior. Restrito a <c>plataforma-admin</c>.</summary>
+    [HttpPost("admin/calendarios-dias-uteis/{id:guid}/vigente")]
+    [Authorize(Roles = "plataforma-admin")]
+    [RequiresIdempotencyKey]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status403Forbidden)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status409Conflict)]
+    public async Task<IActionResult> MarcarVigente(Guid id, CancellationToken cancellationToken)
+    {
+        Result resultado = await _commandBus
+            .Send(new MarcarVigenteCalendarioDiasUteisCommand(id), cancellationToken)
+            .ConfigureAwait(false);
+
+        return resultado.IsSuccess ? NoContent() : resultado.ToActionResult(_mapper);
+    }
+
+    /// <summary>Remove (soft-delete) um dataset não vigente. Restrito a <c>plataforma-admin</c>.</summary>
+    [HttpDelete("admin/calendarios-dias-uteis/{id:guid}")]
+    [Authorize(Roles = "plataforma-admin")]
+    [ProducesResponseType(StatusCodes.Status204NoContent)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status401Unauthorized)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status403Forbidden)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
+    [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status409Conflict)]
+    public async Task<IActionResult> Remover(Guid id, CancellationToken cancellationToken)
+    {
+        Result resultado = await _commandBus
+            .Send(new RemoverCalendarioDiasUteisCommand(id), cancellationToken)
+            .ConfigureAwait(false);
+
+        return resultado.IsSuccess ? NoContent() : resultado.ToActionResult(_mapper);
+    }
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.API/Errors/ConfiguracaoDomainErrorRegistration.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.API/Errors/ConfiguracaoDomainErrorRegistration.cs
@@ -1214,5 +1214,78 @@ internal sealed class ConfiguracaoDomainErrorRegistration : IDomainErrorRegistra
                 StatusCodes.Status404NotFound,
                 "uniplus.configuracao.oferta_curso.nao_encontrada",
                 "Oferta de curso não encontrada")),
+
+        // ── Calendário de dias úteis (UNI-REQ-0080) ───────────────────────
+        new(CalendarioDiasUteisErrorCodes.VersaoDatasetObrigatoria,
+            new DomainErrorMapping(
+                StatusCodes.Status422UnprocessableEntity,
+                "uniplus.configuracao.calendario_dias_uteis.versao_dataset_obrigatoria",
+                "Versão do dataset é obrigatória")),
+
+        new(CalendarioDiasUteisErrorCodes.VersaoDatasetTamanho,
+            new DomainErrorMapping(
+                StatusCodes.Status422UnprocessableEntity,
+                "uniplus.configuracao.calendario_dias_uteis.versao_dataset_tamanho",
+                "Tamanho da versão do dataset inválido")),
+
+        new(CalendarioDiasUteisErrorCodes.SemDiaNaoUtil,
+            new DomainErrorMapping(
+                StatusCodes.Status422UnprocessableEntity,
+                "uniplus.configuracao.calendario_dias_uteis.sem_dia_nao_util",
+                "O dataset precisa de ao menos um dia não útil")),
+
+        new(CalendarioDiasUteisErrorCodes.AbrangenciaInvalida,
+            new DomainErrorMapping(
+                StatusCodes.Status422UnprocessableEntity,
+                "uniplus.configuracao.calendario_dias_uteis.abrangencia_invalida",
+                "Abrangência do dia não útil fora do domínio fechado")),
+
+        new(CalendarioDiasUteisErrorCodes.MunicipioIbgeObrigatorioParaMunicipal,
+            new DomainErrorMapping(
+                StatusCodes.Status422UnprocessableEntity,
+                "uniplus.configuracao.calendario_dias_uteis.municipio_ibge_obrigatorio_para_municipal",
+                "Código IBGE do município é obrigatório para abrangência municipal")),
+
+        new(CalendarioDiasUteisErrorCodes.MunicipioIbgeApenasParaMunicipal,
+            new DomainErrorMapping(
+                StatusCodes.Status422UnprocessableEntity,
+                "uniplus.configuracao.calendario_dias_uteis.municipio_ibge_apenas_para_municipal",
+                "Código IBGE do município só se aplica a abrangência municipal")),
+
+        new(CalendarioDiasUteisErrorCodes.DescricaoObrigatoria,
+            new DomainErrorMapping(
+                StatusCodes.Status422UnprocessableEntity,
+                "uniplus.configuracao.calendario_dias_uteis.descricao_obrigatoria",
+                "Descrição do dia não útil é obrigatória")),
+
+        new(CalendarioDiasUteisErrorCodes.DescricaoTamanho,
+            new DomainErrorMapping(
+                StatusCodes.Status422UnprocessableEntity,
+                "uniplus.configuracao.calendario_dias_uteis.descricao_tamanho",
+                "Tamanho da descrição do dia não útil inválido")),
+
+        new(CalendarioDiasUteisErrorCodes.DataDuplicadaNoDataset,
+            new DomainErrorMapping(
+                StatusCodes.Status422UnprocessableEntity,
+                "uniplus.configuracao.calendario_dias_uteis.data_duplicada_no_dataset",
+                "Data duplicada no dataset (mesma abrangência e município)")),
+
+        new(CalendarioDiasUteisErrorCodes.JaVigente,
+            new DomainErrorMapping(
+                StatusCodes.Status409Conflict,
+                "uniplus.configuracao.calendario_dias_uteis.ja_vigente",
+                "Este dataset já é o vigente")),
+
+        new(CalendarioDiasUteisErrorCodes.NaoRemoveVigente,
+            new DomainErrorMapping(
+                StatusCodes.Status409Conflict,
+                "uniplus.configuracao.calendario_dias_uteis.nao_remove_vigente",
+                "O dataset vigente não pode ser removido")),
+
+        new(CalendarioDiasUteisErrorCodes.NaoEncontrado,
+            new DomainErrorMapping(
+                StatusCodes.Status404NotFound,
+                "uniplus.configuracao.calendario_dias_uteis.nao_encontrado",
+                "Calendário de dias úteis não encontrado")),
     ];
 }

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.API/Errors/ConfiguracaoDomainErrorRegistration.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.API/Errors/ConfiguracaoDomainErrorRegistration.cs
@@ -1252,6 +1252,18 @@ internal sealed class ConfiguracaoDomainErrorRegistration : IDomainErrorRegistra
                 "uniplus.configuracao.calendario_dias_uteis.municipio_ibge_apenas_para_municipal",
                 "Código IBGE do município só se aplica a abrangência municipal")),
 
+        new(CalendarioDiasUteisErrorCodes.MunicipioIbgeFormatoInvalido,
+            new DomainErrorMapping(
+                StatusCodes.Status422UnprocessableEntity,
+                "uniplus.configuracao.calendario_dias_uteis.municipio_ibge_formato_invalido",
+                "Código IBGE do município em formato inválido")),
+
+        new(CalendarioDiasUteisErrorCodes.DiaNaoUtilNulo,
+            new DomainErrorMapping(
+                StatusCodes.Status422UnprocessableEntity,
+                "uniplus.configuracao.calendario_dias_uteis.dia_nao_util_nulo",
+                "Item de dia não útil não pode ser nulo")),
+
         new(CalendarioDiasUteisErrorCodes.DescricaoObrigatoria,
             new DomainErrorMapping(
                 StatusCodes.Status422UnprocessableEntity,
@@ -1287,5 +1299,11 @@ internal sealed class ConfiguracaoDomainErrorRegistration : IDomainErrorRegistra
                 StatusCodes.Status404NotFound,
                 "uniplus.configuracao.calendario_dias_uteis.nao_encontrado",
                 "Calendário de dias úteis não encontrado")),
+
+        new(CalendarioDiasUteisErrorCodes.ConflitoDeConcorrencia,
+            new DomainErrorMapping(
+                StatusCodes.Status409Conflict,
+                "uniplus.configuracao.calendario_dias_uteis.conflito_de_concorrencia",
+                "Outra alteração concorrente modificou o mesmo dataset ou o dataset vigente")),
     ];
 }

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.API/Errors/ConfiguracaoDomainErrorRegistration.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.API/Errors/ConfiguracaoDomainErrorRegistration.cs
@@ -1258,6 +1258,24 @@ internal sealed class ConfiguracaoDomainErrorRegistration : IDomainErrorRegistra
                 "uniplus.configuracao.calendario_dias_uteis.municipio_ibge_formato_invalido",
                 "Código IBGE do município em formato inválido")),
 
+        new(CalendarioDiasUteisErrorCodes.UfObrigatoriaParaEstadual,
+            new DomainErrorMapping(
+                StatusCodes.Status422UnprocessableEntity,
+                "uniplus.configuracao.calendario_dias_uteis.uf_obrigatoria_para_estadual",
+                "UF é obrigatória para abrangência estadual")),
+
+        new(CalendarioDiasUteisErrorCodes.UfApenasParaEstadual,
+            new DomainErrorMapping(
+                StatusCodes.Status422UnprocessableEntity,
+                "uniplus.configuracao.calendario_dias_uteis.uf_apenas_para_estadual",
+                "UF só se aplica a abrangência estadual")),
+
+        new(CalendarioDiasUteisErrorCodes.UfFormatoInvalido,
+            new DomainErrorMapping(
+                StatusCodes.Status422UnprocessableEntity,
+                "uniplus.configuracao.calendario_dias_uteis.uf_formato_invalido",
+                "UF em formato inválido")),
+
         new(CalendarioDiasUteisErrorCodes.DiaNaoUtilNulo,
             new DomainErrorMapping(
                 StatusCodes.Status422UnprocessableEntity,

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.API/Hateoas/CalendarioDiasUteisLinksBuilder.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.API/Hateoas/CalendarioDiasUteisLinksBuilder.cs
@@ -1,0 +1,64 @@
+namespace Unifesspa.UniPlus.Configuracao.API.Hateoas;
+
+using System.Diagnostics.CodeAnalysis;
+
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+
+using Unifesspa.UniPlus.Configuracao.API.Controllers;
+using Unifesspa.UniPlus.Configuracao.Application.DTOs;
+using Unifesspa.UniPlus.Infrastructure.Core.Hateoas;
+
+/// <summary>
+/// Builder de <c>_links</c> hypermedia (HATEOAS Level 1, ADR-0029) para
+/// <see cref="CalendarioDiasUteisDto"/> (dataset completo, endpoint
+/// <c>ObterPorId</c>). Relações em V1: <c>self</c> e <c>collection</c>.
+/// </summary>
+[SuppressMessage(
+    "Performance",
+    "CA1812:Avoid uninstantiated internal classes",
+    Justification = "Instanciada via IServiceProvider.AddSingleton<IResourceLinksBuilder<CalendarioDiasUteisDto>, CalendarioDiasUteisLinksBuilder>().")]
+internal sealed class CalendarioDiasUteisLinksBuilder : IResourceLinksBuilder<CalendarioDiasUteisDto>
+{
+    private readonly LinkGenerator _linkGenerator;
+    private readonly IHttpContextAccessor _httpContextAccessor;
+
+    public CalendarioDiasUteisLinksBuilder(LinkGenerator linkGenerator, IHttpContextAccessor httpContextAccessor)
+    {
+        ArgumentNullException.ThrowIfNull(linkGenerator);
+        ArgumentNullException.ThrowIfNull(httpContextAccessor);
+        _linkGenerator = linkGenerator;
+        _httpContextAccessor = httpContextAccessor;
+    }
+
+    public IReadOnlyDictionary<string, string> Build(CalendarioDiasUteisDto dto)
+    {
+        ArgumentNullException.ThrowIfNull(dto);
+
+        HttpContext? httpContext = _httpContextAccessor.HttpContext;
+        const string controllerName = "CalendariosDiasUteis";
+
+        string self = ResolverPath(
+            httpContext, nameof(CalendariosDiasUteisController.ObterPorId), controllerName, new { id = dto.Id });
+        string collection = ResolverPath(
+            httpContext, nameof(CalendariosDiasUteisController.Listar), controllerName, values: null);
+
+        return new Dictionary<string, string>(StringComparer.Ordinal)
+        {
+            ["self"] = self,
+            ["collection"] = collection,
+        };
+    }
+
+    private string ResolverPath(HttpContext? httpContext, string action, string controller, object? values)
+    {
+        string? path = httpContext is not null
+            ? _linkGenerator.GetPathByAction(httpContext, action: action, controller: controller, values: values)
+            : _linkGenerator.GetPathByAction(action: action, controller: controller, values: values);
+
+        return path
+            ?? throw new InvalidOperationException(
+                $"LinkGenerator não conseguiu resolver a rota para {action}. " +
+                "Verifique o registro do controller e o template de rota.");
+    }
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.API/Hateoas/CalendarioDiasUteisResumoLinksBuilder.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.API/Hateoas/CalendarioDiasUteisResumoLinksBuilder.cs
@@ -1,0 +1,64 @@
+namespace Unifesspa.UniPlus.Configuracao.API.Hateoas;
+
+using System.Diagnostics.CodeAnalysis;
+
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+
+using Unifesspa.UniPlus.Configuracao.API.Controllers;
+using Unifesspa.UniPlus.Configuracao.Application.DTOs;
+using Unifesspa.UniPlus.Infrastructure.Core.Hateoas;
+
+/// <summary>
+/// Builder de <c>_links</c> hypermedia (HATEOAS Level 1, ADR-0029) para
+/// <see cref="CalendarioDiasUteisResumoDto"/> (item de listagem). Relações em V1:
+/// <c>self</c> e <c>collection</c>.
+/// </summary>
+[SuppressMessage(
+    "Performance",
+    "CA1812:Avoid uninstantiated internal classes",
+    Justification = "Instanciada via IServiceProvider.AddSingleton<IResourceLinksBuilder<CalendarioDiasUteisResumoDto>, CalendarioDiasUteisResumoLinksBuilder>().")]
+internal sealed class CalendarioDiasUteisResumoLinksBuilder : IResourceLinksBuilder<CalendarioDiasUteisResumoDto>
+{
+    private readonly LinkGenerator _linkGenerator;
+    private readonly IHttpContextAccessor _httpContextAccessor;
+
+    public CalendarioDiasUteisResumoLinksBuilder(LinkGenerator linkGenerator, IHttpContextAccessor httpContextAccessor)
+    {
+        ArgumentNullException.ThrowIfNull(linkGenerator);
+        ArgumentNullException.ThrowIfNull(httpContextAccessor);
+        _linkGenerator = linkGenerator;
+        _httpContextAccessor = httpContextAccessor;
+    }
+
+    public IReadOnlyDictionary<string, string> Build(CalendarioDiasUteisResumoDto dto)
+    {
+        ArgumentNullException.ThrowIfNull(dto);
+
+        HttpContext? httpContext = _httpContextAccessor.HttpContext;
+        const string controllerName = "CalendariosDiasUteis";
+
+        string self = ResolverPath(
+            httpContext, nameof(CalendariosDiasUteisController.ObterPorId), controllerName, new { id = dto.Id });
+        string collection = ResolverPath(
+            httpContext, nameof(CalendariosDiasUteisController.Listar), controllerName, values: null);
+
+        return new Dictionary<string, string>(StringComparer.Ordinal)
+        {
+            ["self"] = self,
+            ["collection"] = collection,
+        };
+    }
+
+    private string ResolverPath(HttpContext? httpContext, string action, string controller, object? values)
+    {
+        string? path = httpContext is not null
+            ? _linkGenerator.GetPathByAction(httpContext, action: action, controller: controller, values: values)
+            : _linkGenerator.GetPathByAction(action: action, controller: controller, values: values);
+
+        return path
+            ?? throw new InvalidOperationException(
+                $"LinkGenerator não conseguiu resolver a rota para {action}. " +
+                "Verifique o registro do controller e o template de rota.");
+    }
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Abstractions/IConfiguracaoUnitOfWork.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Abstractions/IConfiguracaoUnitOfWork.cs
@@ -3,12 +3,28 @@ namespace Unifesspa.UniPlus.Configuracao.Application.Abstractions;
 using Unifesspa.UniPlus.Application.Abstractions.Interfaces;
 
 /// <summary>
-/// UnitOfWork do módulo Configuracao. Especialização sem novos membros de
-/// <see cref="IUnitOfWork"/> que dá um tipo de registro próprio ao módulo —
-/// garante o isolamento da transação no monólito modular, onde vários módulos
-/// coexistem no mesmo container e um <see cref="IUnitOfWork"/> compartilhado
-/// colidiria no contêiner de DI (o último registro venceria).
+/// UnitOfWork do módulo Configuracao. Especialização de <see cref="IUnitOfWork"/>
+/// que dá um tipo de registro próprio ao módulo — garante o isolamento da
+/// transação no monólito modular, onde vários módulos coexistem no mesmo
+/// container e um <see cref="IUnitOfWork"/> compartilhado colidiria no
+/// contêiner de DI (o último registro venceria).
 /// </summary>
 public interface IConfiguracaoUnitOfWork : IUnitOfWork
 {
+    /// <summary>
+    /// Força a checagem imediata de constraints <c>DEFERRABLE</c> pendentes na
+    /// transação corrente (equivalente a <c>SET CONSTRAINTS ALL IMMEDIATE</c>).
+    /// </summary>
+    /// <remarks>
+    /// O outbox transacional do Wolverine (<c>UseEntityFrameworkCoreTransactions</c>
+    /// + <c>AutoApplyTransactions</c>, ADR-0004) abre a transação ANTES do handler
+    /// rodar e só comita DEPOIS do handler retornar — uma exclusion/unique constraint
+    /// <c>DEFERRABLE INITIALLY DEFERRED</c> só é checada nesse commit externo, fora do
+    /// escopo de qualquer <c>try/catch</c> do handler. Chamar este método logo após
+    /// <see cref="IUnitOfWork.SalvarAlteracoesAsync"/> força a checagem AINDA dentro
+    /// do handler, onde a exceção pode ser traduzida para um <c>DomainError</c>
+    /// (ex.: <c>ExclusionConstraintViolation</c>) em vez de vazar como 500 do commit
+    /// do Wolverine.
+    /// </remarks>
+    Task ForcarChecagemImediataDeConstraintsAsync(CancellationToken cancellationToken = default);
 }

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/CalendariosDiasUteis/CriarCalendarioDiasUteisCommand.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/CalendariosDiasUteis/CriarCalendarioDiasUteisCommand.cs
@@ -1,0 +1,15 @@
+namespace Unifesspa.UniPlus.Configuracao.Application.Commands.CalendariosDiasUteis;
+
+using Unifesspa.UniPlus.Application.Abstractions.Messaging;
+using Unifesspa.UniPlus.Kernel.Results;
+
+/// <summary>
+/// Cria um dataset de calendário de dias úteis (UNI-REQ-0080): a versão do dataset
+/// e a lista completa de dias não úteis. Nasce sempre não vigente — tornar-se o
+/// dataset corrente é o comando <c>MarcarVigenteCalendarioDiasUteisCommand</c>,
+/// separado. O ator de auditoria (<c>created_by</c>) é carimbado server-side via
+/// <c>IUserContext</c>, não no payload.
+/// </summary>
+public sealed record CriarCalendarioDiasUteisCommand(
+    string VersaoDataset,
+    IReadOnlyList<DiaNaoUtilCommandItem> DiasNaoUteis) : ICommand<Result<Guid>>;

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/CalendariosDiasUteis/CriarCalendarioDiasUteisCommandHandler.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/CalendariosDiasUteis/CriarCalendarioDiasUteisCommandHandler.cs
@@ -1,0 +1,41 @@
+namespace Unifesspa.UniPlus.Configuracao.Application.Commands.CalendariosDiasUteis;
+
+using Unifesspa.UniPlus.Configuracao.Application.Abstractions;
+using Unifesspa.UniPlus.Configuracao.Domain.Entities;
+using Unifesspa.UniPlus.Configuracao.Domain.Interfaces;
+using Unifesspa.UniPlus.Kernel.Results;
+
+/// <summary>
+/// Handler do <see cref="CriarCalendarioDiasUteisCommand"/> (convention-based
+/// Wolverine): constrói o agregado (token de abrangência analisado e invariantes
+/// de coerência conferidas no próprio <c>CalendarioDiasUteis.Criar</c>), persiste
+/// e commita. Sem checagem de unicidade — <c>VersaoDataset</c> não é chave natural.
+/// </summary>
+public static class CriarCalendarioDiasUteisCommandHandler
+{
+    public static async Task<Result<Guid>> Handle(
+        CriarCalendarioDiasUteisCommand command,
+        ICalendarioDiasUteisRepository repository,
+        IConfiguracaoUnitOfWork unitOfWork,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(command);
+        ArgumentNullException.ThrowIfNull(repository);
+        ArgumentNullException.ThrowIfNull(unitOfWork);
+
+        Result<CalendarioDiasUteis> calendarioResult = CalendarioDiasUteis.Criar(
+            command.VersaoDataset,
+            [.. command.DiasNaoUteis.Select(d => new DiaNaoUtilCriacao(d.Abrangencia, d.MunicipioIbge, d.Data, d.Descricao))]);
+
+        if (calendarioResult.IsFailure)
+        {
+            return Result<Guid>.Failure(calendarioResult.Error!);
+        }
+
+        CalendarioDiasUteis calendario = calendarioResult.Value!;
+        await repository.AdicionarAsync(calendario, cancellationToken).ConfigureAwait(false);
+        await unitOfWork.SalvarAlteracoesAsync(cancellationToken).ConfigureAwait(false);
+
+        return Result<Guid>.Success(calendario.Id);
+    }
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/CalendariosDiasUteis/CriarCalendarioDiasUteisCommandHandler.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/CalendariosDiasUteis/CriarCalendarioDiasUteisCommandHandler.cs
@@ -25,7 +25,7 @@ public static class CriarCalendarioDiasUteisCommandHandler
 
         Result<CalendarioDiasUteis> calendarioResult = CalendarioDiasUteis.Criar(
             command.VersaoDataset,
-            [.. command.DiasNaoUteis.Select(d => new DiaNaoUtilCriacao(d.Abrangencia, d.MunicipioIbge, d.Data, d.Descricao))]);
+            [.. command.DiasNaoUteis.Select(d => new DiaNaoUtilCriacao(d.Abrangencia, d.MunicipioIbge, d.Data, d.Descricao, d.Uf))]);
 
         if (calendarioResult.IsFailure)
         {

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/CalendariosDiasUteis/CriarCalendarioDiasUteisCommandValidator.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/CalendariosDiasUteis/CriarCalendarioDiasUteisCommandValidator.cs
@@ -13,7 +13,14 @@ public sealed class CriarCalendarioDiasUteisCommandValidator : AbstractValidator
         RuleFor(x => x.DiasNaoUteis)
             .NotEmpty().WithMessage("O dataset precisa de ao menos um dia não útil.");
 
-        RuleForEach(x => x.DiasNaoUteis).ChildRules(dia =>
+        // NotNull por item ANTES do ChildRules: sem isso, um elemento nulo (ex. JSON
+        // "diasNaoUteis":[null]) passa incólume pelas regras — RuleForEach roda
+        // ChildRules contra um objeto raiz nulo sem produzir falha — e o handler
+        // desreferencia o item nulo ao montar DiaNaoUtilCriacao (500 em vez de 422).
+        RuleForEach(x => x.DiasNaoUteis)
+            .NotNull().WithMessage("Item de dia não útil não pode ser nulo.");
+
+        RuleForEach(x => x.DiasNaoUteis).Where(d => d is not null).ChildRules(dia =>
         {
             dia.RuleFor(d => d.Abrangencia).NotEmpty().WithMessage("Abrangência é obrigatória.");
             dia.RuleFor(d => d.Descricao)

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/CalendariosDiasUteis/CriarCalendarioDiasUteisCommandValidator.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/CalendariosDiasUteis/CriarCalendarioDiasUteisCommandValidator.cs
@@ -1,0 +1,24 @@
+namespace Unifesspa.UniPlus.Configuracao.Application.Commands.CalendariosDiasUteis;
+
+using FluentValidation;
+
+public sealed class CriarCalendarioDiasUteisCommandValidator : AbstractValidator<CriarCalendarioDiasUteisCommand>
+{
+    public CriarCalendarioDiasUteisCommandValidator()
+    {
+        RuleFor(x => x.VersaoDataset)
+            .NotEmpty().WithMessage("Versão do dataset é obrigatória.")
+            .MaximumLength(60).WithMessage("Versão do dataset deve ter no máximo 60 caracteres.");
+
+        RuleFor(x => x.DiasNaoUteis)
+            .NotEmpty().WithMessage("O dataset precisa de ao menos um dia não útil.");
+
+        RuleForEach(x => x.DiasNaoUteis).ChildRules(dia =>
+        {
+            dia.RuleFor(d => d.Abrangencia).NotEmpty().WithMessage("Abrangência é obrigatória.");
+            dia.RuleFor(d => d.Descricao)
+                .NotEmpty().WithMessage("Descrição é obrigatória.")
+                .MaximumLength(200).WithMessage("Descrição deve ter no máximo 200 caracteres.");
+        });
+    }
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/CalendariosDiasUteis/DiaNaoUtilCommandItem.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/CalendariosDiasUteis/DiaNaoUtilCommandItem.cs
@@ -3,10 +3,12 @@ namespace Unifesspa.UniPlus.Configuracao.Application.Commands.CalendariosDiasUte
 /// <summary>
 /// Item de entrada de um dia não útil no payload de criação. <c>Abrangencia</c> é o
 /// token canônico UPPER_SNAKE (ex.: <c>NACIONAL</c>, <c>MUNICIPAL</c>) — a análise
-/// e a validação de campo ocorrem no agregado (<c>CalendarioDiasUteis.Criar</c>).
+/// e a validação de campo (inclusive <c>Uf</c> obrigatória para ESTADUAL) ocorrem
+/// no agregado (<c>CalendarioDiasUteis.Criar</c>).
 /// </summary>
 public sealed record DiaNaoUtilCommandItem(
     string Abrangencia,
     string? MunicipioIbge,
     DateOnly Data,
-    string Descricao);
+    string Descricao,
+    string? Uf = null);

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/CalendariosDiasUteis/DiaNaoUtilCommandItem.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/CalendariosDiasUteis/DiaNaoUtilCommandItem.cs
@@ -1,0 +1,12 @@
+namespace Unifesspa.UniPlus.Configuracao.Application.Commands.CalendariosDiasUteis;
+
+/// <summary>
+/// Item de entrada de um dia não útil no payload de criação. <c>Abrangencia</c> é o
+/// token canônico UPPER_SNAKE (ex.: <c>NACIONAL</c>, <c>MUNICIPAL</c>) — a análise
+/// e a validação de campo ocorrem no agregado (<c>CalendarioDiasUteis.Criar</c>).
+/// </summary>
+public sealed record DiaNaoUtilCommandItem(
+    string Abrangencia,
+    string? MunicipioIbge,
+    DateOnly Data,
+    string Descricao);

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/CalendariosDiasUteis/ExclusionConstraintViolation.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/CalendariosDiasUteis/ExclusionConstraintViolation.cs
@@ -1,0 +1,63 @@
+namespace Unifesspa.UniPlus.Configuracao.Application.Commands.CalendariosDiasUteis;
+
+/// <summary>
+/// Helper para mapear violações 23P01 (exclusion_violation) da exclusion constraint
+/// GiST <c>ex_calendario_dias_uteis_vigente_unico</c> (issue #1016) para o
+/// <c>DomainError</c> de conflito. A inspeção do tipo da exceção por
+/// <see cref="Type.FullName"/> evita dependência direta de <c>Npgsql</c>/
+/// <c>Microsoft.EntityFrameworkCore</c> na camada Application (mantém Clean Arch).
+/// </summary>
+/// <remarks>
+/// Diferente do <c>UniqueConstraintViolation</c> dos demais cadastros (que só
+/// olham dentro de um <c>DbUpdateException</c>): como a constraint é
+/// <c>DEFERRABLE INITIALLY DEFERRED</c>, a checagem só roda no <c>COMMIT</c> da
+/// transação — a violação chega como <c>Npgsql.PostgresException</c> BRUTA de
+/// <c>NpgsqlTransaction.Commit</c>, não embrulhada em <c>DbUpdateException</c> (que
+/// o EF Core só produz para falhas durante a execução do batch de comandos). Este
+/// helper cobre os dois formatos.
+/// </remarks>
+internal static class ExclusionConstraintViolation
+{
+    private const string ExclusionViolationSqlState = "23P01";
+
+    private const string VigenteConstraint = "ex_calendario_dias_uteis_vigente_unico";
+
+    private const string PostgresExceptionFullName = "Npgsql.PostgresException";
+
+    private const string DbUpdateExceptionFullName = "Microsoft.EntityFrameworkCore.DbUpdateException";
+
+    /// <summary><see langword="true"/> quando <paramref name="ex"/> é a violação da exclusion constraint de vigência.</summary>
+    public static bool IsVigenteConflict(Exception ex)
+    {
+        ArgumentNullException.ThrowIfNull(ex);
+        return string.Equals(GetViolatedConstraint(ex), VigenteConstraint, StringComparison.Ordinal);
+    }
+
+    private static string? GetViolatedConstraint(Exception ex)
+    {
+        Exception pgCandidate = ex;
+
+        if (string.Equals(ex.GetType().FullName, DbUpdateExceptionFullName, StringComparison.Ordinal))
+        {
+            if (ex.InnerException is null)
+            {
+                return null;
+            }
+
+            pgCandidate = ex.InnerException;
+        }
+        else if (!string.Equals(ex.GetType().FullName, PostgresExceptionFullName, StringComparison.Ordinal))
+        {
+            return null;
+        }
+
+        Type pgType = pgCandidate.GetType();
+        string? sqlState = pgType.GetProperty("SqlState")?.GetValue(pgCandidate) as string;
+        if (sqlState != ExclusionViolationSqlState)
+        {
+            return null;
+        }
+
+        return pgType.GetProperty("ConstraintName")?.GetValue(pgCandidate) as string;
+    }
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/CalendariosDiasUteis/MarcarVigenteCalendarioDiasUteisCommand.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/CalendariosDiasUteis/MarcarVigenteCalendarioDiasUteisCommand.cs
@@ -1,0 +1,10 @@
+namespace Unifesspa.UniPlus.Configuracao.Application.Commands.CalendariosDiasUteis;
+
+using Unifesspa.UniPlus.Application.Abstractions.Messaging;
+using Unifesspa.UniPlus.Kernel.Results;
+
+/// <summary>
+/// Torna o dataset <paramref name="Id"/> o vigente, desmarcando o vigente anterior
+/// (se houver) na mesma transação — no máximo um dataset é vigente por vez.
+/// </summary>
+public sealed record MarcarVigenteCalendarioDiasUteisCommand(Guid Id) : ICommand<Result>;

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/CalendariosDiasUteis/MarcarVigenteCalendarioDiasUteisCommandHandler.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/CalendariosDiasUteis/MarcarVigenteCalendarioDiasUteisCommandHandler.cs
@@ -9,8 +9,8 @@ using Unifesspa.UniPlus.Kernel.Results;
 /// <summary>
 /// Handler do <see cref="MarcarVigenteCalendarioDiasUteisCommand"/>: localiza o
 /// vigente anterior (se houver) e o desmarca antes de marcar o novo — a invariante
-/// "no máximo um vigente" é aplicada aqui (cross-agregado), reforçada pelo índice
-/// único parcial de banco como defesa de última linha.
+/// "no máximo um vigente" é aplicada aqui (cross-agregado), reforçada pela
+/// exclusion constraint de banco como defesa de última linha.
 /// </summary>
 public static class MarcarVigenteCalendarioDiasUteisCommandHandler
 {
@@ -48,7 +48,21 @@ public static class MarcarVigenteCalendarioDiasUteisCommandHandler
             vigenteAnterior.MarcarNaoVigente();
         }
 
-        await unitOfWork.SalvarAlteracoesAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            await unitOfWork.SalvarAlteracoesAsync(cancellationToken).ConfigureAwait(false);
+        }
+        catch (Exception ex) when (ExclusionConstraintViolation.IsVigenteConflict(ex) || OptimisticConcurrencyViolation.Is(ex))
+        {
+            // Corrida entre duas ativações concorrentes (exclusion constraint, dois
+            // registros disputando o mesmo "vigente = true") ou entre esta ativação e
+            // uma remoção concorrente do MESMO dataset (xmin) — em ambos os casos o
+            // outro lado já decidiu o estado; o filtro do `when` garante que outras
+            // exceções propagam intactas.
+            return Result.Failure(new DomainError(
+                CalendarioDiasUteisErrorCodes.ConflitoDeConcorrencia,
+                "Outra alteração concorrente já modificou este dataset ou o dataset vigente. Tente novamente."));
+        }
 
         return Result.Success();
     }

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/CalendariosDiasUteis/MarcarVigenteCalendarioDiasUteisCommandHandler.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/CalendariosDiasUteis/MarcarVigenteCalendarioDiasUteisCommandHandler.cs
@@ -51,6 +51,12 @@ public static class MarcarVigenteCalendarioDiasUteisCommandHandler
         try
         {
             await unitOfWork.SalvarAlteracoesAsync(cancellationToken).ConfigureAwait(false);
+
+            // A exclusion constraint de vigência é DEFERRABLE INITIALLY DEFERRED — sem
+            // forçar a checagem aqui, ela só rodaria no commit externo que o outbox do
+            // Wolverine executa DEPOIS deste handler retornar (UseEntityFrameworkCoreTransactions
+            // + AutoApplyTransactions, ADR-0004), fora do alcance deste catch.
+            await unitOfWork.ForcarChecagemImediataDeConstraintsAsync(cancellationToken).ConfigureAwait(false);
         }
         catch (Exception ex) when (ExclusionConstraintViolation.IsVigenteConflict(ex) || OptimisticConcurrencyViolation.Is(ex))
         {

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/CalendariosDiasUteis/MarcarVigenteCalendarioDiasUteisCommandHandler.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/CalendariosDiasUteis/MarcarVigenteCalendarioDiasUteisCommandHandler.cs
@@ -1,0 +1,55 @@
+namespace Unifesspa.UniPlus.Configuracao.Application.Commands.CalendariosDiasUteis;
+
+using Unifesspa.UniPlus.Configuracao.Application.Abstractions;
+using Unifesspa.UniPlus.Configuracao.Domain.Entities;
+using Unifesspa.UniPlus.Configuracao.Domain.Errors;
+using Unifesspa.UniPlus.Configuracao.Domain.Interfaces;
+using Unifesspa.UniPlus.Kernel.Results;
+
+/// <summary>
+/// Handler do <see cref="MarcarVigenteCalendarioDiasUteisCommand"/>: localiza o
+/// vigente anterior (se houver) e o desmarca antes de marcar o novo — a invariante
+/// "no máximo um vigente" é aplicada aqui (cross-agregado), reforçada pelo índice
+/// único parcial de banco como defesa de última linha.
+/// </summary>
+public static class MarcarVigenteCalendarioDiasUteisCommandHandler
+{
+    public static async Task<Result> Handle(
+        MarcarVigenteCalendarioDiasUteisCommand command,
+        ICalendarioDiasUteisRepository repository,
+        IConfiguracaoUnitOfWork unitOfWork,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(command);
+        ArgumentNullException.ThrowIfNull(repository);
+        ArgumentNullException.ThrowIfNull(unitOfWork);
+
+        CalendarioDiasUteis? calendario = await repository
+            .ObterPorIdAsync(command.Id, cancellationToken)
+            .ConfigureAwait(false);
+        if (calendario is null)
+        {
+            return Result.Failure(new DomainError(
+                CalendarioDiasUteisErrorCodes.NaoEncontrado,
+                "Calendário de dias úteis não encontrado."));
+        }
+
+        Result marcarResult = calendario.MarcarVigente();
+        if (marcarResult.IsFailure)
+        {
+            return marcarResult;
+        }
+
+        CalendarioDiasUteis? vigenteAnterior = await repository
+            .ObterVigenteAsync(cancellationToken)
+            .ConfigureAwait(false);
+        if (vigenteAnterior is not null && vigenteAnterior.Id != calendario.Id)
+        {
+            vigenteAnterior.MarcarNaoVigente();
+        }
+
+        await unitOfWork.SalvarAlteracoesAsync(cancellationToken).ConfigureAwait(false);
+
+        return Result.Success();
+    }
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/CalendariosDiasUteis/OptimisticConcurrencyViolation.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/CalendariosDiasUteis/OptimisticConcurrencyViolation.cs
@@ -1,0 +1,25 @@
+namespace Unifesspa.UniPlus.Configuracao.Application.Commands.CalendariosDiasUteis;
+
+/// <summary>
+/// Detecta <c>DbUpdateConcurrencyException</c> por <see cref="Type.FullName"/> (evita
+/// dependência direta de <c>Microsoft.EntityFrameworkCore</c> na camada Application —
+/// mantém Clean Arch, mesmo raciocínio de <see cref="ExclusionConstraintViolation"/>).
+/// </summary>
+/// <remarks>
+/// O token de concorrência otimista (<c>xmin</c>, ver
+/// <c>CalendarioDiasUteisConfiguration</c>) detecta a corrida entre
+/// <c>MarcarVigenteCalendarioDiasUteisCommandHandler</c> e
+/// <c>RemoverCalendarioDiasUteisCommandHandler</c> quando os dois mutam o MESMO
+/// registro (ex.: ativar um dataset enquanto ele é removido) — corrida que a
+/// exclusion constraint de vigência não cobre, por só comparar registros diferentes.
+/// </remarks>
+internal static class OptimisticConcurrencyViolation
+{
+    private const string DbUpdateConcurrencyExceptionFullName = "Microsoft.EntityFrameworkCore.DbUpdateConcurrencyException";
+
+    public static bool Is(Exception ex)
+    {
+        ArgumentNullException.ThrowIfNull(ex);
+        return string.Equals(ex.GetType().FullName, DbUpdateConcurrencyExceptionFullName, StringComparison.Ordinal);
+    }
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/CalendariosDiasUteis/RemoverCalendarioDiasUteisCommand.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/CalendariosDiasUteis/RemoverCalendarioDiasUteisCommand.cs
@@ -1,0 +1,6 @@
+namespace Unifesspa.UniPlus.Configuracao.Application.Commands.CalendariosDiasUteis;
+
+using Unifesspa.UniPlus.Application.Abstractions.Messaging;
+using Unifesspa.UniPlus.Kernel.Results;
+
+public sealed record RemoverCalendarioDiasUteisCommand(Guid Id) : ICommand<Result>;

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/CalendariosDiasUteis/RemoverCalendarioDiasUteisCommandHandler.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/CalendariosDiasUteis/RemoverCalendarioDiasUteisCommandHandler.cs
@@ -44,7 +44,24 @@ public static class RemoverCalendarioDiasUteisCommandHandler
         }
 
         repository.Remover(calendario);
-        await unitOfWork.SalvarAlteracoesAsync(cancellationToken).ConfigureAwait(false);
+
+        try
+        {
+            await unitOfWork.SalvarAlteracoesAsync(cancellationToken).ConfigureAwait(false);
+        }
+        catch (Exception ex) when (OptimisticConcurrencyViolation.Is(ex))
+        {
+            // Corrida com uma ativação concorrente do MESMO dataset (xmin, ver
+            // CalendarioDiasUteisConfiguration): a checagem acima leu Vigente=false,
+            // mas MarcarVigenteCalendarioDiasUteisCommandHandler pode ter marcado este
+            // dataset como o vigente entre a leitura e este commit — sem o token de
+            // concorrência, o resultado seria remover silenciosamente o dataset que
+            // acabou de virar vigente, deixando nenhum vigente visível. O filtro do
+            // `when` garante que outras exceções propagam intactas.
+            return Result.Failure(new DomainError(
+                CalendarioDiasUteisErrorCodes.ConflitoDeConcorrencia,
+                "Este dataset foi modificado concorrentemente (possivelmente marcado vigente). Tente novamente."));
+        }
 
         return Result.Success();
     }

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/CalendariosDiasUteis/RemoverCalendarioDiasUteisCommandHandler.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/CalendariosDiasUteis/RemoverCalendarioDiasUteisCommandHandler.cs
@@ -1,0 +1,51 @@
+namespace Unifesspa.UniPlus.Configuracao.Application.Commands.CalendariosDiasUteis;
+
+using Unifesspa.UniPlus.Configuracao.Application.Abstractions;
+using Unifesspa.UniPlus.Configuracao.Domain.Entities;
+using Unifesspa.UniPlus.Configuracao.Domain.Errors;
+using Unifesspa.UniPlus.Configuracao.Domain.Interfaces;
+using Unifesspa.UniPlus.Kernel.Results;
+
+/// <summary>
+/// Handler do <see cref="RemoverCalendarioDiasUteisCommand"/>. Soft-delete via
+/// <c>SoftDeleteInterceptor</c>; os dias não úteis (filhos, sem soft-delete
+/// próprio) permanecem intactos sob a linha soft-deleted (ADR do padrão
+/// Unidade/Historico). Recusa remover o dataset vigente — trocar de vigente é
+/// operação explícita (<c>MarcarVigenteCalendarioDiasUteisCommand</c>), nunca
+/// efeito colateral de uma remoção.
+/// </summary>
+public static class RemoverCalendarioDiasUteisCommandHandler
+{
+    public static async Task<Result> Handle(
+        RemoverCalendarioDiasUteisCommand command,
+        ICalendarioDiasUteisRepository repository,
+        IConfiguracaoUnitOfWork unitOfWork,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(command);
+        ArgumentNullException.ThrowIfNull(repository);
+        ArgumentNullException.ThrowIfNull(unitOfWork);
+
+        CalendarioDiasUteis? calendario = await repository
+            .ObterPorIdAsync(command.Id, cancellationToken)
+            .ConfigureAwait(false);
+        if (calendario is null)
+        {
+            return Result.Failure(new DomainError(
+                CalendarioDiasUteisErrorCodes.NaoEncontrado,
+                "Calendário de dias úteis não encontrado."));
+        }
+
+        if (calendario.Vigente)
+        {
+            return Result.Failure(new DomainError(
+                CalendarioDiasUteisErrorCodes.NaoRemoveVigente,
+                "O dataset vigente não pode ser removido — marque outro dataset como vigente antes."));
+        }
+
+        repository.Remover(calendario);
+        await unitOfWork.SalvarAlteracoesAsync(cancellationToken).ConfigureAwait(false);
+
+        return Result.Success();
+    }
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/DTOs/CalendarioDiasUteisDto.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/DTOs/CalendarioDiasUteisDto.cs
@@ -1,0 +1,20 @@
+namespace Unifesspa.UniPlus.Configuracao.Application.DTOs;
+
+using System.Text.Json.Serialization;
+
+/// <summary>
+/// DTO de resposta HTTP para <c>CalendarioDiasUteis</c>, com a lista completa de
+/// dias não úteis — usado pelo <c>ObterPorId</c>. Suporta HATEOAS Level 1 via
+/// <c>_links</c> (ADR-0029).
+/// </summary>
+public sealed record CalendarioDiasUteisDto(
+    Guid Id,
+    string VersaoDataset,
+    bool Vigente,
+    IReadOnlyList<DiaNaoUtilDto> DiasNaoUteis,
+    DateTimeOffset CriadoEm)
+{
+    [JsonPropertyName("_links")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public IReadOnlyDictionary<string, string>? Links { get; init; }
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/DTOs/CalendarioDiasUteisResumoDto.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/DTOs/CalendarioDiasUteisResumoDto.cs
@@ -1,0 +1,19 @@
+namespace Unifesspa.UniPlus.Configuracao.Application.DTOs;
+
+using System.Text.Json.Serialization;
+
+/// <summary>
+/// DTO de resposta HTTP para <c>CalendarioDiasUteis</c> na listagem — sem os dias
+/// não úteis (a listagem não carrega a coleção filha; use <c>ObterPorId</c> para o
+/// dataset completo). Suporta HATEOAS Level 1 via <c>_links</c> (ADR-0029).
+/// </summary>
+public sealed record CalendarioDiasUteisResumoDto(
+    Guid Id,
+    string VersaoDataset,
+    bool Vigente,
+    DateTimeOffset CriadoEm)
+{
+    [JsonPropertyName("_links")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public IReadOnlyDictionary<string, string>? Links { get; init; }
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/DTOs/DiaNaoUtilDto.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/DTOs/DiaNaoUtilDto.cs
@@ -1,0 +1,9 @@
+namespace Unifesspa.UniPlus.Configuracao.Application.DTOs;
+
+/// <summary>Um dia não útil do dataset, projetado para resposta HTTP (token de <c>Abrangencia</c> UPPER_SNAKE).</summary>
+public sealed record DiaNaoUtilDto(
+    Guid Id,
+    string Abrangencia,
+    string? MunicipioIbge,
+    DateOnly Data,
+    string Descricao);

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/DTOs/DiaNaoUtilDto.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/DTOs/DiaNaoUtilDto.cs
@@ -5,5 +5,6 @@ public sealed record DiaNaoUtilDto(
     Guid Id,
     string Abrangencia,
     string? MunicipioIbge,
+    string? Uf,
     DateOnly Data,
     string Descricao);

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Mappings/CalendarioDiasUteisMapping.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Mappings/CalendarioDiasUteisMapping.cs
@@ -32,6 +32,7 @@ public static class CalendarioDiasUteisMapping
             dia.Id,
             Abrangencias.ParaTokenCanonico(dia.Abrangencia),
             dia.MunicipioIbge,
+            dia.Uf,
             dia.Data,
             dia.Descricao);
 }

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Mappings/CalendarioDiasUteisMapping.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Mappings/CalendarioDiasUteisMapping.cs
@@ -1,0 +1,37 @@
+namespace Unifesspa.UniPlus.Configuracao.Application.Mappings;
+
+using Unifesspa.UniPlus.Configuracao.Application.DTOs;
+using Unifesspa.UniPlus.Configuracao.Domain.Entities;
+using Unifesspa.UniPlus.Configuracao.Domain.Enums;
+
+public static class CalendarioDiasUteisMapping
+{
+    public static CalendarioDiasUteisDto ToDto(this CalendarioDiasUteis calendario)
+    {
+        ArgumentNullException.ThrowIfNull(calendario);
+        return new CalendarioDiasUteisDto(
+            calendario.Id,
+            calendario.VersaoDataset,
+            calendario.Vigente,
+            [.. calendario.DiasNaoUteis.Select(ToDto)],
+            calendario.CreatedAt);
+    }
+
+    public static CalendarioDiasUteisResumoDto ToResumoDto(this CalendarioDiasUteis calendario)
+    {
+        ArgumentNullException.ThrowIfNull(calendario);
+        return new CalendarioDiasUteisResumoDto(
+            calendario.Id,
+            calendario.VersaoDataset,
+            calendario.Vigente,
+            calendario.CreatedAt);
+    }
+
+    private static DiaNaoUtilDto ToDto(DiaNaoUtil dia) =>
+        new(
+            dia.Id,
+            Abrangencias.ParaTokenCanonico(dia.Abrangencia),
+            dia.MunicipioIbge,
+            dia.Data,
+            dia.Descricao);
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Queries/CalendariosDiasUteis/ListarCalendariosDiasUteisQuery.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Queries/CalendariosDiasUteis/ListarCalendariosDiasUteisQuery.cs
@@ -1,0 +1,14 @@
+namespace Unifesspa.UniPlus.Configuracao.Application.Queries.CalendariosDiasUteis;
+
+using Unifesspa.UniPlus.Application.Abstractions.Messaging;
+using Unifesspa.UniPlus.Kernel.Pagination;
+
+/// <summary>
+/// Lista datasets de calendário de dias úteis vivos, paginados por cursor
+/// bidirecional (ADR-0026 + ADR-0089). Sem os dias não úteis — use
+/// <c>ObterCalendarioDiasUteisPorIdQuery</c> para o dataset completo.
+/// </summary>
+public sealed record ListarCalendariosDiasUteisQuery(
+    Guid? AfterId,
+    int Limit,
+    PaginationDirection Direction) : IQuery<ListarCalendariosDiasUteisResult>;

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Queries/CalendariosDiasUteis/ListarCalendariosDiasUteisQueryHandler.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Queries/CalendariosDiasUteis/ListarCalendariosDiasUteisQueryHandler.cs
@@ -1,0 +1,25 @@
+namespace Unifesspa.UniPlus.Configuracao.Application.Queries.CalendariosDiasUteis;
+
+using Unifesspa.UniPlus.Configuracao.Application.DTOs;
+using Unifesspa.UniPlus.Configuracao.Application.Mappings;
+using Unifesspa.UniPlus.Configuracao.Domain.Entities;
+using Unifesspa.UniPlus.Configuracao.Domain.Interfaces;
+
+public static class ListarCalendariosDiasUteisQueryHandler
+{
+    public static async Task<ListarCalendariosDiasUteisResult> Handle(
+        ListarCalendariosDiasUteisQuery query,
+        ICalendarioDiasUteisRepository repository,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(query);
+        ArgumentNullException.ThrowIfNull(repository);
+
+        (IReadOnlyList<CalendarioDiasUteis> itens, Guid? anteriorAfterId, Guid? proximoAfterId) = await repository
+            .ListarPaginadoAsync(query.AfterId, query.Limit, query.Direction, cancellationToken)
+            .ConfigureAwait(false);
+
+        CalendarioDiasUteisResumoDto[] items = [.. itens.Select(c => c.ToResumoDto())];
+        return new ListarCalendariosDiasUteisResult(items, anteriorAfterId, proximoAfterId);
+    }
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Queries/CalendariosDiasUteis/ListarCalendariosDiasUteisResult.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Queries/CalendariosDiasUteis/ListarCalendariosDiasUteisResult.cs
@@ -1,0 +1,13 @@
+namespace Unifesspa.UniPlus.Configuracao.Application.Queries.CalendariosDiasUteis;
+
+using Unifesspa.UniPlus.Configuracao.Application.DTOs;
+
+/// <summary>
+/// Resultado da <see cref="ListarCalendariosDiasUteisQuery"/>: lote de datasets
+/// projetados + âncoras opcionais para o controller construir os cursores
+/// prev/next (ADR-0026 + ADR-0089). Não vaza entidades de domínio.
+/// </summary>
+public sealed record ListarCalendariosDiasUteisResult(
+    IReadOnlyList<CalendarioDiasUteisResumoDto> Items,
+    Guid? AnteriorAfterId,
+    Guid? ProximoAfterId);

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Queries/CalendariosDiasUteis/ObterCalendarioDiasUteisPorIdQuery.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Queries/CalendariosDiasUteis/ObterCalendarioDiasUteisPorIdQuery.cs
@@ -1,0 +1,6 @@
+namespace Unifesspa.UniPlus.Configuracao.Application.Queries.CalendariosDiasUteis;
+
+using Unifesspa.UniPlus.Application.Abstractions.Messaging;
+using Unifesspa.UniPlus.Configuracao.Application.DTOs;
+
+public sealed record ObterCalendarioDiasUteisPorIdQuery(Guid Id) : IQuery<CalendarioDiasUteisDto?>;

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Queries/CalendariosDiasUteis/ObterCalendarioDiasUteisPorIdQueryHandler.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Queries/CalendariosDiasUteis/ObterCalendarioDiasUteisPorIdQueryHandler.cs
@@ -1,0 +1,24 @@
+namespace Unifesspa.UniPlus.Configuracao.Application.Queries.CalendariosDiasUteis;
+
+using Unifesspa.UniPlus.Configuracao.Application.DTOs;
+using Unifesspa.UniPlus.Configuracao.Application.Mappings;
+using Unifesspa.UniPlus.Configuracao.Domain.Entities;
+using Unifesspa.UniPlus.Configuracao.Domain.Interfaces;
+
+public static class ObterCalendarioDiasUteisPorIdQueryHandler
+{
+    public static async Task<CalendarioDiasUteisDto?> Handle(
+        ObterCalendarioDiasUteisPorIdQuery query,
+        ICalendarioDiasUteisRepository repository,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(query);
+        ArgumentNullException.ThrowIfNull(repository);
+
+        CalendarioDiasUteis? calendario = await repository
+            .ObterPorIdParaLeituraAsync(query.Id, cancellationToken)
+            .ConfigureAwait(false);
+
+        return calendario?.ToDto();
+    }
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Contracts/CalendarioVigenteView.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Contracts/CalendarioVigenteView.cs
@@ -4,12 +4,22 @@ namespace Unifesspa.UniPlus.Configuracao.Contracts;
 /// DTO read-only do dataset vigente de calendário de dias úteis, para consumo
 /// cross-módulo via <see cref="ICalendarioVigenteReader"/> (ADR-0056). O motor de
 /// contagem de dias úteis (módulo de Recursos, escopo futuro) resolve um
-/// instante-âncora contra <see cref="Datas"/> para decidir se cai em dia não útil.
+/// instante-âncora contra <see cref="DiasNaoUteis"/> para decidir se cai em dia
+/// não útil — inclusive quando a abrangência é municipal/estadual e só se aplica a
+/// uma localidade específica.
 /// </summary>
 /// <param name="Id">Identificador do dataset (Guid v7 — ADR-0032).</param>
 /// <param name="VersaoDataset">Versão do dataset vigente.</param>
-/// <param name="Datas">Todas as datas não úteis do dataset vigente, sem distinção de abrangência/município.</param>
+/// <param name="DiasNaoUteis">Todos os dias não úteis do dataset vigente, com abrangência e município preservados.</param>
 public sealed record CalendarioVigenteView(
     Guid Id,
     string VersaoDataset,
-    IReadOnlyList<DateOnly> Datas);
+    IReadOnlyList<DiaNaoUtilView> DiasNaoUteis);
+
+/// <summary>
+/// Um dia não útil do dataset vigente, projetado para consumo cross-módulo.
+/// </summary>
+/// <param name="Data">A data não útil.</param>
+/// <param name="Abrangencia">Token canônico UPPER_SNAKE (ex.: <c>NACIONAL</c>, <c>MUNICIPAL</c>) — determina onde a data se aplica.</param>
+/// <param name="MunicipioIbge">Código IBGE do município, presente apenas quando <see cref="Abrangencia"/> é <c>MUNICIPAL</c>.</param>
+public sealed record DiaNaoUtilView(DateOnly Data, string Abrangencia, string? MunicipioIbge);

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Contracts/CalendarioVigenteView.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Contracts/CalendarioVigenteView.cs
@@ -22,4 +22,5 @@ public sealed record CalendarioVigenteView(
 /// <param name="Data">A data não útil.</param>
 /// <param name="Abrangencia">Token canônico UPPER_SNAKE (ex.: <c>NACIONAL</c>, <c>MUNICIPAL</c>) — determina onde a data se aplica.</param>
 /// <param name="MunicipioIbge">Código IBGE do município, presente apenas quando <see cref="Abrangencia"/> é <c>MUNICIPAL</c>.</param>
-public sealed record DiaNaoUtilView(DateOnly Data, string Abrangencia, string? MunicipioIbge);
+/// <param name="Uf">UF (2 letras), presente apenas quando <see cref="Abrangencia"/> é <c>ESTADUAL</c>.</param>
+public sealed record DiaNaoUtilView(DateOnly Data, string Abrangencia, string? MunicipioIbge, string? Uf);

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Contracts/CalendarioVigenteView.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Contracts/CalendarioVigenteView.cs
@@ -1,0 +1,15 @@
+namespace Unifesspa.UniPlus.Configuracao.Contracts;
+
+/// <summary>
+/// DTO read-only do dataset vigente de calendário de dias úteis, para consumo
+/// cross-módulo via <see cref="ICalendarioVigenteReader"/> (ADR-0056). O motor de
+/// contagem de dias úteis (módulo de Recursos, escopo futuro) resolve um
+/// instante-âncora contra <see cref="Datas"/> para decidir se cai em dia não útil.
+/// </summary>
+/// <param name="Id">Identificador do dataset (Guid v7 — ADR-0032).</param>
+/// <param name="VersaoDataset">Versão do dataset vigente.</param>
+/// <param name="Datas">Todas as datas não úteis do dataset vigente, sem distinção de abrangência/município.</param>
+public sealed record CalendarioVigenteView(
+    Guid Id,
+    string VersaoDataset,
+    IReadOnlyList<DateOnly> Datas);

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Contracts/ICalendarioVigenteReader.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Contracts/ICalendarioVigenteReader.cs
@@ -1,0 +1,13 @@
+namespace Unifesspa.UniPlus.Configuracao.Contracts;
+
+/// <summary>
+/// Leitor cross-módulo do calendário de dias úteis vigente (ADR-0056, UNI-REQ-0080).
+/// Expõe a pergunta "há dataset vigente?" e suas datas, para consumo pelo motor de
+/// contagem de prazos em dias úteis (módulo de Recursos, RN13 — escopo futuro), sem
+/// acesso direto ao banco de Configuração (ADR-0054).
+/// </summary>
+public interface ICalendarioVigenteReader
+{
+    /// <summary>Obtém o dataset vigente, ou <see langword="null"/> se nenhum foi marcado vigente ainda.</summary>
+    Task<CalendarioVigenteView?> ObterVigenteAsync(CancellationToken cancellationToken = default);
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Domain/Entities/CalendarioDiasUteis.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Domain/Entities/CalendarioDiasUteis.cs
@@ -30,6 +30,7 @@ public sealed class CalendarioDiasUteis : SoftDeletableEntity, IAuditableEntity
     private const int VersaoDatasetMinLength = 1;
     private const int VersaoDatasetMaxLength = 60;
     private const int DescricaoMaxLength = 200;
+    private const int MunicipioIbgeLength = 7;
 
     private readonly List<DiaNaoUtil> _diasNaoUteis = [];
 
@@ -127,6 +128,11 @@ public sealed class CalendarioDiasUteis : SoftDeletableEntity, IAuditableEntity
 
         foreach (DiaNaoUtilCriacao dia in diasNaoUteis)
         {
+            if (dia is null)
+            {
+                return Falha(CalendarioDiasUteisErrorCodes.DiaNaoUtilNulo, "Item de dia não útil não pode ser nulo.");
+            }
+
             if (!Abrangencias.TryAnalisar(dia.Abrangencia, out Abrangencia abrangencia))
             {
                 return Falha(
@@ -141,6 +147,15 @@ public sealed class CalendarioDiasUteis : SoftDeletableEntity, IAuditableEntity
                 return Falha(
                     CalendarioDiasUteisErrorCodes.MunicipioIbgeObrigatorioParaMunicipal,
                     $"Código IBGE do município é obrigatório para a data {dia.Data:yyyy-MM-dd} (abrangência municipal).");
+            }
+
+            if (abrangencia == Abrangencia.Municipal
+                && (dia.MunicipioIbge!.Trim().Length != MunicipioIbgeLength || !dia.MunicipioIbge.Trim().All(char.IsAsciiDigit)))
+            {
+                return Falha(
+                    CalendarioDiasUteisErrorCodes.MunicipioIbgeFormatoInvalido,
+                    $"Código IBGE do município deve ter exatamente {MunicipioIbgeLength} dígitos numéricos "
+                    + $"(data {dia.Data:yyyy-MM-dd}).");
             }
 
             if (abrangencia != Abrangencia.Municipal && temMunicipio)

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Domain/Entities/CalendarioDiasUteis.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Domain/Entities/CalendarioDiasUteis.cs
@@ -31,6 +31,7 @@ public sealed class CalendarioDiasUteis : SoftDeletableEntity, IAuditableEntity
     private const int VersaoDatasetMaxLength = 60;
     private const int DescricaoMaxLength = 200;
     private const int MunicipioIbgeLength = 7;
+    private const int UfLength = 2;
 
     private readonly List<DiaNaoUtil> _diasNaoUteis = [];
 
@@ -73,7 +74,7 @@ public sealed class CalendarioDiasUteis : SoftDeletableEntity, IAuditableEntity
         foreach (DiaNaoUtilResolvido dia in validacao.Value!)
         {
             calendario._diasNaoUteis.Add(DiaNaoUtil.Abrir(
-                calendario.Id, dia.Abrangencia, dia.MunicipioIbge, dia.Data, dia.Descricao));
+                calendario.Id, dia.Abrangencia, dia.MunicipioIbge, dia.Uf, dia.Data, dia.Descricao));
         }
 
         return Result<CalendarioDiasUteis>.Success(calendario);
@@ -124,7 +125,7 @@ public sealed class CalendarioDiasUteis : SoftDeletableEntity, IAuditableEntity
         }
 
         var resolvidos = new List<DiaNaoUtilResolvido>(diasNaoUteis.Count);
-        var vistos = new HashSet<(DateOnly Data, Abrangencia Abrangencia, string? Municipio)>();
+        var vistos = new HashSet<(DateOnly Data, Abrangencia Abrangencia, string? Municipio, string? Uf)>();
 
         foreach (DiaNaoUtilCriacao dia in diasNaoUteis)
         {
@@ -142,6 +143,14 @@ public sealed class CalendarioDiasUteis : SoftDeletableEntity, IAuditableEntity
             }
 
             bool temMunicipio = !string.IsNullOrWhiteSpace(dia.MunicipioIbge);
+            // Normalizado UMA vez e usado daqui em diante (validação, deduplicação em
+            // `vistos` e persistência em DiaNaoUtilResolvido) — manter o valor cru só
+            // para a checagem de formato deixava o valor NÃO aparado (ex. " 1501402 ",
+            // 9 caracteres) chegar ao varchar(7) da coluna, e espaços-em-branco para
+            // abrangência não-municipal seriam persistidos como não-nulos, violando
+            // ck_dia_nao_util_municipio_coerente.
+            string? municipioIbgeNorm = temMunicipio ? dia.MunicipioIbge!.Trim() : null;
+
             if (abrangencia == Abrangencia.Municipal && !temMunicipio)
             {
                 return Falha(
@@ -150,7 +159,7 @@ public sealed class CalendarioDiasUteis : SoftDeletableEntity, IAuditableEntity
             }
 
             if (abrangencia == Abrangencia.Municipal
-                && (dia.MunicipioIbge!.Trim().Length != MunicipioIbgeLength || !dia.MunicipioIbge.Trim().All(char.IsAsciiDigit)))
+                && (municipioIbgeNorm!.Length != MunicipioIbgeLength || !municipioIbgeNorm.All(char.IsAsciiDigit)))
             {
                 return Falha(
                     CalendarioDiasUteisErrorCodes.MunicipioIbgeFormatoInvalido,
@@ -163,6 +172,32 @@ public sealed class CalendarioDiasUteis : SoftDeletableEntity, IAuditableEntity
                 return Falha(
                     CalendarioDiasUteisErrorCodes.MunicipioIbgeApenasParaMunicipal,
                     $"Código IBGE do município só se aplica a abrangência municipal (data {dia.Data:yyyy-MM-dd}).");
+            }
+
+            bool temUf = !string.IsNullOrWhiteSpace(dia.Uf);
+            string? ufNorm = temUf ? dia.Uf!.Trim().ToUpperInvariant() : null;
+
+            if (abrangencia == Abrangencia.Estadual && !temUf)
+            {
+                return Falha(
+                    CalendarioDiasUteisErrorCodes.UfObrigatoriaParaEstadual,
+                    $"UF é obrigatória para a data {dia.Data:yyyy-MM-dd} (abrangência estadual) — sem ela, feriados "
+                    + "de estados diferentes seriam indistinguíveis.");
+            }
+
+            if (abrangencia == Abrangencia.Estadual
+                && (ufNorm!.Length != UfLength || !ufNorm.All(char.IsAsciiLetterUpper)))
+            {
+                return Falha(
+                    CalendarioDiasUteisErrorCodes.UfFormatoInvalido,
+                    $"UF deve ter exatamente {UfLength} letras (data {dia.Data:yyyy-MM-dd}).");
+            }
+
+            if (abrangencia != Abrangencia.Estadual && temUf)
+            {
+                return Falha(
+                    CalendarioDiasUteisErrorCodes.UfApenasParaEstadual,
+                    $"UF só se aplica a abrangência estadual (data {dia.Data:yyyy-MM-dd}).");
             }
 
             if (string.IsNullOrWhiteSpace(dia.Descricao))
@@ -180,14 +215,14 @@ public sealed class CalendarioDiasUteis : SoftDeletableEntity, IAuditableEntity
                     $"Descrição deve ter no máximo {DescricaoMaxLength} caracteres (data {dia.Data:yyyy-MM-dd}).");
             }
 
-            if (!vistos.Add((dia.Data, abrangencia, dia.MunicipioIbge)))
+            if (!vistos.Add((dia.Data, abrangencia, municipioIbgeNorm, ufNorm)))
             {
                 return Falha(
                     CalendarioDiasUteisErrorCodes.DataDuplicadaNoDataset,
-                    $"Data {dia.Data:yyyy-MM-dd} duplicada no dataset (mesma abrangência e município).");
+                    $"Data {dia.Data:yyyy-MM-dd} duplicada no dataset (mesma abrangência, município e UF).");
             }
 
-            resolvidos.Add(new DiaNaoUtilResolvido(abrangencia, dia.MunicipioIbge, dia.Data, descricaoNorm));
+            resolvidos.Add(new DiaNaoUtilResolvido(abrangencia, municipioIbgeNorm, ufNorm, dia.Data, descricaoNorm));
         }
 
         return Result<IReadOnlyList<DiaNaoUtilResolvido>>.Success(resolvidos);
@@ -201,8 +236,11 @@ public sealed class CalendarioDiasUteis : SoftDeletableEntity, IAuditableEntity
 /// Entrada de criação de um <see cref="DiaNaoUtil"/>, usada só por
 /// <see cref="CalendarioDiasUteis.Criar"/>. <c>Abrangencia</c> é o token canônico
 /// UPPER_SNAKE (ex.: <c>NACIONAL</c>, <c>MUNICIPAL</c>), analisado internamente.
+/// <c>Uf</c> é obrigatória para abrangência ESTADUAL — sem ela, feriados de
+/// estados diferentes seriam indistinguíveis para o consumidor cross-módulo.
 /// </summary>
-public sealed record DiaNaoUtilCriacao(string Abrangencia, string? MunicipioIbge, DateOnly Data, string Descricao);
+public sealed record DiaNaoUtilCriacao(
+    string Abrangencia, string? MunicipioIbge, DateOnly Data, string Descricao, string? Uf = null);
 
 /// <summary>Dia não útil já validado e com os campos analisados/normalizados, pronto para <see cref="DiaNaoUtil.Abrir"/>.</summary>
-internal sealed record DiaNaoUtilResolvido(Abrangencia Abrangencia, string? MunicipioIbge, DateOnly Data, string Descricao);
+internal sealed record DiaNaoUtilResolvido(Abrangencia Abrangencia, string? MunicipioIbge, string? Uf, DateOnly Data, string Descricao);

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Domain/Entities/CalendarioDiasUteis.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Domain/Entities/CalendarioDiasUteis.cs
@@ -2,6 +2,7 @@ namespace Unifesspa.UniPlus.Configuracao.Domain.Entities;
 
 using Unifesspa.UniPlus.Configuracao.Domain.Enums;
 using Unifesspa.UniPlus.Configuracao.Domain.Errors;
+using Unifesspa.UniPlus.Kernel.Domain.Cidades;
 using Unifesspa.UniPlus.Kernel.Domain.Entities;
 using Unifesspa.UniPlus.Kernel.Domain.Interfaces;
 using Unifesspa.UniPlus.Kernel.Results;
@@ -142,58 +143,62 @@ public sealed class CalendarioDiasUteis : SoftDeletableEntity, IAuditableEntity
                     + string.Join(", ", Abrangencias.TokensCanonicos) + ".");
             }
 
-            bool temMunicipio = !string.IsNullOrWhiteSpace(dia.MunicipioIbge);
             // Normalizado UMA vez e usado daqui em diante (validação, deduplicação em
             // `vistos` e persistência em DiaNaoUtilResolvido) — manter o valor cru só
             // para a checagem de formato deixava o valor NÃO aparado (ex. " 1501402 ",
             // 9 caracteres) chegar ao varchar(7) da coluna, e espaços-em-branco para
             // abrangência não-municipal seriam persistidos como não-nulos, violando
-            // ck_dia_nao_util_municipio_coerente.
-            string? municipioIbgeNorm = temMunicipio ? dia.MunicipioIbge!.Trim() : null;
+            // ck_dia_nao_util_municipio_coerente. O null-check aninhado (em vez de uma
+            // guarda combinada com `&&`) é o que deixa o compilador (e o CodeQL)
+            // provarem `municipioIbgeNorm` não-nulo daqui em diante, sem `!`.
+            string? municipioIbgeNorm = string.IsNullOrWhiteSpace(dia.MunicipioIbge) ? null : dia.MunicipioIbge.Trim();
 
-            if (abrangencia == Abrangencia.Municipal && !temMunicipio)
+            if (abrangencia == Abrangencia.Municipal)
             {
-                return Falha(
-                    CalendarioDiasUteisErrorCodes.MunicipioIbgeObrigatorioParaMunicipal,
-                    $"Código IBGE do município é obrigatório para a data {dia.Data:yyyy-MM-dd} (abrangência municipal).");
-            }
+                if (municipioIbgeNorm is null)
+                {
+                    return Falha(
+                        CalendarioDiasUteisErrorCodes.MunicipioIbgeObrigatorioParaMunicipal,
+                        $"Código IBGE do município é obrigatório para a data {dia.Data:yyyy-MM-dd} (abrangência municipal).");
+                }
 
-            if (abrangencia == Abrangencia.Municipal
-                && (municipioIbgeNorm!.Length != MunicipioIbgeLength || !municipioIbgeNorm.All(char.IsAsciiDigit)))
-            {
-                return Falha(
-                    CalendarioDiasUteisErrorCodes.MunicipioIbgeFormatoInvalido,
-                    $"Código IBGE do município deve ter exatamente {MunicipioIbgeLength} dígitos numéricos "
-                    + $"(data {dia.Data:yyyy-MM-dd}).");
+                if (municipioIbgeNorm.Length != MunicipioIbgeLength
+                    || !municipioIbgeNorm.All(char.IsAsciiDigit)
+                    || !ReferenciaCidadeGeo.TemPrefixoDeUfValido(municipioIbgeNorm))
+                {
+                    return Falha(
+                        CalendarioDiasUteisErrorCodes.MunicipioIbgeFormatoInvalido,
+                        $"Código IBGE do município deve ter exatamente {MunicipioIbgeLength} dígitos numéricos, "
+                        + $"com prefixo de UF válido (data {dia.Data:yyyy-MM-dd}).");
+                }
             }
-
-            if (abrangencia != Abrangencia.Municipal && temMunicipio)
+            else if (municipioIbgeNorm is not null)
             {
                 return Falha(
                     CalendarioDiasUteisErrorCodes.MunicipioIbgeApenasParaMunicipal,
                     $"Código IBGE do município só se aplica a abrangência municipal (data {dia.Data:yyyy-MM-dd}).");
             }
 
-            bool temUf = !string.IsNullOrWhiteSpace(dia.Uf);
-            string? ufNorm = temUf ? dia.Uf!.Trim().ToUpperInvariant() : null;
+            string? ufNorm = string.IsNullOrWhiteSpace(dia.Uf) ? null : dia.Uf.Trim().ToUpperInvariant();
 
-            if (abrangencia == Abrangencia.Estadual && !temUf)
+            if (abrangencia == Abrangencia.Estadual)
             {
-                return Falha(
-                    CalendarioDiasUteisErrorCodes.UfObrigatoriaParaEstadual,
-                    $"UF é obrigatória para a data {dia.Data:yyyy-MM-dd} (abrangência estadual) — sem ela, feriados "
-                    + "de estados diferentes seriam indistinguíveis.");
-            }
+                if (ufNorm is null)
+                {
+                    return Falha(
+                        CalendarioDiasUteisErrorCodes.UfObrigatoriaParaEstadual,
+                        $"UF é obrigatória para a data {dia.Data:yyyy-MM-dd} (abrangência estadual) — sem ela, "
+                        + "feriados de estados diferentes seriam indistinguíveis.");
+                }
 
-            if (abrangencia == Abrangencia.Estadual
-                && (ufNorm!.Length != UfLength || !ufNorm.All(char.IsAsciiLetterUpper)))
-            {
-                return Falha(
-                    CalendarioDiasUteisErrorCodes.UfFormatoInvalido,
-                    $"UF deve ter exatamente {UfLength} letras (data {dia.Data:yyyy-MM-dd}).");
+                if (ufNorm.Length != UfLength || !ReferenciaCidadeGeo.EhUfValida(ufNorm))
+                {
+                    return Falha(
+                        CalendarioDiasUteisErrorCodes.UfFormatoInvalido,
+                        $"UF deve ser uma das 27 siglas válidas (data {dia.Data:yyyy-MM-dd}).");
+                }
             }
-
-            if (abrangencia != Abrangencia.Estadual && temUf)
+            else if (ufNorm is not null)
             {
                 return Falha(
                     CalendarioDiasUteisErrorCodes.UfApenasParaEstadual,

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Domain/Entities/CalendarioDiasUteis.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Domain/Entities/CalendarioDiasUteis.cs
@@ -1,0 +1,193 @@
+namespace Unifesspa.UniPlus.Configuracao.Domain.Entities;
+
+using Unifesspa.UniPlus.Configuracao.Domain.Enums;
+using Unifesspa.UniPlus.Configuracao.Domain.Errors;
+using Unifesspa.UniPlus.Kernel.Domain.Entities;
+using Unifesspa.UniPlus.Kernel.Domain.Interfaces;
+using Unifesspa.UniPlus.Kernel.Results;
+
+/// <summary>
+/// Um dataset versionado do calendário de dias não úteis (feriados nacionais,
+/// estaduais, municipais e recessos institucionais) usado para contar prazos
+/// expressos em dias úteis (UNI-REQ-0080/RN13).
+/// </summary>
+/// <remarks>
+/// <para>Reference data versionada por dataset, não por linha: uma correção publica
+/// um dataset novo (<see cref="Criar"/>) com a lista completa de dias não úteis — nunca
+/// edita a lista de um dataset existente. Não há método <c>Atualizar</c> por design:
+/// o cadastro é ou criado (rascunho, <see cref="Vigente"/> = false), ou marcado vigente
+/// (<see cref="MarcarVigente"/>), ou removido por soft-delete (quando ainda não vigente
+/// — o handler recusa remover o dataset corrente).</para>
+/// <para>No máximo um dataset é vigente por vez — a invariante cross-agregado é
+/// aplicada pelo handler (que desmarca o vigente anterior na mesma transação) e
+/// reforçada por índice único parcial de banco, nunca só por guarda em memória.</para>
+/// <para>Motor de contagem de dias úteis (como um instante-âncora em dia não útil se
+/// resolve) é escopo futuro do módulo de Recursos — esta entidade só entrega o
+/// cadastro e a pergunta "há dataset vigente?".</para>
+/// </remarks>
+public sealed class CalendarioDiasUteis : SoftDeletableEntity, IAuditableEntity
+{
+    private const int VersaoDatasetMinLength = 1;
+    private const int VersaoDatasetMaxLength = 60;
+    private const int DescricaoMaxLength = 200;
+
+    private readonly List<DiaNaoUtil> _diasNaoUteis = [];
+
+    public string VersaoDataset { get; private set; } = string.Empty;
+    public bool Vigente { get; private set; }
+    public IReadOnlyList<DiaNaoUtil> DiasNaoUteis => _diasNaoUteis.AsReadOnly();
+
+    public string? CreatedBy { get; private set; }
+    public string? UpdatedBy { get; private set; }
+
+    // EF Core materialization
+    private CalendarioDiasUteis()
+    {
+    }
+
+    /// <summary>
+    /// Cria um dataset novo, com a lista completa de dias não úteis. Nasce sempre
+    /// <b>não vigente</b> — tornar-se o dataset corrente é uma operação explícita
+    /// (<see cref="MarcarVigente"/>), nunca implícita na criação. <c>Abrangencia</c>
+    /// chega como token canônico UPPER_SNAKE (ex.: <c>NACIONAL</c>) — a análise e a
+    /// validação de campo ocorrem aqui, não no chamador.
+    /// </summary>
+    public static Result<CalendarioDiasUteis> Criar(string versaoDataset, IReadOnlyCollection<DiaNaoUtilCriacao> diasNaoUteis)
+    {
+        ArgumentNullException.ThrowIfNull(versaoDataset);
+        ArgumentNullException.ThrowIfNull(diasNaoUteis);
+
+        Result<IReadOnlyList<DiaNaoUtilResolvido>> validacao = ValidarCampos(versaoDataset, diasNaoUteis);
+        if (validacao.IsFailure)
+        {
+            return Result<CalendarioDiasUteis>.Failure(validacao.Error!);
+        }
+
+        var calendario = new CalendarioDiasUteis
+        {
+            VersaoDataset = versaoDataset.Trim(),
+            Vigente = false,
+        };
+
+        foreach (DiaNaoUtilResolvido dia in validacao.Value!)
+        {
+            calendario._diasNaoUteis.Add(DiaNaoUtil.Abrir(
+                calendario.Id, dia.Abrangencia, dia.MunicipioIbge, dia.Data, dia.Descricao));
+        }
+
+        return Result<CalendarioDiasUteis>.Success(calendario);
+    }
+
+    /// <summary>
+    /// Marca este dataset como o vigente. Falha se já estiver vigente — chamar de
+    /// novo sobre o mesmo dataset é erro do caller, não um no-op silencioso. Não
+    /// desmarca nenhum outro dataset: essa é responsabilidade do handler, que
+    /// precisa localizar o vigente anterior (se houver) na mesma transação.
+    /// </summary>
+    public Result MarcarVigente()
+    {
+        if (Vigente)
+        {
+            return Result.Failure(new DomainError(
+                CalendarioDiasUteisErrorCodes.JaVigente,
+                "Este dataset já é o vigente."));
+        }
+
+        Vigente = true;
+        return Result.Success();
+    }
+
+    /// <summary>Desmarca este dataset como vigente. Chamado pelo handler sobre o vigente anterior.</summary>
+    public void MarcarNaoVigente() => Vigente = false;
+
+    private static Result<IReadOnlyList<DiaNaoUtilResolvido>> ValidarCampos(
+        string versaoDataset, IReadOnlyCollection<DiaNaoUtilCriacao> diasNaoUteis)
+    {
+        if (string.IsNullOrWhiteSpace(versaoDataset))
+        {
+            return Falha(CalendarioDiasUteisErrorCodes.VersaoDatasetObrigatoria, "Versão do dataset é obrigatória.");
+        }
+
+        if (versaoDataset.Trim().Length is < VersaoDatasetMinLength or > VersaoDatasetMaxLength)
+        {
+            return Falha(
+                CalendarioDiasUteisErrorCodes.VersaoDatasetTamanho,
+                $"Versão do dataset deve ter entre {VersaoDatasetMinLength} e {VersaoDatasetMaxLength} caracteres.");
+        }
+
+        if (diasNaoUteis.Count == 0)
+        {
+            return Falha(
+                CalendarioDiasUteisErrorCodes.SemDiaNaoUtil,
+                "O dataset precisa de ao menos um dia não útil — um calendário vazio não conta nada.");
+        }
+
+        var resolvidos = new List<DiaNaoUtilResolvido>(diasNaoUteis.Count);
+        var vistos = new HashSet<(DateOnly Data, Abrangencia Abrangencia, string? Municipio)>();
+
+        foreach (DiaNaoUtilCriacao dia in diasNaoUteis)
+        {
+            if (!Abrangencias.TryAnalisar(dia.Abrangencia, out Abrangencia abrangencia))
+            {
+                return Falha(
+                    CalendarioDiasUteisErrorCodes.AbrangenciaInvalida,
+                    $"Abrangência inválida para a data {dia.Data:yyyy-MM-dd}. Deve ser uma de: "
+                    + string.Join(", ", Abrangencias.TokensCanonicos) + ".");
+            }
+
+            bool temMunicipio = !string.IsNullOrWhiteSpace(dia.MunicipioIbge);
+            if (abrangencia == Abrangencia.Municipal && !temMunicipio)
+            {
+                return Falha(
+                    CalendarioDiasUteisErrorCodes.MunicipioIbgeObrigatorioParaMunicipal,
+                    $"Código IBGE do município é obrigatório para a data {dia.Data:yyyy-MM-dd} (abrangência municipal).");
+            }
+
+            if (abrangencia != Abrangencia.Municipal && temMunicipio)
+            {
+                return Falha(
+                    CalendarioDiasUteisErrorCodes.MunicipioIbgeApenasParaMunicipal,
+                    $"Código IBGE do município só se aplica a abrangência municipal (data {dia.Data:yyyy-MM-dd}).");
+            }
+
+            if (string.IsNullOrWhiteSpace(dia.Descricao))
+            {
+                return Falha(
+                    CalendarioDiasUteisErrorCodes.DescricaoObrigatoria,
+                    $"Descrição é obrigatória para a data {dia.Data:yyyy-MM-dd}.");
+            }
+
+            string descricaoNorm = dia.Descricao.Trim();
+            if (descricaoNorm.Length > DescricaoMaxLength)
+            {
+                return Falha(
+                    CalendarioDiasUteisErrorCodes.DescricaoTamanho,
+                    $"Descrição deve ter no máximo {DescricaoMaxLength} caracteres (data {dia.Data:yyyy-MM-dd}).");
+            }
+
+            if (!vistos.Add((dia.Data, abrangencia, dia.MunicipioIbge)))
+            {
+                return Falha(
+                    CalendarioDiasUteisErrorCodes.DataDuplicadaNoDataset,
+                    $"Data {dia.Data:yyyy-MM-dd} duplicada no dataset (mesma abrangência e município).");
+            }
+
+            resolvidos.Add(new DiaNaoUtilResolvido(abrangencia, dia.MunicipioIbge, dia.Data, descricaoNorm));
+        }
+
+        return Result<IReadOnlyList<DiaNaoUtilResolvido>>.Success(resolvidos);
+    }
+
+    private static Result<IReadOnlyList<DiaNaoUtilResolvido>> Falha(string codigo, string mensagem) =>
+        Result<IReadOnlyList<DiaNaoUtilResolvido>>.Failure(new DomainError(codigo, mensagem));
+}
+
+/// <summary>
+/// Entrada de criação de um <see cref="DiaNaoUtil"/>, usada só por
+/// <see cref="CalendarioDiasUteis.Criar"/>. <c>Abrangencia</c> é o token canônico
+/// UPPER_SNAKE (ex.: <c>NACIONAL</c>, <c>MUNICIPAL</c>), analisado internamente.
+/// </summary>
+public sealed record DiaNaoUtilCriacao(string Abrangencia, string? MunicipioIbge, DateOnly Data, string Descricao);
+
+/// <summary>Dia não útil já validado e com os campos analisados/normalizados, pronto para <see cref="DiaNaoUtil.Abrir"/>.</summary>
+internal sealed record DiaNaoUtilResolvido(Abrangencia Abrangencia, string? MunicipioIbge, DateOnly Data, string Descricao);

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Domain/Entities/DiaNaoUtil.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Domain/Entities/DiaNaoUtil.cs
@@ -1,0 +1,44 @@
+namespace Unifesspa.UniPlus.Configuracao.Domain.Entities;
+
+using Unifesspa.UniPlus.Configuracao.Domain.Enums;
+using Unifesspa.UniPlus.Kernel.Domain.Entities;
+
+/// <summary>
+/// Uma data não útil (feriado ou recesso) dentro de um <see cref="CalendarioDiasUteis"/>.
+/// </summary>
+/// <remarks>
+/// Entidade interna ao agregado <see cref="CalendarioDiasUteis"/>; criada apenas por
+/// métodos do agregado, nunca por repositório próprio. Não implementa soft-delete:
+/// deriva de <see cref="EntityBase"/> — corrigir o dataset é publicar uma nova versão
+/// (novo <see cref="CalendarioDiasUteis"/>), não editar linhas de uma versão existente.
+/// </remarks>
+public sealed class DiaNaoUtil : EntityBase
+{
+    public Guid CalendarioDiasUteisId { get; private set; }
+    public Abrangencia Abrangencia { get; private set; }
+    public string? MunicipioIbge { get; private set; }
+    public DateOnly Data { get; private set; }
+    public string Descricao { get; private set; } = string.Empty;
+
+    // EF Core materialization
+    private DiaNaoUtil()
+    {
+    }
+
+    internal static DiaNaoUtil Abrir(
+        Guid calendarioDiasUteisId,
+        Abrangencia abrangencia,
+        string? municipioIbge,
+        DateOnly data,
+        string descricao)
+    {
+        return new DiaNaoUtil
+        {
+            CalendarioDiasUteisId = calendarioDiasUteisId,
+            Abrangencia = abrangencia,
+            MunicipioIbge = municipioIbge,
+            Data = data,
+            Descricao = descricao,
+        };
+    }
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Domain/Entities/DiaNaoUtil.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Domain/Entities/DiaNaoUtil.cs
@@ -17,6 +17,7 @@ public sealed class DiaNaoUtil : EntityBase
     public Guid CalendarioDiasUteisId { get; private set; }
     public Abrangencia Abrangencia { get; private set; }
     public string? MunicipioIbge { get; private set; }
+    public string? Uf { get; private set; }
     public DateOnly Data { get; private set; }
     public string Descricao { get; private set; } = string.Empty;
 
@@ -29,6 +30,7 @@ public sealed class DiaNaoUtil : EntityBase
         Guid calendarioDiasUteisId,
         Abrangencia abrangencia,
         string? municipioIbge,
+        string? uf,
         DateOnly data,
         string descricao)
     {
@@ -37,6 +39,7 @@ public sealed class DiaNaoUtil : EntityBase
             CalendarioDiasUteisId = calendarioDiasUteisId,
             Abrangencia = abrangencia,
             MunicipioIbge = municipioIbge,
+            Uf = uf,
             Data = data,
             Descricao = descricao,
         };

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Domain/Enums/Abrangencia.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Domain/Enums/Abrangencia.cs
@@ -1,0 +1,23 @@
+namespace Unifesspa.UniPlus.Configuracao.Domain.Enums;
+
+/// <summary>
+/// Abrangência territorial de um dia não útil no calendário de contagem de prazos
+/// (UNI-REQ-0080/RN13). Persistida como token UPPER_SNAKE (<see cref="Abrangencias"/>).
+/// </summary>
+public enum Abrangencia
+{
+    /// <summary>Sentinela — indica entrada inválida/corrupção se encontrado em runtime.</summary>
+    Nenhuma = 0,
+
+    /// <summary>Feriado nacional — vale para todo o território.</summary>
+    Nacional = 1,
+
+    /// <summary>Feriado estadual — vale só no estado declarado.</summary>
+    Estadual = 2,
+
+    /// <summary>Feriado municipal — vale só no município declarado (exige <c>MunicipioIbge</c>).</summary>
+    Municipal = 3,
+
+    /// <summary>Recesso institucional da Unifesspa, sem correspondência em calendário civil.</summary>
+    Institucional = 4,
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Domain/Enums/Abrangencias.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Domain/Enums/Abrangencias.cs
@@ -1,0 +1,56 @@
+namespace Unifesspa.UniPlus.Configuracao.Domain.Enums;
+
+/// <summary>
+/// Mapeamento entre <see cref="Abrangencia"/> (domínio, PascalCase) e o token
+/// textual de contrato/banco (UPPER_SNAKE), com parsing de domínio fechado.
+/// </summary>
+/// <remarks>
+/// Parsing por <b>allowlist textual explícita</b> (<see cref="TryAnalisar"/>) — não usa
+/// <c>Enum.TryParse</c>, que aceitaria tokens numéricos e nomes PascalCase fora do
+/// contrato textual.
+/// </remarks>
+public static class Abrangencias
+{
+    private static readonly Dictionary<Abrangencia, string> ParaToken = new()
+    {
+        [Abrangencia.Nacional] = "NACIONAL",
+        [Abrangencia.Estadual] = "ESTADUAL",
+        [Abrangencia.Municipal] = "MUNICIPAL",
+        [Abrangencia.Institucional] = "INSTITUCIONAL",
+    };
+
+    private static readonly Dictionary<string, Abrangencia> DeToken =
+        ParaToken.ToDictionary(kv => kv.Value, kv => kv.Key, StringComparer.Ordinal);
+
+    /// <summary>Os quatro tokens canônicos (UPPER_SNAKE), para o CHECK de domínio e mensagens.</summary>
+    public static readonly IReadOnlyList<string> TokensCanonicos = [.. ParaToken.Values];
+
+    /// <summary>Token textual de contrato/banco (UPPER_SNAKE) de uma abrangência válida.</summary>
+    /// <exception cref="ArgumentOutOfRangeException">Se <paramref name="abrangencia"/> é <see cref="Abrangencia.Nenhuma"/> ou fora do roster.</exception>
+    public static string ParaTokenCanonico(Abrangencia abrangencia) =>
+        ParaToken.TryGetValue(abrangencia, out string? token)
+            ? token
+            : throw new ArgumentOutOfRangeException(
+                nameof(abrangencia), abrangencia, "Abrangência fora do domínio fechado.");
+
+    /// <summary>
+    /// Resolve um token textual (UPPER_SNAKE) à abrangência correspondente. Aceita
+    /// <c>Trim</c>, mas é case-sensitive e rejeita tokens fora do domínio (allowlist).
+    /// Retorna <see langword="false"/> quando inválido.
+    /// </summary>
+    public static bool TryAnalisar(string? token, out Abrangencia abrangencia)
+    {
+        if (!string.IsNullOrWhiteSpace(token)
+            && DeToken.TryGetValue(token.Trim(), out Abrangencia resolvida))
+        {
+            abrangencia = resolvida;
+            return true;
+        }
+
+        abrangencia = Abrangencia.Nenhuma;
+        return false;
+    }
+
+    /// <summary>Indica se <paramref name="token"/> é um dos tokens canônicos, sem alocar resultado.</summary>
+    public static bool EhValido(string? token) => TryAnalisar(token, out _);
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Domain/Errors/CalendarioDiasUteisErrorCodes.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Domain/Errors/CalendarioDiasUteisErrorCodes.cs
@@ -1,0 +1,17 @@
+namespace Unifesspa.UniPlus.Configuracao.Domain.Errors;
+
+public static class CalendarioDiasUteisErrorCodes
+{
+    public const string VersaoDatasetObrigatoria = "CalendarioDiasUteis.VersaoDatasetObrigatoria";
+    public const string VersaoDatasetTamanho = "CalendarioDiasUteis.VersaoDatasetTamanho";
+    public const string SemDiaNaoUtil = "CalendarioDiasUteis.SemDiaNaoUtil";
+    public const string AbrangenciaInvalida = "CalendarioDiasUteis.AbrangenciaInvalida";
+    public const string MunicipioIbgeObrigatorioParaMunicipal = "CalendarioDiasUteis.MunicipioIbgeObrigatorioParaMunicipal";
+    public const string MunicipioIbgeApenasParaMunicipal = "CalendarioDiasUteis.MunicipioIbgeApenasParaMunicipal";
+    public const string DescricaoObrigatoria = "CalendarioDiasUteis.DescricaoObrigatoria";
+    public const string DescricaoTamanho = "CalendarioDiasUteis.DescricaoTamanho";
+    public const string DataDuplicadaNoDataset = "CalendarioDiasUteis.DataDuplicadaNoDataset";
+    public const string JaVigente = "CalendarioDiasUteis.JaVigente";
+    public const string NaoRemoveVigente = "CalendarioDiasUteis.NaoRemoveVigente";
+    public const string NaoEncontrado = "CalendarioDiasUteis.NaoEncontrado";
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Domain/Errors/CalendarioDiasUteisErrorCodes.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Domain/Errors/CalendarioDiasUteisErrorCodes.cs
@@ -9,6 +9,9 @@ public static class CalendarioDiasUteisErrorCodes
     public const string MunicipioIbgeObrigatorioParaMunicipal = "CalendarioDiasUteis.MunicipioIbgeObrigatorioParaMunicipal";
     public const string MunicipioIbgeApenasParaMunicipal = "CalendarioDiasUteis.MunicipioIbgeApenasParaMunicipal";
     public const string MunicipioIbgeFormatoInvalido = "CalendarioDiasUteis.MunicipioIbgeFormatoInvalido";
+    public const string UfObrigatoriaParaEstadual = "CalendarioDiasUteis.UfObrigatoriaParaEstadual";
+    public const string UfApenasParaEstadual = "CalendarioDiasUteis.UfApenasParaEstadual";
+    public const string UfFormatoInvalido = "CalendarioDiasUteis.UfFormatoInvalido";
     public const string DiaNaoUtilNulo = "CalendarioDiasUteis.DiaNaoUtilNulo";
     public const string DescricaoObrigatoria = "CalendarioDiasUteis.DescricaoObrigatoria";
     public const string DescricaoTamanho = "CalendarioDiasUteis.DescricaoTamanho";

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Domain/Errors/CalendarioDiasUteisErrorCodes.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Domain/Errors/CalendarioDiasUteisErrorCodes.cs
@@ -8,10 +8,13 @@ public static class CalendarioDiasUteisErrorCodes
     public const string AbrangenciaInvalida = "CalendarioDiasUteis.AbrangenciaInvalida";
     public const string MunicipioIbgeObrigatorioParaMunicipal = "CalendarioDiasUteis.MunicipioIbgeObrigatorioParaMunicipal";
     public const string MunicipioIbgeApenasParaMunicipal = "CalendarioDiasUteis.MunicipioIbgeApenasParaMunicipal";
+    public const string MunicipioIbgeFormatoInvalido = "CalendarioDiasUteis.MunicipioIbgeFormatoInvalido";
+    public const string DiaNaoUtilNulo = "CalendarioDiasUteis.DiaNaoUtilNulo";
     public const string DescricaoObrigatoria = "CalendarioDiasUteis.DescricaoObrigatoria";
     public const string DescricaoTamanho = "CalendarioDiasUteis.DescricaoTamanho";
     public const string DataDuplicadaNoDataset = "CalendarioDiasUteis.DataDuplicadaNoDataset";
     public const string JaVigente = "CalendarioDiasUteis.JaVigente";
     public const string NaoRemoveVigente = "CalendarioDiasUteis.NaoRemoveVigente";
     public const string NaoEncontrado = "CalendarioDiasUteis.NaoEncontrado";
+    public const string ConflitoDeConcorrencia = "CalendarioDiasUteis.ConflitoDeConcorrencia";
 }

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Domain/Interfaces/ICalendarioDiasUteisRepository.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Domain/Interfaces/ICalendarioDiasUteisRepository.cs
@@ -1,0 +1,40 @@
+namespace Unifesspa.UniPlus.Configuracao.Domain.Interfaces;
+
+using Unifesspa.UniPlus.Configuracao.Domain.Entities;
+using Unifesspa.UniPlus.Kernel.Pagination;
+
+/// <summary>
+/// Repositório da entidade <see cref="CalendarioDiasUteis"/> (ADR-0054: banco isolado
+/// <c>uniplus_configuracao</c>). Todas as leituras excluem registros soft-deleted via
+/// query filter por convenção.
+/// </summary>
+public interface ICalendarioDiasUteisRepository
+{
+    /// <summary>Carrega o dataset rastreado pelo contexto (com <see cref="CalendarioDiasUteis.DiasNaoUteis"/>), para mutação.</summary>
+    Task<CalendarioDiasUteis?> ObterPorIdAsync(Guid id, CancellationToken cancellationToken);
+
+    /// <summary>Carrega o dataset para leitura (<c>AsNoTracking</c>) — projeção em DTO.</summary>
+    Task<CalendarioDiasUteis?> ObterPorIdParaLeituraAsync(Guid id, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Lista datasets vivos paginados por cursor keyset bidirecional (ADR-0026 +
+    /// ADR-0089): ordena por <c>Id</c> (Guid v7, ADR-0032) e devolve as âncoras
+    /// de <c>prev</c>/<c>next</c> (nulas quando não há aquele lado).
+    /// </summary>
+    Task<(IReadOnlyList<CalendarioDiasUteis> Itens, Guid? AnteriorAfterId, Guid? ProximoAfterId)> ListarPaginadoAsync(
+        Guid? afterId,
+        int limit,
+        PaginationDirection direction,
+        CancellationToken cancellationToken);
+
+    /// <summary>Carrega o dataset vigente, rastreado, se houver — para o handler desmarcá-lo ao trocar de vigente.</summary>
+    Task<CalendarioDiasUteis?> ObterVigenteAsync(CancellationToken cancellationToken);
+
+    Task AdicionarAsync(CalendarioDiasUteis calendario, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Marca o dataset para remoção; o <c>SoftDeleteInterceptor</c> converte em
+    /// soft-delete preenchendo <c>DeletedBy</c>/<c>DeletedAt</c>.
+    /// </summary>
+    void Remover(CalendarioDiasUteis calendario);
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Infrastructure/DependencyInjection.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Infrastructure/DependencyInjection.cs
@@ -47,6 +47,7 @@ public static class ConfiguracaoInfrastructureRegistration
         services.AddScoped<ICursoRepository, CursoRepository>();
         services.AddScoped<IOfertaCursoRepository, OfertaCursoRepository>();
         services.AddScoped<IPrecedenciaFaseRepository, PrecedenciaFaseRepository>();
+        services.AddScoped<ICalendarioDiasUteisRepository, CalendarioDiasUteisRepository>();
 
         // Readers cross-módulo (ADR-0056).
         services.AddScoped<IReferenciaReservaDemograficaReader, ReferenciaReservaDemograficaReader>();
@@ -63,6 +64,7 @@ public static class ConfiguracaoInfrastructureRegistration
         // sem repositório (não há escrita em runtime).
         services.AddScoped<IFatoCandidatoReader, FatoCandidatoReader>();
         services.AddScoped<IPrecedenciaFaseReader, PrecedenciaFaseReader>();
+        services.AddScoped<ICalendarioVigenteReader, CalendarioVigenteReader>();
 
         return services;
     }

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Infrastructure/Persistence/ConfiguracaoDbContext.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Infrastructure/Persistence/ConfiguracaoDbContext.cs
@@ -55,6 +55,8 @@ public sealed class ConfiguracaoDbContext : DbContext, IConfiguracaoUnitOfWork
 
     public DbSet<OfertaCurso> OfertasCurso => Set<OfertaCurso>();
 
+    public DbSet<CalendarioDiasUteis> CalendariosDiasUteis => Set<CalendarioDiasUteis>();
+
     /// <summary>
     /// Catálogo seed-governado do vocabulário fechado de fatos do candidato
     /// (UNI-REQ-0077, ADR-0111). Metadado de classificação, sem PII.

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Infrastructure/Persistence/ConfiguracaoDbContext.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Infrastructure/Persistence/ConfiguracaoDbContext.cs
@@ -101,4 +101,9 @@ public sealed class ConfiguracaoDbContext : DbContext, IConfiguracaoUnitOfWork
     {
         return await SaveChangesAsync(cancellationToken).ConfigureAwait(false);
     }
+
+    public async Task ForcarChecagemImediataDeConstraintsAsync(CancellationToken cancellationToken = default)
+    {
+        await Database.ExecuteSqlRawAsync("SET CONSTRAINTS ALL IMMEDIATE", cancellationToken).ConfigureAwait(false);
+    }
 }

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Infrastructure/Persistence/Configurations/CalendarioDiasUteisConfiguration.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Infrastructure/Persistence/Configurations/CalendarioDiasUteisConfiguration.cs
@@ -23,6 +23,19 @@ internal sealed class CalendarioDiasUteisConfiguration : IEntityTypeConfiguratio
         builder.Property(c => c.VersaoDataset).HasMaxLength(VersaoDatasetMaxLength).IsRequired();
         builder.Property(c => c.Vigente).IsRequired();
 
+        // Token de concorrência otimista mapeado para a coluna de sistema `xmin` do
+        // Postgres (shadow property `uint` + IsRowVersion — convenção do provider
+        // Npgsql, sem coluna/migration própria): MarcarVigenteCalendarioDiasUteisCommandHandler
+        // e RemoverCalendarioDiasUteisCommandHandler podem, em corrida, ler e mutar o
+        // MESMO registro (ex.: ativar um dataset enquanto ele é removido) sem colidir
+        // com a exclusion constraint de vigência, que só cobre a unicidade entre
+        // registros DIFERENTES. Com xmin, quem confirma por último recebe
+        // DbUpdateConcurrencyException em vez de sobrescrever silenciosamente o
+        // resultado do outro.
+        builder.Property<uint>("Version").IsRowVersion();
+
+        // Auditoria (IAuditableEntity)
+
         // Auditoria (IAuditableEntity)
         builder.Property(c => c.CreatedBy).HasMaxLength(255);
         builder.Property(c => c.UpdatedBy).HasMaxLength(255);

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Infrastructure/Persistence/Configurations/CalendarioDiasUteisConfiguration.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Infrastructure/Persistence/Configurations/CalendarioDiasUteisConfiguration.cs
@@ -1,0 +1,64 @@
+namespace Unifesspa.UniPlus.Configuracao.Infrastructure.Persistence.Configurations;
+
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+using Unifesspa.UniPlus.Configuracao.Domain.Entities;
+
+[System.Diagnostics.CodeAnalysis.SuppressMessage(
+    "Performance",
+    "CA1812:Avoid uninstantiated internal classes",
+    Justification = "Instanciada via EF Core ModelBuilder.ApplyConfigurationsFromAssembly por reflection.")]
+internal sealed class CalendarioDiasUteisConfiguration : IEntityTypeConfiguration<CalendarioDiasUteis>
+{
+    private const int VersaoDatasetMaxLength = 60;
+
+    public void Configure(EntityTypeBuilder<CalendarioDiasUteis> builder)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+
+        builder.ToTable("calendario_dias_uteis");
+        builder.HasKey(c => c.Id);
+
+        builder.Property(c => c.VersaoDataset).HasMaxLength(VersaoDatasetMaxLength).IsRequired();
+        builder.Property(c => c.Vigente).IsRequired();
+
+        // Auditoria (IAuditableEntity)
+        builder.Property(c => c.CreatedBy).HasMaxLength(255);
+        builder.Property(c => c.UpdatedBy).HasMaxLength(255);
+
+        // Dias não úteis do dataset: append-only enquanto o dataset existe — a lista
+        // só nasce inteira no Criar, nunca ganha/perde linha depois (issue #1016 §2).
+        // ClientNoAction (não Restrict/Cascade): com a coleção já rastreada,
+        // Restrict/NoAction lançam "required relationship severed" ao marcar o
+        // CalendarioDiasUteis como Deleted, ANTES de o interceptor convertê-lo em
+        // soft-delete; ClientNoAction deixa o interceptor converter em UPDATE e os
+        // dias não úteis permanecem intactos (mesmo padrão de Unidade.Historico).
+        builder.HasMany(c => c.DiasNaoUteis)
+            .WithOne()
+            .HasForeignKey(d => d.CalendarioDiasUteisId)
+            .OnDelete(DeleteBehavior.ClientNoAction);
+        builder.Navigation(c => c.DiasNaoUteis)
+            .UsePropertyAccessMode(PropertyAccessMode.Field);
+
+        // No máximo um dataset vivo é vigente: EXCLUDE constraint GiST DEFERRABLE
+        // INITIALLY DEFERRED (ex_calendario_dias_uteis_vigente_unico), criada via SQL
+        // cru na migration — de propósito AUSENTE daqui como HasIndex().IsUnique(),
+        // mesmo padrão de ex_nos_exigencia_irmaos_ordem (NoExigenciaConfiguration.cs) e
+        // ex_tipo_ato_publicado_codigo_vigencia (TipoAtoPublicadoConfiguration.cs), que o
+        // Fluent API do EF Core não modela. Um índice único comum é verificado
+        // por-statement: MarcarVigenteCalendarioDiasUteisCommandHandler desmarca o
+        // vigente anterior e marca o novo na MESMA SaveChangesAsync, e o EF Core não
+        // garante que o UPDATE de desmarcar execute antes do de marcar — com um índice
+        // não-deferível, a ordem inversa faz o segundo UPDATE colidir com o primeiro
+        // (23505) mesmo a transação terminando num estado final válido. Deferir a
+        // checagem para o COMMIT resolve sem separar a troca de vigente em duas
+        // chamadas a SaveChangesAsync. A invariante primária continua no handler, que
+        // localiza e desmarca o vigente anterior na mesma transação — a constraint de
+        // banco é defesa de última linha.
+
+        builder.HasIndex(c => c.VersaoDataset)
+            .HasFilter("is_deleted = false")
+            .HasDatabaseName("ix_calendario_dias_uteis_versao_dataset");
+    }
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Infrastructure/Persistence/Configurations/DiaNaoUtilConfiguration.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Infrastructure/Persistence/Configurations/DiaNaoUtilConfiguration.cs
@@ -13,6 +13,7 @@ using Unifesspa.UniPlus.Configuracao.Infrastructure.Persistence.Converters;
 internal sealed class DiaNaoUtilConfiguration : IEntityTypeConfiguration<DiaNaoUtil>
 {
     private const int MunicipioIbgeMaxLength = 7;
+    private const int UfMaxLength = 2;
     private const int DescricaoMaxLength = 200;
 
     public void Configure(EntityTypeBuilder<DiaNaoUtil> builder)
@@ -21,9 +22,15 @@ internal sealed class DiaNaoUtilConfiguration : IEntityTypeConfiguration<DiaNaoU
 
         builder.ToTable(
             "dia_nao_util",
-            t => t.HasCheckConstraint(
-                "ck_dia_nao_util_municipio_coerente",
-                "(abrangencia = 'MUNICIPAL') = (municipio_ibge IS NOT NULL)"));
+            t =>
+            {
+                t.HasCheckConstraint(
+                    "ck_dia_nao_util_municipio_coerente",
+                    "(abrangencia = 'MUNICIPAL') = (municipio_ibge IS NOT NULL)");
+                t.HasCheckConstraint(
+                    "ck_dia_nao_util_uf_coerente",
+                    "(abrangencia = 'ESTADUAL') = (uf IS NOT NULL)");
+            });
 
         builder.HasKey(d => d.Id);
 
@@ -35,6 +42,7 @@ internal sealed class DiaNaoUtilConfiguration : IEntityTypeConfiguration<DiaNaoU
             .IsRequired();
 
         builder.Property(d => d.MunicipioIbge).HasMaxLength(MunicipioIbgeMaxLength);
+        builder.Property(d => d.Uf).HasMaxLength(UfMaxLength);
         builder.Property(d => d.Data).IsRequired();
         builder.Property(d => d.Descricao).HasMaxLength(DescricaoMaxLength).IsRequired();
 

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Infrastructure/Persistence/Configurations/DiaNaoUtilConfiguration.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Infrastructure/Persistence/Configurations/DiaNaoUtilConfiguration.cs
@@ -1,0 +1,44 @@
+namespace Unifesspa.UniPlus.Configuracao.Infrastructure.Persistence.Configurations;
+
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+using Unifesspa.UniPlus.Configuracao.Domain.Entities;
+using Unifesspa.UniPlus.Configuracao.Infrastructure.Persistence.Converters;
+
+[System.Diagnostics.CodeAnalysis.SuppressMessage(
+    "Performance",
+    "CA1812:Avoid uninstantiated internal classes",
+    Justification = "Instanciada via EF Core ModelBuilder.ApplyConfigurationsFromAssembly por reflection.")]
+internal sealed class DiaNaoUtilConfiguration : IEntityTypeConfiguration<DiaNaoUtil>
+{
+    private const int MunicipioIbgeMaxLength = 7;
+    private const int DescricaoMaxLength = 200;
+
+    public void Configure(EntityTypeBuilder<DiaNaoUtil> builder)
+    {
+        ArgumentNullException.ThrowIfNull(builder);
+
+        builder.ToTable(
+            "dia_nao_util",
+            t => t.HasCheckConstraint(
+                "ck_dia_nao_util_municipio_coerente",
+                "(abrangencia = 'MUNICIPAL') = (municipio_ibge IS NOT NULL)"));
+
+        builder.HasKey(d => d.Id);
+
+        builder.Property(d => d.CalendarioDiasUteisId).IsRequired();
+
+        builder.Property(d => d.Abrangencia)
+            .HasConversion<AbrangenciaValueConverter>()
+            .HasMaxLength(20)
+            .IsRequired();
+
+        builder.Property(d => d.MunicipioIbge).HasMaxLength(MunicipioIbgeMaxLength);
+        builder.Property(d => d.Data).IsRequired();
+        builder.Property(d => d.Descricao).HasMaxLength(DescricaoMaxLength).IsRequired();
+
+        builder.HasIndex(d => new { d.CalendarioDiasUteisId, d.Data })
+            .HasDatabaseName("ix_dia_nao_util_calendario_data");
+    }
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Infrastructure/Persistence/Converters/AbrangenciaValueConverter.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Infrastructure/Persistence/Converters/AbrangenciaValueConverter.cs
@@ -1,0 +1,30 @@
+namespace Unifesspa.UniPlus.Configuracao.Infrastructure.Persistence.Converters;
+
+using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
+
+using Unifesspa.UniPlus.Configuracao.Domain.Enums;
+
+// Mapeia Abrangencia ↔ string (varchar) usando o token canônico UPPER_SNAKE
+// (NACIONAL…), não o nome PascalCase do enum. A reidratação falha explicitamente
+// (com contexto) caso a coluna seja corrompida fora do fluxo da aplicação.
+public sealed class AbrangenciaValueConverter : ValueConverter<Abrangencia, string>
+{
+    public AbrangenciaValueConverter()
+        : base(
+            abrangencia => Abrangencias.ParaTokenCanonico(abrangencia),
+            token => Reidratar(token))
+    {
+    }
+
+    private static Abrangencia Reidratar(string token)
+    {
+        if (!Abrangencias.TryAnalisar(token, out Abrangencia abrangencia))
+        {
+            throw new InvalidOperationException(
+                $"Dado inválido no banco ao reidratar {nameof(Abrangencia)}: '{token}'. " +
+                "Verifique se houve alteração manual da coluna fora do fluxo da aplicação.");
+        }
+
+        return abrangencia;
+    }
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Infrastructure/Persistence/Migrations/20260802202733_CriaCalendarioDiasUteis.Designer.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Infrastructure/Persistence/Migrations/20260802202733_CriaCalendarioDiasUteis.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Unifesspa.UniPlus.Configuracao.Infrastructure.Persistence;
@@ -11,9 +12,11 @@ using Unifesspa.UniPlus.Configuracao.Infrastructure.Persistence;
 namespace Unifesspa.UniPlus.Configuracao.Infrastructure.Persistence.Migrations
 {
     [DbContext(typeof(ConfiguracaoDbContext))]
-    partial class ConfiguracaoDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260802202733_CriaCalendarioDiasUteis")]
+    partial class CriaCalendarioDiasUteis
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Infrastructure/Persistence/Migrations/20260802202733_CriaCalendarioDiasUteis.Designer.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Infrastructure/Persistence/Migrations/20260802202733_CriaCalendarioDiasUteis.Designer.cs
@@ -375,6 +375,11 @@ namespace Unifesspa.UniPlus.Configuracao.Infrastructure.Persistence.Migrations
                         .HasColumnType("character varying(7)")
                         .HasColumnName("municipio_ibge");
 
+                    b.Property<string>("Uf")
+                        .HasMaxLength(2)
+                        .HasColumnType("character varying(2)")
+                        .HasColumnName("uf");
+
                     b.Property<DateTimeOffset?>("UpdatedAt")
                         .HasColumnType("timestamp with time zone")
                         .HasColumnName("updated_at");
@@ -388,6 +393,8 @@ namespace Unifesspa.UniPlus.Configuracao.Infrastructure.Persistence.Migrations
                     b.ToTable("dia_nao_util", "configuracao", t =>
                         {
                             t.HasCheckConstraint("ck_dia_nao_util_municipio_coerente", "(abrangencia = 'MUNICIPAL') = (municipio_ibge IS NOT NULL)");
+
+                            t.HasCheckConstraint("ck_dia_nao_util_uf_coerente", "(abrangencia = 'ESTADUAL') = (uf IS NOT NULL)");
                         });
                 });
 

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Infrastructure/Persistence/Migrations/20260802202733_CriaCalendarioDiasUteis.Designer.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Infrastructure/Persistence/Migrations/20260802202733_CriaCalendarioDiasUteis.Designer.cs
@@ -63,6 +63,12 @@ namespace Unifesspa.UniPlus.Configuracao.Infrastructure.Persistence.Migrations
                         .HasColumnType("character varying(255)")
                         .HasColumnName("updated_by");
 
+                    b.Property<uint>("Version")
+                        .IsConcurrencyToken()
+                        .ValueGeneratedOnAddOrUpdate()
+                        .HasColumnType("xid")
+                        .HasColumnName("xmin");
+
                     b.Property<string>("VersaoDataset")
                         .IsRequired()
                         .HasMaxLength(60)

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Infrastructure/Persistence/Migrations/20260802202733_CriaCalendarioDiasUteis.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Infrastructure/Persistence/Migrations/20260802202733_CriaCalendarioDiasUteis.cs
@@ -1,0 +1,116 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Unifesspa.UniPlus.Configuracao.Infrastructure.Persistence.Migrations
+{
+    /// <inheritdoc />
+    public partial class CriaCalendarioDiasUteis : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "calendario_dias_uteis",
+                schema: "configuracao",
+                columns: table => new
+                {
+                    id = table.Column<Guid>(type: "uuid", nullable: false),
+                    versao_dataset = table.Column<string>(type: "character varying(60)", maxLength: 60, nullable: false),
+                    vigente = table.Column<bool>(type: "boolean", nullable: false),
+                    created_by = table.Column<string>(type: "character varying(255)", maxLength: 255, nullable: true),
+                    updated_by = table.Column<string>(type: "character varying(255)", maxLength: 255, nullable: true),
+                    created_at = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false),
+                    updated_at = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: true),
+                    is_deleted = table.Column<bool>(type: "boolean", nullable: false),
+                    deleted_at = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: true),
+                    deleted_by = table.Column<string>(type: "text", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("pk_calendario_dias_uteis", x => x.id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "dia_nao_util",
+                schema: "configuracao",
+                columns: table => new
+                {
+                    id = table.Column<Guid>(type: "uuid", nullable: false),
+                    calendario_dias_uteis_id = table.Column<Guid>(type: "uuid", nullable: false),
+                    abrangencia = table.Column<string>(type: "character varying(20)", maxLength: 20, nullable: false),
+                    municipio_ibge = table.Column<string>(type: "character varying(7)", maxLength: 7, nullable: true),
+                    data = table.Column<DateOnly>(type: "date", nullable: false),
+                    descricao = table.Column<string>(type: "character varying(200)", maxLength: 200, nullable: false),
+                    created_at = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false),
+                    updated_at = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("pk_dia_nao_util", x => x.id);
+                    table.CheckConstraint("ck_dia_nao_util_municipio_coerente", "(abrangencia = 'MUNICIPAL') = (municipio_ibge IS NOT NULL)");
+                    table.ForeignKey(
+                        name: "fk_dia_nao_util_calendarios_dias_uteis_calendario_dias_uteis_id",
+                        column: x => x.calendario_dias_uteis_id,
+                        principalSchema: "configuracao",
+                        principalTable: "calendario_dias_uteis",
+                        principalColumn: "id");
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "ix_calendario_dias_uteis_versao_dataset",
+                schema: "configuracao",
+                table: "calendario_dias_uteis",
+                column: "versao_dataset",
+                filter: "is_deleted = false");
+
+            migrationBuilder.CreateIndex(
+                name: "ix_dia_nao_util_calendario_data",
+                schema: "configuracao",
+                table: "dia_nao_util",
+                columns: new[] { "calendario_dias_uteis_id", "data" });
+
+            // Pré-requisito da exclusion constraint abaixo: sem btree_gist o operador `=`
+            // de boolean não tem classe GIST. `calendario_dias_uteis` compartilha o mesmo
+            // banco físico do schema `publicacoes` (só schemas isolam os módulos, não
+            // bancos — ver 20260710021244_AddTipoAtoPublicado, que já criou a extensão),
+            // mas IF NOT EXISTS mantém esta migration autossuficiente mesmo rodando
+            // isolada (ex.: containers efêmeros de teste de integração que só aplicam o
+            // DbContext de Configuracao).
+            migrationBuilder.Sql("CREATE EXTENSION IF NOT EXISTS btree_gist;");
+
+            // No máximo um dataset vivo é vigente. Um índice único comum é verificado
+            // por-statement: MarcarVigenteCalendarioDiasUteisCommandHandler desmarca o
+            // vigente anterior e marca o novo na mesma SaveChangesAsync, e o EF Core não
+            // garante a ordem entre os dois UPDATEs — com um índice não-deferível, a
+            // ordem inversa colide (23505) mesmo a transação terminando num estado final
+            // válido. DEFERRABLE INITIALLY DEFERRED adia a checagem para o COMMIT. Mesmo
+            // padrão de ex_nos_exigencia_irmaos_ordem (NoExigenciaConfiguration.cs) e
+            // ex_tipo_ato_publicado_codigo_vigencia (TipoAtoPublicadoConfiguration.cs) —
+            // EXCLUDE com predicado parcial não é modelável pelo Fluent API do EF Core,
+            // então vive só aqui e no ModelSnapshot (não em CalendarioDiasUteisConfiguration.cs).
+            migrationBuilder.Sql(
+                """
+                ALTER TABLE configuracao.calendario_dias_uteis
+                ADD CONSTRAINT ex_calendario_dias_uteis_vigente_unico
+                EXCLUDE USING gist (
+                    vigente WITH =
+                ) WHERE (vigente = true AND is_deleted = false)
+                DEFERRABLE INITIALLY DEFERRED;
+                """);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "dia_nao_util",
+                schema: "configuracao");
+
+            migrationBuilder.DropTable(
+                name: "calendario_dias_uteis",
+                schema: "configuracao");
+        }
+    }
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Infrastructure/Persistence/Migrations/20260802202733_CriaCalendarioDiasUteis.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Infrastructure/Persistence/Migrations/20260802202733_CriaCalendarioDiasUteis.cs
@@ -41,6 +41,7 @@ namespace Unifesspa.UniPlus.Configuracao.Infrastructure.Persistence.Migrations
                     calendario_dias_uteis_id = table.Column<Guid>(type: "uuid", nullable: false),
                     abrangencia = table.Column<string>(type: "character varying(20)", maxLength: 20, nullable: false),
                     municipio_ibge = table.Column<string>(type: "character varying(7)", maxLength: 7, nullable: true),
+                    uf = table.Column<string>(type: "character varying(2)", maxLength: 2, nullable: true),
                     data = table.Column<DateOnly>(type: "date", nullable: false),
                     descricao = table.Column<string>(type: "character varying(200)", maxLength: 200, nullable: false),
                     created_at = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false),
@@ -50,6 +51,7 @@ namespace Unifesspa.UniPlus.Configuracao.Infrastructure.Persistence.Migrations
                 {
                     table.PrimaryKey("pk_dia_nao_util", x => x.id);
                     table.CheckConstraint("ck_dia_nao_util_municipio_coerente", "(abrangencia = 'MUNICIPAL') = (municipio_ibge IS NOT NULL)");
+                    table.CheckConstraint("ck_dia_nao_util_uf_coerente", "(abrangencia = 'ESTADUAL') = (uf IS NOT NULL)");
                     table.ForeignKey(
                         name: "fk_dia_nao_util_calendarios_dias_uteis_calendario_dias_uteis_id",
                         column: x => x.calendario_dias_uteis_id,

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Infrastructure/Persistence/Migrations/ConfiguracaoDbContextModelSnapshot.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Infrastructure/Persistence/Migrations/ConfiguracaoDbContextModelSnapshot.cs
@@ -66,6 +66,12 @@ namespace Unifesspa.UniPlus.Configuracao.Infrastructure.Persistence.Migrations
                         .HasColumnType("character varying(60)")
                         .HasColumnName("versao_dataset");
 
+                    b.Property<uint>("Version")
+                        .IsConcurrencyToken()
+                        .ValueGeneratedOnAddOrUpdate()
+                        .HasColumnType("xid")
+                        .HasColumnName("xmin");
+
                     b.Property<bool>("Vigente")
                         .HasColumnType("boolean")
                         .HasColumnName("vigente");

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Infrastructure/Persistence/Migrations/ConfiguracaoDbContextModelSnapshot.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Infrastructure/Persistence/Migrations/ConfiguracaoDbContextModelSnapshot.cs
@@ -372,6 +372,11 @@ namespace Unifesspa.UniPlus.Configuracao.Infrastructure.Persistence.Migrations
                         .HasColumnType("character varying(7)")
                         .HasColumnName("municipio_ibge");
 
+                    b.Property<string>("Uf")
+                        .HasMaxLength(2)
+                        .HasColumnType("character varying(2)")
+                        .HasColumnName("uf");
+
                     b.Property<DateTimeOffset?>("UpdatedAt")
                         .HasColumnType("timestamp with time zone")
                         .HasColumnName("updated_at");
@@ -385,6 +390,8 @@ namespace Unifesspa.UniPlus.Configuracao.Infrastructure.Persistence.Migrations
                     b.ToTable("dia_nao_util", "configuracao", t =>
                         {
                             t.HasCheckConstraint("ck_dia_nao_util_municipio_coerente", "(abrangencia = 'MUNICIPAL') = (municipio_ibge IS NOT NULL)");
+
+                            t.HasCheckConstraint("ck_dia_nao_util_uf_coerente", "(abrangencia = 'ESTADUAL') = (uf IS NOT NULL)");
                         });
                 });
 

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Infrastructure/Persistence/Repositories/CalendarioDiasUteisRepository.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Infrastructure/Persistence/Repositories/CalendarioDiasUteisRepository.cs
@@ -1,0 +1,71 @@
+namespace Unifesspa.UniPlus.Configuracao.Infrastructure.Persistence.Repositories;
+
+using Microsoft.EntityFrameworkCore;
+
+using Unifesspa.UniPlus.Configuracao.Domain.Entities;
+using Unifesspa.UniPlus.Configuracao.Domain.Interfaces;
+using Unifesspa.UniPlus.Infrastructure.Core.Pagination;
+using Unifesspa.UniPlus.Kernel.Pagination;
+
+[System.Diagnostics.CodeAnalysis.SuppressMessage(
+    "Performance",
+    "CA1812:Avoid uninstantiated internal classes",
+    Justification = "Instanciada via DI em ConfiguracaoInfrastructureRegistration.")]
+public sealed class CalendarioDiasUteisRepository : ICalendarioDiasUteisRepository
+{
+    private readonly ConfiguracaoDbContext _dbContext;
+
+    public CalendarioDiasUteisRepository(ConfiguracaoDbContext dbContext)
+    {
+        ArgumentNullException.ThrowIfNull(dbContext);
+        _dbContext = dbContext;
+    }
+
+    public Task<CalendarioDiasUteis?> ObterPorIdAsync(Guid id, CancellationToken cancellationToken)
+    {
+        return _dbContext.CalendariosDiasUteis
+            .Include(c => c.DiasNaoUteis)
+            .FirstOrDefaultAsync(c => c.Id == id, cancellationToken);
+    }
+
+    public Task<CalendarioDiasUteis?> ObterPorIdParaLeituraAsync(Guid id, CancellationToken cancellationToken)
+    {
+        return _dbContext.CalendariosDiasUteis
+            .AsNoTracking()
+            .Include(c => c.DiasNaoUteis)
+            .FirstOrDefaultAsync(c => c.Id == id, cancellationToken);
+    }
+
+    public async Task<(IReadOnlyList<CalendarioDiasUteis> Itens, Guid? AnteriorAfterId, Guid? ProximoAfterId)> ListarPaginadoAsync(
+        Guid? afterId,
+        int limit,
+        PaginationDirection direction,
+        CancellationToken cancellationToken)
+    {
+        // Keyset bidirecional (ADR-0089): ordenação por Id (Guid v7, ADR-0026/0032).
+        // Sem Include de DiasNaoUteis — a listagem projeta só o cabeçalho do dataset.
+        CursorKeysetPage<CalendarioDiasUteis> page = await CursorKeyset
+            .ApplyAsync(_dbContext.CalendariosDiasUteis.AsNoTracking(), afterId, limit, direction, cancellationToken)
+            .ConfigureAwait(false);
+
+        return (page.Items, page.PrevAfterId, page.NextAfterId);
+    }
+
+    public Task<CalendarioDiasUteis?> ObterVigenteAsync(CancellationToken cancellationToken)
+    {
+        return _dbContext.CalendariosDiasUteis
+            .FirstOrDefaultAsync(c => c.Vigente, cancellationToken);
+    }
+
+    public async Task AdicionarAsync(CalendarioDiasUteis calendario, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(calendario);
+        await _dbContext.CalendariosDiasUteis.AddAsync(calendario, cancellationToken).ConfigureAwait(false);
+    }
+
+    public void Remover(CalendarioDiasUteis calendario)
+    {
+        ArgumentNullException.ThrowIfNull(calendario);
+        _dbContext.CalendariosDiasUteis.Remove(calendario);
+    }
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Infrastructure/Readers/CalendarioVigenteReader.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Infrastructure/Readers/CalendarioVigenteReader.cs
@@ -4,6 +4,7 @@ using Microsoft.EntityFrameworkCore;
 
 using Unifesspa.UniPlus.Configuracao.Contracts;
 using Unifesspa.UniPlus.Configuracao.Domain.Entities;
+using Unifesspa.UniPlus.Configuracao.Domain.Enums;
 using Unifesspa.UniPlus.Configuracao.Infrastructure.Persistence;
 
 /// <summary>
@@ -39,7 +40,10 @@ internal sealed class CalendarioVigenteReader : ICalendarioVigenteReader
             return null;
         }
 
-        DateOnly[] datas = [.. calendario.DiasNaoUteis.Select(d => d.Data)];
-        return new CalendarioVigenteView(calendario.Id, calendario.VersaoDataset, datas);
+        DiaNaoUtilView[] dias = [.. calendario.DiasNaoUteis.Select(ParaView)];
+        return new CalendarioVigenteView(calendario.Id, calendario.VersaoDataset, dias);
     }
+
+    private static DiaNaoUtilView ParaView(DiaNaoUtil dia) =>
+        new(dia.Data, Abrangencias.ParaTokenCanonico(dia.Abrangencia), dia.MunicipioIbge);
 }

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Infrastructure/Readers/CalendarioVigenteReader.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Infrastructure/Readers/CalendarioVigenteReader.cs
@@ -1,0 +1,45 @@
+namespace Unifesspa.UniPlus.Configuracao.Infrastructure.Readers;
+
+using Microsoft.EntityFrameworkCore;
+
+using Unifesspa.UniPlus.Configuracao.Contracts;
+using Unifesspa.UniPlus.Configuracao.Domain.Entities;
+using Unifesspa.UniPlus.Configuracao.Infrastructure.Persistence;
+
+/// <summary>
+/// Implementação de <see cref="ICalendarioVigenteReader"/> (ADR-0056): leitura
+/// direta do banco de Configuração (<c>AsNoTracking</c>, query filter de
+/// soft-delete por convenção). Sem cache — troca de vigente é rara e o
+/// congelamento por valor no consumidor (ADR-0061) dispensa releitura quente.
+/// </summary>
+[System.Diagnostics.CodeAnalysis.SuppressMessage(
+    "Performance",
+    "CA1812:Avoid uninstantiated internal classes",
+    Justification = "Instanciada via DI em ConfiguracaoInfrastructureRegistration.")]
+internal sealed class CalendarioVigenteReader : ICalendarioVigenteReader
+{
+    private readonly ConfiguracaoDbContext _dbContext;
+
+    public CalendarioVigenteReader(ConfiguracaoDbContext dbContext)
+    {
+        ArgumentNullException.ThrowIfNull(dbContext);
+        _dbContext = dbContext;
+    }
+
+    public async Task<CalendarioVigenteView?> ObterVigenteAsync(CancellationToken cancellationToken = default)
+    {
+        CalendarioDiasUteis? calendario = await _dbContext.CalendariosDiasUteis
+            .AsNoTracking()
+            .Include(c => c.DiasNaoUteis)
+            .FirstOrDefaultAsync(c => c.Vigente, cancellationToken)
+            .ConfigureAwait(false);
+
+        if (calendario is null)
+        {
+            return null;
+        }
+
+        DateOnly[] datas = [.. calendario.DiasNaoUteis.Select(d => d.Data)];
+        return new CalendarioVigenteView(calendario.Id, calendario.VersaoDataset, datas);
+    }
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Infrastructure/Readers/CalendarioVigenteReader.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Infrastructure/Readers/CalendarioVigenteReader.cs
@@ -45,5 +45,5 @@ internal sealed class CalendarioVigenteReader : ICalendarioVigenteReader
     }
 
     private static DiaNaoUtilView ParaView(DiaNaoUtil dia) =>
-        new(dia.Data, Abrangencias.ParaTokenCanonico(dia.Abrangencia), dia.MunicipioIbge);
+        new(dia.Data, Abrangencias.ParaTokenCanonico(dia.Abrangencia), dia.MunicipioIbge, dia.Uf);
 }

--- a/src/shared/Unifesspa.UniPlus.Kernel/Domain/Cidades/ReferenciaCidadeGeo.cs
+++ b/src/shared/Unifesspa.UniPlus.Kernel/Domain/Cidades/ReferenciaCidadeGeo.cs
@@ -77,6 +77,34 @@ public static class ReferenciaCidadeGeo
     }.ToFrozenDictionary(StringComparer.Ordinal);
 
     /// <summary>
+    /// As 27 siglas de UF válidas (unidades federativas do Brasil), derivadas dos
+    /// valores de <see cref="UfPorPrefixo"/> — mesma fonte de verdade, sem
+    /// duplicar a lista.
+    /// </summary>
+    private static readonly FrozenSet<string> UfsValidas =
+        UfPorPrefixo.Values.ToFrozenSet(StringComparer.Ordinal);
+
+    /// <summary>
+    /// Indica se os dois primeiros dígitos de <paramref name="codigoIbge"/>
+    /// (assumido já validado como 7 dígitos numéricos) correspondem a um prefixo
+    /// de UF real. Útil para consumidores que só têm o código IBGE, sem
+    /// <c>cidadeUf</c> declarada para cruzar coerência (ex.: cadastros que
+    /// referenciam um município sem exibir nome/UF).
+    /// </summary>
+    public static bool TemPrefixoDeUfValido(string codigoIbge)
+    {
+        ArgumentNullException.ThrowIfNull(codigoIbge);
+        return codigoIbge.Length >= 2 && UfPorPrefixo.ContainsKey(codigoIbge[..2]);
+    }
+
+    /// <summary>Indica se <paramref name="uf"/> é uma das 27 siglas de UF válidas (comparação exata, case-sensitive).</summary>
+    public static bool EhUfValida(string uf)
+    {
+        ArgumentNullException.ThrowIfNull(uf);
+        return UfsValidas.Contains(uf);
+    }
+
+    /// <summary>
     /// Valida a referência de cidade (formato + coerência de UF). Retorna
     /// <see cref="Result.Success"/> quando o código tem 7 dígitos numéricos com
     /// prefixo de UF coerente com <paramref name="cidadeUf"/> e

--- a/tests/Unifesspa.UniPlus.Configuracao.Application.UnitTests/Commands/CriarCalendarioDiasUteisCommandHandlerTests.cs
+++ b/tests/Unifesspa.UniPlus.Configuracao.Application.UnitTests/Commands/CriarCalendarioDiasUteisCommandHandlerTests.cs
@@ -1,0 +1,49 @@
+namespace Unifesspa.UniPlus.Configuracao.Application.UnitTests.Commands;
+
+using AwesomeAssertions;
+
+using NSubstitute;
+
+using Unifesspa.UniPlus.Configuracao.Application.Abstractions;
+using Unifesspa.UniPlus.Configuracao.Application.Commands.CalendariosDiasUteis;
+using Unifesspa.UniPlus.Configuracao.Domain.Entities;
+using Unifesspa.UniPlus.Configuracao.Domain.Errors;
+using Unifesspa.UniPlus.Configuracao.Domain.Interfaces;
+using Unifesspa.UniPlus.Kernel.Results;
+
+public sealed class CriarCalendarioDiasUteisCommandHandlerTests
+{
+    private readonly ICalendarioDiasUteisRepository _repository = Substitute.For<ICalendarioDiasUteisRepository>();
+    private readonly IConfiguracaoUnitOfWork _unitOfWork = Substitute.For<IConfiguracaoUnitOfWork>();
+
+    private static CriarCalendarioDiasUteisCommand ComandoValido() =>
+        new(
+            "2027.1",
+            [new DiaNaoUtilCommandItem("NACIONAL", null, new DateOnly(2027, 1, 1), "Confraternização Universal")]);
+
+    [Fact(DisplayName = "Cria o calendário, persiste e retorna o Id")]
+    public async Task Handle_ComandoValido_CriaEPersiste()
+    {
+        Result<Guid> resultado = await CriarCalendarioDiasUteisCommandHandler.Handle(
+            ComandoValido(), _repository, _unitOfWork, CancellationToken.None);
+
+        resultado.IsSuccess.Should().BeTrue();
+        resultado.Value.Should().NotBe(Guid.Empty);
+        await _repository.Received(1).AdicionarAsync(Arg.Any<CalendarioDiasUteis>(), Arg.Any<CancellationToken>());
+        await _unitOfWork.Received(1).SalvarAlteracoesAsync(Arg.Any<CancellationToken>());
+    }
+
+    [Fact(DisplayName = "Comando com versão do dataset vazia falha sem persistir")]
+    public async Task Handle_VersaoDatasetVazia_RetornaErroSemPersistir()
+    {
+        CriarCalendarioDiasUteisCommand comando = ComandoValido() with { VersaoDataset = string.Empty };
+
+        Result<Guid> resultado = await CriarCalendarioDiasUteisCommandHandler.Handle(
+            comando, _repository, _unitOfWork, CancellationToken.None);
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be(CalendarioDiasUteisErrorCodes.VersaoDatasetObrigatoria);
+        await _repository.DidNotReceive().AdicionarAsync(Arg.Any<CalendarioDiasUteis>(), Arg.Any<CancellationToken>());
+        await _unitOfWork.DidNotReceive().SalvarAlteracoesAsync(Arg.Any<CancellationToken>());
+    }
+}

--- a/tests/Unifesspa.UniPlus.Configuracao.Application.UnitTests/Commands/MarcarVigenteCalendarioDiasUteisCommandHandlerTests.cs
+++ b/tests/Unifesspa.UniPlus.Configuracao.Application.UnitTests/Commands/MarcarVigenteCalendarioDiasUteisCommandHandlerTests.cs
@@ -1,0 +1,86 @@
+namespace Unifesspa.UniPlus.Configuracao.Application.UnitTests.Commands;
+
+using AwesomeAssertions;
+
+using NSubstitute;
+
+using Unifesspa.UniPlus.Configuracao.Application.Abstractions;
+using Unifesspa.UniPlus.Configuracao.Application.Commands.CalendariosDiasUteis;
+using Unifesspa.UniPlus.Configuracao.Domain.Entities;
+using Unifesspa.UniPlus.Configuracao.Domain.Errors;
+using Unifesspa.UniPlus.Configuracao.Domain.Interfaces;
+using Unifesspa.UniPlus.Kernel.Results;
+
+public sealed class MarcarVigenteCalendarioDiasUteisCommandHandlerTests
+{
+    private readonly ICalendarioDiasUteisRepository _repository = Substitute.For<ICalendarioDiasUteisRepository>();
+    private readonly IConfiguracaoUnitOfWork _unitOfWork = Substitute.For<IConfiguracaoUnitOfWork>();
+
+    private static CalendarioDiasUteis Novo(string versaoDataset = "2027.1") =>
+        CalendarioDiasUteis.Criar(
+            versaoDataset,
+            [new DiaNaoUtilCriacao("NACIONAL", null, new DateOnly(2027, 1, 1), "Confraternização Universal")]).Value!;
+
+    [Fact(DisplayName = "Id inexistente retorna NaoEncontrado")]
+    public async Task Handle_NaoEncontrado_RetornaErro()
+    {
+        Guid id = Guid.NewGuid();
+        _repository.ObterPorIdAsync(id, Arg.Any<CancellationToken>()).Returns((CalendarioDiasUteis?)null);
+
+        Result resultado = await MarcarVigenteCalendarioDiasUteisCommandHandler.Handle(
+            new MarcarVigenteCalendarioDiasUteisCommand(id), _repository, _unitOfWork, CancellationToken.None);
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be(CalendarioDiasUteisErrorCodes.NaoEncontrado);
+        await _unitOfWork.DidNotReceive().SalvarAlteracoesAsync(Arg.Any<CancellationToken>());
+    }
+
+    [Fact(DisplayName = "Dataset já vigente falha (JaVigente)")]
+    public async Task Handle_JaVigente_RetornaErro()
+    {
+        CalendarioDiasUteis calendario = Novo();
+        calendario.MarcarVigente();
+        _repository.ObterPorIdAsync(calendario.Id, Arg.Any<CancellationToken>()).Returns(calendario);
+
+        Result resultado = await MarcarVigenteCalendarioDiasUteisCommandHandler.Handle(
+            new MarcarVigenteCalendarioDiasUteisCommand(calendario.Id), _repository, _unitOfWork, CancellationToken.None);
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be(CalendarioDiasUteisErrorCodes.JaVigente);
+        await _unitOfWork.DidNotReceive().SalvarAlteracoesAsync(Arg.Any<CancellationToken>());
+    }
+
+    [Fact(DisplayName = "Dataset não vigente sem vigente anterior fica vigente e persiste")]
+    public async Task Handle_SemVigenteAnterior_MarcaVigenteEPersiste()
+    {
+        CalendarioDiasUteis calendario = Novo();
+        _repository.ObterPorIdAsync(calendario.Id, Arg.Any<CancellationToken>()).Returns(calendario);
+        _repository.ObterVigenteAsync(Arg.Any<CancellationToken>()).Returns((CalendarioDiasUteis?)null);
+
+        Result resultado = await MarcarVigenteCalendarioDiasUteisCommandHandler.Handle(
+            new MarcarVigenteCalendarioDiasUteisCommand(calendario.Id), _repository, _unitOfWork, CancellationToken.None);
+
+        resultado.IsSuccess.Should().BeTrue();
+        calendario.Vigente.Should().BeTrue();
+        await _unitOfWork.Received(1).SalvarAlteracoesAsync(Arg.Any<CancellationToken>());
+    }
+
+    [Fact(DisplayName = "Dataset não vigente com vigente anterior desmarca o anterior e marca o novo")]
+    public async Task Handle_ComVigenteAnterior_DesmarcaAnteriorEMarcaNovo()
+    {
+        CalendarioDiasUteis novo = Novo("2027.1");
+        CalendarioDiasUteis vigenteAnterior = Novo("2026.2");
+        vigenteAnterior.MarcarVigente();
+
+        _repository.ObterPorIdAsync(novo.Id, Arg.Any<CancellationToken>()).Returns(novo);
+        _repository.ObterVigenteAsync(Arg.Any<CancellationToken>()).Returns(vigenteAnterior);
+
+        Result resultado = await MarcarVigenteCalendarioDiasUteisCommandHandler.Handle(
+            new MarcarVigenteCalendarioDiasUteisCommand(novo.Id), _repository, _unitOfWork, CancellationToken.None);
+
+        resultado.IsSuccess.Should().BeTrue();
+        novo.Vigente.Should().BeTrue();
+        vigenteAnterior.Vigente.Should().BeFalse();
+        await _unitOfWork.Received(1).SalvarAlteracoesAsync(Arg.Any<CancellationToken>());
+    }
+}

--- a/tests/Unifesspa.UniPlus.Configuracao.Application.UnitTests/Commands/MarcarVigenteCalendarioDiasUteisCommandHandlerTests.cs
+++ b/tests/Unifesspa.UniPlus.Configuracao.Application.UnitTests/Commands/MarcarVigenteCalendarioDiasUteisCommandHandlerTests.cs
@@ -2,10 +2,14 @@ namespace Unifesspa.UniPlus.Configuracao.Application.UnitTests.Commands;
 
 using AwesomeAssertions;
 
+using Microsoft.EntityFrameworkCore;
+
 using NSubstitute;
+using NSubstitute.ExceptionExtensions;
 
 using Unifesspa.UniPlus.Configuracao.Application.Abstractions;
 using Unifesspa.UniPlus.Configuracao.Application.Commands.CalendariosDiasUteis;
+using Unifesspa.UniPlus.Configuracao.Application.UnitTests.TestSupport;
 using Unifesspa.UniPlus.Configuracao.Domain.Entities;
 using Unifesspa.UniPlus.Configuracao.Domain.Errors;
 using Unifesspa.UniPlus.Configuracao.Domain.Interfaces;
@@ -82,5 +86,52 @@ public sealed class MarcarVigenteCalendarioDiasUteisCommandHandlerTests
         novo.Vigente.Should().BeTrue();
         vigenteAnterior.Vigente.Should().BeFalse();
         await _unitOfWork.Received(1).SalvarAlteracoesAsync(Arg.Any<CancellationToken>());
+    }
+
+    [Fact(DisplayName = "Exclusion constraint de vigência colidindo no commit vira ConflitoDeConcorrencia")]
+    public async Task Handle_ColisaoNaExclusionConstraint_RetornaConflitoDeConcorrencia()
+    {
+        CalendarioDiasUteis calendario = Novo();
+        _repository.ObterPorIdAsync(calendario.Id, Arg.Any<CancellationToken>()).Returns(calendario);
+        _repository.ObterVigenteAsync(Arg.Any<CancellationToken>()).Returns((CalendarioDiasUteis?)null);
+        _unitOfWork.SalvarAlteracoesAsync(Arg.Any<CancellationToken>())
+            .ThrowsAsync(PostgresExceptionFactory.Create("23P01", "ex_calendario_dias_uteis_vigente_unico"));
+
+        Result resultado = await MarcarVigenteCalendarioDiasUteisCommandHandler.Handle(
+            new MarcarVigenteCalendarioDiasUteisCommand(calendario.Id), _repository, _unitOfWork, CancellationToken.None);
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be(CalendarioDiasUteisErrorCodes.ConflitoDeConcorrencia);
+    }
+
+    [Fact(DisplayName = "DbUpdateConcurrencyException (xmin) no commit vira ConflitoDeConcorrencia")]
+    public async Task Handle_ConcorrenciaOtimista_RetornaConflitoDeConcorrencia()
+    {
+        CalendarioDiasUteis calendario = Novo();
+        _repository.ObterPorIdAsync(calendario.Id, Arg.Any<CancellationToken>()).Returns(calendario);
+        _repository.ObterVigenteAsync(Arg.Any<CancellationToken>()).Returns((CalendarioDiasUteis?)null);
+        _unitOfWork.SalvarAlteracoesAsync(Arg.Any<CancellationToken>())
+            .ThrowsAsync(new DbUpdateConcurrencyException("conflito sintético de teste"));
+
+        Result resultado = await MarcarVigenteCalendarioDiasUteisCommandHandler.Handle(
+            new MarcarVigenteCalendarioDiasUteisCommand(calendario.Id), _repository, _unitOfWork, CancellationToken.None);
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be(CalendarioDiasUteisErrorCodes.ConflitoDeConcorrencia);
+    }
+
+    [Fact(DisplayName = "Violação de outra constraint não é engolida — propaga")]
+    public async Task Handle_OutraViolacaoDeConstraint_Propaga()
+    {
+        CalendarioDiasUteis calendario = Novo();
+        _repository.ObterPorIdAsync(calendario.Id, Arg.Any<CancellationToken>()).Returns(calendario);
+        _repository.ObterVigenteAsync(Arg.Any<CancellationToken>()).Returns((CalendarioDiasUteis?)null);
+        _unitOfWork.SalvarAlteracoesAsync(Arg.Any<CancellationToken>())
+            .ThrowsAsync(PostgresExceptionFactory.Create("23505", "outra_constraint_qualquer"));
+
+        Func<Task> act = () => MarcarVigenteCalendarioDiasUteisCommandHandler.Handle(
+            new MarcarVigenteCalendarioDiasUteisCommand(calendario.Id), _repository, _unitOfWork, CancellationToken.None);
+
+        await act.Should().ThrowAsync<Npgsql.PostgresException>();
     }
 }

--- a/tests/Unifesspa.UniPlus.Configuracao.Application.UnitTests/Commands/MarcarVigenteCalendarioDiasUteisCommandHandlerTests.cs
+++ b/tests/Unifesspa.UniPlus.Configuracao.Application.UnitTests/Commands/MarcarVigenteCalendarioDiasUteisCommandHandlerTests.cs
@@ -88,13 +88,17 @@ public sealed class MarcarVigenteCalendarioDiasUteisCommandHandlerTests
         await _unitOfWork.Received(1).SalvarAlteracoesAsync(Arg.Any<CancellationToken>());
     }
 
-    [Fact(DisplayName = "Exclusion constraint de vigência colidindo no commit vira ConflitoDeConcorrencia")]
+    [Fact(DisplayName = "Exclusion constraint de vigência colidindo na checagem forçada vira ConflitoDeConcorrencia")]
     public async Task Handle_ColisaoNaExclusionConstraint_RetornaConflitoDeConcorrencia()
     {
+        // A violação surge em ForcarChecagemImediataDeConstraintsAsync (SET CONSTRAINTS
+        // IMMEDIATE), não em SalvarAlteracoesAsync — a constraint é DEFERRABLE INITIALLY
+        // DEFERRED, então SaveChangesAsync sozinho não a checaria (só o faria no commit
+        // externo do outbox do Wolverine, fora do try do handler).
         CalendarioDiasUteis calendario = Novo();
         _repository.ObterPorIdAsync(calendario.Id, Arg.Any<CancellationToken>()).Returns(calendario);
         _repository.ObterVigenteAsync(Arg.Any<CancellationToken>()).Returns((CalendarioDiasUteis?)null);
-        _unitOfWork.SalvarAlteracoesAsync(Arg.Any<CancellationToken>())
+        _unitOfWork.ForcarChecagemImediataDeConstraintsAsync(Arg.Any<CancellationToken>())
             .ThrowsAsync(PostgresExceptionFactory.Create("23P01", "ex_calendario_dias_uteis_vigente_unico"));
 
         Result resultado = await MarcarVigenteCalendarioDiasUteisCommandHandler.Handle(

--- a/tests/Unifesspa.UniPlus.Configuracao.Application.UnitTests/Commands/RemoverCalendarioDiasUteisCommandHandlerTests.cs
+++ b/tests/Unifesspa.UniPlus.Configuracao.Application.UnitTests/Commands/RemoverCalendarioDiasUteisCommandHandlerTests.cs
@@ -1,0 +1,67 @@
+namespace Unifesspa.UniPlus.Configuracao.Application.UnitTests.Commands;
+
+using AwesomeAssertions;
+
+using NSubstitute;
+
+using Unifesspa.UniPlus.Configuracao.Application.Abstractions;
+using Unifesspa.UniPlus.Configuracao.Application.Commands.CalendariosDiasUteis;
+using Unifesspa.UniPlus.Configuracao.Domain.Entities;
+using Unifesspa.UniPlus.Configuracao.Domain.Errors;
+using Unifesspa.UniPlus.Configuracao.Domain.Interfaces;
+using Unifesspa.UniPlus.Kernel.Results;
+
+public sealed class RemoverCalendarioDiasUteisCommandHandlerTests
+{
+    private readonly ICalendarioDiasUteisRepository _repository = Substitute.For<ICalendarioDiasUteisRepository>();
+    private readonly IConfiguracaoUnitOfWork _unitOfWork = Substitute.For<IConfiguracaoUnitOfWork>();
+
+    private static CalendarioDiasUteis Novo() =>
+        CalendarioDiasUteis.Criar(
+            "2027.1",
+            [new DiaNaoUtilCriacao("NACIONAL", null, new DateOnly(2027, 1, 1), "Confraternização Universal")]).Value!;
+
+    [Fact(DisplayName = "Id inexistente retorna NaoEncontrado")]
+    public async Task Handle_NaoEncontrado_RetornaErro()
+    {
+        Guid id = Guid.NewGuid();
+        _repository.ObterPorIdAsync(id, Arg.Any<CancellationToken>()).Returns((CalendarioDiasUteis?)null);
+
+        Result resultado = await RemoverCalendarioDiasUteisCommandHandler.Handle(
+            new RemoverCalendarioDiasUteisCommand(id), _repository, _unitOfWork, CancellationToken.None);
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be(CalendarioDiasUteisErrorCodes.NaoEncontrado);
+        _repository.DidNotReceive().Remover(Arg.Any<CalendarioDiasUteis>());
+    }
+
+    [Fact(DisplayName = "Dataset vigente não pode ser removido (NaoRemoveVigente)")]
+    public async Task Handle_DatasetVigente_RetornaErroSemRemover()
+    {
+        CalendarioDiasUteis calendario = Novo();
+        calendario.MarcarVigente();
+        _repository.ObterPorIdAsync(calendario.Id, Arg.Any<CancellationToken>()).Returns(calendario);
+
+        Result resultado = await RemoverCalendarioDiasUteisCommandHandler.Handle(
+            new RemoverCalendarioDiasUteisCommand(calendario.Id), _repository, _unitOfWork, CancellationToken.None);
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be(CalendarioDiasUteisErrorCodes.NaoRemoveVigente);
+        _repository.DidNotReceive().Remover(Arg.Any<CalendarioDiasUteis>());
+        await _unitOfWork.DidNotReceive().SalvarAlteracoesAsync(Arg.Any<CancellationToken>());
+    }
+
+    [Fact(DisplayName = "Dataset não vigente é removido e persistido")]
+    public async Task Handle_DatasetNaoVigente_RemoveEPersiste()
+    {
+        CalendarioDiasUteis calendario = Novo();
+        _repository.ObterPorIdAsync(calendario.Id, Arg.Any<CancellationToken>()).Returns(calendario);
+
+        Result resultado = await RemoverCalendarioDiasUteisCommandHandler.Handle(
+            new RemoverCalendarioDiasUteisCommand(calendario.Id), _repository, _unitOfWork, CancellationToken.None);
+
+        resultado.IsSuccess.Should().BeTrue();
+        _repository.Received(1).Remover(calendario);
+        await _unitOfWork.Received(1).SalvarAlteracoesAsync(Arg.Any<CancellationToken>());
+    }
+}

--- a/tests/Unifesspa.UniPlus.Configuracao.Application.UnitTests/Commands/RemoverCalendarioDiasUteisCommandHandlerTests.cs
+++ b/tests/Unifesspa.UniPlus.Configuracao.Application.UnitTests/Commands/RemoverCalendarioDiasUteisCommandHandlerTests.cs
@@ -2,7 +2,10 @@ namespace Unifesspa.UniPlus.Configuracao.Application.UnitTests.Commands;
 
 using AwesomeAssertions;
 
+using Microsoft.EntityFrameworkCore;
+
 using NSubstitute;
+using NSubstitute.ExceptionExtensions;
 
 using Unifesspa.UniPlus.Configuracao.Application.Abstractions;
 using Unifesspa.UniPlus.Configuracao.Application.Commands.CalendariosDiasUteis;
@@ -63,5 +66,20 @@ public sealed class RemoverCalendarioDiasUteisCommandHandlerTests
         resultado.IsSuccess.Should().BeTrue();
         _repository.Received(1).Remover(calendario);
         await _unitOfWork.Received(1).SalvarAlteracoesAsync(Arg.Any<CancellationToken>());
+    }
+
+    [Fact(DisplayName = "Remoção colidindo com ativação concorrente do mesmo dataset (xmin) vira ConflitoDeConcorrencia")]
+    public async Task Handle_ConcorrenciaOtimista_RetornaConflitoDeConcorrencia()
+    {
+        CalendarioDiasUteis calendario = Novo();
+        _repository.ObterPorIdAsync(calendario.Id, Arg.Any<CancellationToken>()).Returns(calendario);
+        _unitOfWork.SalvarAlteracoesAsync(Arg.Any<CancellationToken>())
+            .ThrowsAsync(new DbUpdateConcurrencyException("conflito sintético de teste"));
+
+        Result resultado = await RemoverCalendarioDiasUteisCommandHandler.Handle(
+            new RemoverCalendarioDiasUteisCommand(calendario.Id), _repository, _unitOfWork, CancellationToken.None);
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be(CalendarioDiasUteisErrorCodes.ConflitoDeConcorrencia);
     }
 }

--- a/tests/Unifesspa.UniPlus.Configuracao.Application.UnitTests/TestSupport/PostgresExceptionFactory.cs
+++ b/tests/Unifesspa.UniPlus.Configuracao.Application.UnitTests/TestSupport/PostgresExceptionFactory.cs
@@ -1,0 +1,30 @@
+namespace Unifesspa.UniPlus.Configuracao.Application.UnitTests.TestSupport;
+
+using System.Reflection;
+
+using Npgsql;
+
+/// <summary>
+/// Constrói <see cref="PostgresException"/> sintéticas para testar a tradução de
+/// exceção em <c>ExclusionConstraintViolation</c>/<c>UniqueConstraintViolation</c>
+/// sem precisar de um Postgres real. <c>ConstraintName</c> só tem setter privado no
+/// driver (populado normalmente a partir da mensagem de erro do protocolo) — o
+/// backing field é setado via reflection, técnica restrita a este helper de teste.
+/// </summary>
+public static class PostgresExceptionFactory
+{
+    public static PostgresException Create(string sqlState, string? constraintName = null)
+    {
+        var ex = new PostgresException("ERROR", "ERROR", "mensagem sintética de teste", sqlState);
+
+        if (constraintName is not null)
+        {
+            FieldInfo field = typeof(PostgresException)
+                .GetField("<ConstraintName>k__BackingField", BindingFlags.NonPublic | BindingFlags.Instance)
+                ?? throw new InvalidOperationException("Backing field de ConstraintName não encontrado — API do Npgsql mudou.");
+            field.SetValue(ex, constraintName);
+        }
+
+        return ex;
+    }
+}

--- a/tests/Unifesspa.UniPlus.Configuracao.Application.UnitTests/Unifesspa.UniPlus.Configuracao.Application.UnitTests.csproj
+++ b/tests/Unifesspa.UniPlus.Configuracao.Application.UnitTests/Unifesspa.UniPlus.Configuracao.Application.UnitTests.csproj
@@ -11,6 +11,12 @@
     <PackageReference Include="xunit.runner.visualstudio" />
     <PackageReference Include="AwesomeAssertions" />
     <PackageReference Include="NSubstitute" />
+    <!-- Só para construir DbUpdateException/DbUpdateConcurrencyException/PostgresException
+         sintéticos nos testes de tradução de exceção — a Application src NÃO referencia
+         estes pacotes (Clean Architecture); ver ExclusionConstraintViolation/
+         OptimisticConcurrencyViolation, que casam por Type.FullName via reflection. -->
+    <PackageReference Include="Microsoft.EntityFrameworkCore" />
+    <PackageReference Include="Npgsql" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Unifesspa.UniPlus.Configuracao.Application.UnitTests/Validators/CriarCalendarioDiasUteisCommandValidatorTests.cs
+++ b/tests/Unifesspa.UniPlus.Configuracao.Application.UnitTests/Validators/CriarCalendarioDiasUteisCommandValidatorTests.cs
@@ -1,0 +1,91 @@
+namespace Unifesspa.UniPlus.Configuracao.Application.UnitTests.Validators;
+
+using AwesomeAssertions;
+
+using FluentValidation.Results;
+
+using Unifesspa.UniPlus.Configuracao.Application.Commands.CalendariosDiasUteis;
+
+public sealed class CriarCalendarioDiasUteisCommandValidatorTests
+{
+    private readonly CriarCalendarioDiasUteisCommandValidator _validator = new();
+
+    private static CriarCalendarioDiasUteisCommand Base() =>
+        new(
+            "2027.1",
+            [new DiaNaoUtilCommandItem("NACIONAL", null, new DateOnly(2027, 1, 1), "Confraternização Universal")]);
+
+    [Fact(DisplayName = "Comando válido passa no validator")]
+    public void Valido_Passa()
+    {
+        _validator.Validate(Base()).IsValid.Should().BeTrue();
+    }
+
+    [Theory(DisplayName = "Versão do dataset ausente ou em branco é rejeitada")]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void VersaoDatasetVazia_Rejeita(string versaoDataset)
+    {
+        ValidationResult resultado = _validator.Validate(Base() with { VersaoDataset = versaoDataset });
+
+        resultado.IsValid.Should().BeFalse();
+        resultado.Errors.Should().Contain(e => e.PropertyName == nameof(CriarCalendarioDiasUteisCommand.VersaoDataset));
+    }
+
+    [Fact(DisplayName = "Versão do dataset acima de 60 caracteres é rejeitada")]
+    public void VersaoDatasetMuitoLonga_Rejeita()
+    {
+        ValidationResult resultado = _validator.Validate(Base() with { VersaoDataset = new string('A', 61) });
+
+        resultado.IsValid.Should().BeFalse();
+        resultado.Errors.Should().Contain(e => e.PropertyName == nameof(CriarCalendarioDiasUteisCommand.VersaoDataset));
+    }
+
+    [Fact(DisplayName = "Lista de dias não úteis vazia é rejeitada")]
+    public void DiasNaoUteisVazia_Rejeita()
+    {
+        ValidationResult resultado = _validator.Validate(Base() with { DiasNaoUteis = [] });
+
+        resultado.IsValid.Should().BeFalse();
+        resultado.Errors.Should().Contain(e => e.PropertyName == nameof(CriarCalendarioDiasUteisCommand.DiasNaoUteis));
+    }
+
+    [Fact(DisplayName = "Item com abrangência vazia é rejeitado")]
+    public void ItemComAbrangenciaVazia_Rejeita()
+    {
+        ValidationResult resultado = _validator.Validate(Base() with
+        {
+            DiasNaoUteis = [new DiaNaoUtilCommandItem("", null, new DateOnly(2027, 1, 1), "Descrição válida")],
+        });
+
+        resultado.IsValid.Should().BeFalse();
+        resultado.Errors.Should().Contain(e => e.PropertyName.EndsWith(
+            nameof(DiaNaoUtilCommandItem.Abrangencia), StringComparison.Ordinal));
+    }
+
+    [Fact(DisplayName = "Item com descrição vazia é rejeitado")]
+    public void ItemComDescricaoVazia_Rejeita()
+    {
+        ValidationResult resultado = _validator.Validate(Base() with
+        {
+            DiasNaoUteis = [new DiaNaoUtilCommandItem("NACIONAL", null, new DateOnly(2027, 1, 1), "")],
+        });
+
+        resultado.IsValid.Should().BeFalse();
+        resultado.Errors.Should().Contain(e => e.PropertyName.EndsWith(
+            nameof(DiaNaoUtilCommandItem.Descricao), StringComparison.Ordinal));
+    }
+
+    [Fact(DisplayName = "Item com descrição acima de 200 caracteres é rejeitado")]
+    public void ItemComDescricaoMuitoLonga_Rejeita()
+    {
+        ValidationResult resultado = _validator.Validate(Base() with
+        {
+            DiasNaoUteis = [new DiaNaoUtilCommandItem("NACIONAL", null, new DateOnly(2027, 1, 1), new string('A', 201))],
+        });
+
+        resultado.IsValid.Should().BeFalse();
+        resultado.Errors.Should().Contain(e => e.PropertyName.EndsWith(
+            nameof(DiaNaoUtilCommandItem.Descricao), StringComparison.Ordinal));
+    }
+}

--- a/tests/Unifesspa.UniPlus.Configuracao.Application.UnitTests/Validators/CriarCalendarioDiasUteisCommandValidatorTests.cs
+++ b/tests/Unifesspa.UniPlus.Configuracao.Application.UnitTests/Validators/CriarCalendarioDiasUteisCommandValidatorTests.cs
@@ -50,6 +50,19 @@ public sealed class CriarCalendarioDiasUteisCommandValidatorTests
         resultado.Errors.Should().Contain(e => e.PropertyName == nameof(CriarCalendarioDiasUteisCommand.DiasNaoUteis));
     }
 
+    [Fact(DisplayName = "Item nulo na lista de dias não úteis é rejeitado")]
+    public void ItemNulo_Rejeita()
+    {
+        ValidationResult resultado = _validator.Validate(Base() with
+        {
+            DiasNaoUteis = [new DiaNaoUtilCommandItem("NACIONAL", null, new DateOnly(2027, 1, 1), "Válido"), null!],
+        });
+
+        resultado.IsValid.Should().BeFalse();
+        resultado.Errors.Should().Contain(e => e.PropertyName.StartsWith(
+            nameof(CriarCalendarioDiasUteisCommand.DiasNaoUteis), StringComparison.Ordinal));
+    }
+
     [Fact(DisplayName = "Item com abrangência vazia é rejeitado")]
     public void ItemComAbrangenciaVazia_Rejeita()
     {

--- a/tests/Unifesspa.UniPlus.Configuracao.Application.UnitTests/packages.lock.json
+++ b/tests/Unifesspa.UniPlus.Configuracao.Application.UnitTests/packages.lock.json
@@ -14,6 +14,18 @@
         "resolved": "8.0.1",
         "contentHash": "heVQl5tKYnnIDYlR1QMVGueYH6iriZTcZB6AjDczQNwZzxkjDIt9C84Pt4cCiZYrbo7jkZOYGWbs6Lo9wAtVLg=="
       },
+      "Microsoft.EntityFrameworkCore": {
+        "type": "Direct",
+        "requested": "[10.0.10, )",
+        "resolved": "10.0.10",
+        "contentHash": "a0V7zj/VbYP6dTdWpUgE/r2PuLKtUGe2aJ0lVKkn/wP9ZhaxUz2kQydVfvOjCv2SKxlrqdBfHhPD4Cvlf+4ffA==",
+        "dependencies": {
+          "Microsoft.EntityFrameworkCore.Abstractions": "10.0.10",
+          "Microsoft.EntityFrameworkCore.Analyzers": "10.0.10",
+          "Microsoft.Extensions.Caching.Memory": "10.0.10",
+          "Microsoft.Extensions.Logging": "10.0.10"
+        }
+      },
       "Microsoft.NET.Test.Sdk": {
         "type": "Direct",
         "requested": "[18.8.1, )",
@@ -22,6 +34,15 @@
         "dependencies": {
           "Microsoft.CodeCoverage": "18.8.1",
           "Microsoft.TestPlatform.TestHost": "18.8.1"
+        }
+      },
+      "Npgsql": {
+        "type": "Direct",
+        "requested": "[10.0.3, )",
+        "resolved": "10.0.3",
+        "contentHash": "7nb5YzXuvWWJxB0J8DiyL3we+X4FOctZrt0fIBnucOIaIevFEEwGQVZKtiu9olXdlNAK1eNgqSral6r/jlhI4w==",
+        "dependencies": {
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.0"
         }
       },
       "NSubstitute": {
@@ -239,24 +260,34 @@
         "resolved": "18.8.1",
         "contentHash": "Eclse/ZZjr4lmWzZFNN9h/OluhKL+SK/QbUyKUewgX139aGeyMEO/DkMPwuFs2MixvanTnz6891rF8UHDg+W4Q=="
       },
+      "Microsoft.EntityFrameworkCore.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.10",
+        "contentHash": "bOzrFCl6uZCjaSh2bG1ToRQRdx+iXvxosCg9hFyG9OWeAzOFI4xev9OqKeWfKf/kAHyox2JnbcvLVf2ceA7sqA=="
+      },
+      "Microsoft.EntityFrameworkCore.Analyzers": {
+        "type": "Transitive",
+        "resolved": "10.0.10",
+        "contentHash": "2gLDordUCGf3aNOOuqtTbP5mxhiP9nk6TnvGiE3RnqT891O+Zf/qKu1PIREubs1M16A0SImr4vULBfU5BTDs1Q=="
+      },
       "Microsoft.Extensions.Caching.Abstractions": {
         "type": "Transitive",
-        "resolved": "10.0.0",
-        "contentHash": "Zcoy6H9mSoGyvr7UvlGokEZrlZkcPCICPZr8mCsSt9U/N8eeCwCXwKF5bShdA66R0obxBCwP4AxomQHvVkC/uA==",
+        "resolved": "10.0.10",
+        "contentHash": "4ZFBNE+jzR+CrWWlhOesnmywCW7pYKT0dxyAQRdL11yJwxe4jvcAu31eorFtEkoFeCDcUTeNssgPv2yaRRptaQ==",
         "dependencies": {
-          "Microsoft.Extensions.Primitives": "10.0.0"
+          "Microsoft.Extensions.Primitives": "10.0.10"
         }
       },
       "Microsoft.Extensions.Caching.Memory": {
         "type": "Transitive",
-        "resolved": "10.0.0",
-        "contentHash": "krK19MKp0BNiR9rpBDW7PKSrTMLVlifS9am3CVc4O1Jq6GWz0o4F+sw5OSL4L3mVd56W8l6JRgghUa2KB51vOw==",
+        "resolved": "10.0.10",
+        "contentHash": "N1w5H7uK6gCTnCBZAWzE0/EQYSPysij/uYwDqntqBVvBa6bjMmBKitsnEFd6yh/SX3wLm67nO6+OnZ84K+gZWg==",
         "dependencies": {
-          "Microsoft.Extensions.Caching.Abstractions": "10.0.0",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.0",
-          "Microsoft.Extensions.Logging.Abstractions": "10.0.0",
-          "Microsoft.Extensions.Options": "10.0.0",
-          "Microsoft.Extensions.Primitives": "10.0.0"
+          "Microsoft.Extensions.Caching.Abstractions": "10.0.10",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.10",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.10",
+          "Microsoft.Extensions.Options": "10.0.10",
+          "Microsoft.Extensions.Primitives": "10.0.10"
         }
       },
       "Microsoft.Extensions.Configuration": {
@@ -339,16 +370,16 @@
       },
       "Microsoft.Extensions.DependencyInjection": {
         "type": "Transitive",
-        "resolved": "10.0.0",
-        "contentHash": "f0RBabswJq+gRu5a+hWIobrLWiUYPKMhCD9WO3sYBAdSy3FFH14LMvLVFZc2kPSCimBLxSuitUhsd6tb0TAY6A==",
+        "resolved": "10.0.10",
+        "contentHash": "ANyvsgkNBRvcJh2XLgn8veGmajf+8m0AbKK+HPWdRL1yraSNVVSmQhFntLtdz/C795jxqqup+k05cs/3jZQPOA==",
         "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.0"
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.10"
         }
       },
       "Microsoft.Extensions.DependencyInjection.Abstractions": {
         "type": "Transitive",
-        "resolved": "10.0.7",
-        "contentHash": "Z6mfFEaFcwCfSboxJwOLfu7/31npCY9q70WUamHW/vRQhDvBKOT4Vf9YkZj5J6hLvJpb0oDEYfHunQZj0xxvKw=="
+        "resolved": "10.0.10",
+        "contentHash": "z/2xXlFw2aLGjHyEm6E0tQ+In6VfzQzTrtArbQ2c0TQE16ZbyDCMGPvaUT9I0s8rgy9sRWlU2P9waW37qV04qA=="
       },
       "Microsoft.Extensions.Diagnostics": {
         "type": "Transitive",
@@ -440,12 +471,12 @@
       },
       "Microsoft.Extensions.Logging": {
         "type": "Transitive",
-        "resolved": "10.0.0",
-        "contentHash": "BStFkd5CcnEtarlcgYDBcFzGYCuuNMzPs02wN3WBsOFoYIEmYoUdAiU+au6opzoqfTYJsMTW00AeqDdnXH2CvA==",
+        "resolved": "10.0.10",
+        "contentHash": "Tf6z5HsL0VDYRTfvsoNrTGHGheCwkTsZBA2FFh5ATJUbkAwug+FFNISJK2gjpUNemlAOoWllAK52HOWCjto3EQ==",
         "dependencies": {
-          "Microsoft.Extensions.DependencyInjection": "10.0.0",
-          "Microsoft.Extensions.Logging.Abstractions": "10.0.0",
-          "Microsoft.Extensions.Options": "10.0.0"
+          "Microsoft.Extensions.DependencyInjection": "10.0.10",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.10",
+          "Microsoft.Extensions.Options": "10.0.10"
         }
       },
       "Microsoft.Extensions.Logging.Configuration": {
@@ -516,11 +547,11 @@
       },
       "Microsoft.Extensions.Options": {
         "type": "Transitive",
-        "resolved": "10.0.0",
-        "contentHash": "8oCAgXOow5XDrY9HaXX1QmH3ORsyZO/ANVHBlhLyCeWTH5Sg4UuqZeOTWJi6484M+LqSx0RqQXDJtdYy2BNiLQ==",
+        "resolved": "10.0.10",
+        "contentHash": "srnhnk7nE8krBiIXp71LvBmKBtraBONWSRzdjJgRv1Ko9Mp8IVNqv4vIS9hGeVteBig8aQkva9ZG+sC+o5sVcA==",
         "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.0",
-          "Microsoft.Extensions.Primitives": "10.0.0"
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.10",
+          "Microsoft.Extensions.Primitives": "10.0.10"
         }
       },
       "Microsoft.Extensions.Options.ConfigurationExtensions": {
@@ -537,8 +568,8 @@
       },
       "Microsoft.Extensions.Primitives": {
         "type": "Transitive",
-        "resolved": "10.0.0",
-        "contentHash": "inRnbpCS0nwO/RuoZIAqxQUuyjaknOOnCEZB55KSMMjRhl0RQDttSmLSGsUJN3RQ3ocf5NDLFd2mOQViHqMK5w=="
+        "resolved": "10.0.10",
+        "contentHash": "5wu/GrYVd8mG2DVUw3vFJzF+O336TyTGg/Kmcgw9bfwYhCoFiV5lR5QeEmKecJyrW4W54nMfD3p3589E8a7czQ=="
       },
       "Microsoft.TestPlatform.ObjectModel": {
         "type": "Transitive",
@@ -738,10 +769,10 @@
       "Microsoft.Extensions.Logging.Abstractions": {
         "type": "CentralTransitive",
         "requested": "[10.0.7, )",
-        "resolved": "10.0.7",
-        "contentHash": "tIEcQ2gvERrH2KiCjdsVcHGhXt9lIsuDStfOIeZWr7/fP8IXhGiYfx0/80PNI7WPO2IYuFtlZLSlnTS8+/Mchw==",
+        "resolved": "10.0.10",
+        "contentHash": "zkFxGYUvdxAvIKTyXHrmW+Sux53D4SezD9dMyZ6hrwwzPQJNuwCRy1f5W7AvYTqacEGhWF2XderRQG1OvbV8og==",
         "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7"
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.10"
         }
       },
       "WolverineFx": {

--- a/tests/Unifesspa.UniPlus.Configuracao.Domain.UnitTests/Entities/CalendarioDiasUteisTests.cs
+++ b/tests/Unifesspa.UniPlus.Configuracao.Domain.UnitTests/Entities/CalendarioDiasUteisTests.cs
@@ -14,8 +14,8 @@ public sealed class CalendarioDiasUteisTests
     private static DiaNaoUtilCriacao Nacional(DateOnly? data = null) =>
         new("NACIONAL", null, data ?? DataBase, "Confraternização Universal");
 
-    private static DiaNaoUtilCriacao Estadual(DateOnly? data = null) =>
-        new("ESTADUAL", null, data ?? DataBase.AddDays(1), "Data magna do estado");
+    private static DiaNaoUtilCriacao Estadual(DateOnly? data = null, string uf = "PA") =>
+        new("ESTADUAL", null, data ?? DataBase.AddDays(1), "Data magna do estado", uf);
 
     private static DiaNaoUtilCriacao Municipal(DateOnly? data = null, string municipioIbge = "1501402") =>
         new("MUNICIPAL", municipioIbge, data ?? DataBase.AddDays(2), "Aniversário do município");
@@ -60,6 +60,16 @@ public sealed class CalendarioDiasUteisTests
             && d.MunicipioIbge == "1501402"
             && d.Data == DataBase.AddDays(2)
             && d.Descricao == "Aniversário do município");
+    }
+
+    [Fact(DisplayName = "Criar apara o código IBGE e persiste o valor normalizado, não o cru")]
+    public void Criar_MunicipioIbgeComEspacos_PersisteAparado()
+    {
+        Result<CalendarioDiasUteis> resultado = CalendarioDiasUteis.Criar(
+            "2027.1", [new DiaNaoUtilCriacao("MUNICIPAL", " 1501402 ", DataBase, "Aniversário do município")]);
+
+        resultado.IsSuccess.Should().BeTrue();
+        resultado.Value!.DiasNaoUteis.Should().Contain(d => d.MunicipioIbge == "1501402");
     }
 
     [Theory(DisplayName = "Criar com versão do dataset ausente ou em branco falha")]
@@ -122,6 +132,65 @@ public sealed class CalendarioDiasUteisTests
 
         resultado.IsFailure.Should().BeTrue();
         resultado.Error!.Code.Should().Be(CalendarioDiasUteisErrorCodes.MunicipioIbgeApenasParaMunicipal);
+    }
+
+    [Fact(DisplayName = "Criar com abrangência estadual sem UF falha")]
+    public void Criar_EstadualSemUf_Falha()
+    {
+        Result<CalendarioDiasUteis> resultado = CalendarioDiasUteis.Criar(
+            "2027.1", [new DiaNaoUtilCriacao("ESTADUAL", null, DataBase, "Data magna do estado")]);
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be(CalendarioDiasUteisErrorCodes.UfObrigatoriaParaEstadual);
+    }
+
+    [Theory(DisplayName = "Criar com UF em formato inválido falha")]
+    [InlineData("P")]
+    [InlineData("PAR")]
+    [InlineData("P1")]
+    public void Criar_UfFormatoInvalido_Falha(string uf)
+    {
+        Result<CalendarioDiasUteis> resultado = CalendarioDiasUteis.Criar(
+            "2027.1", [new DiaNaoUtilCriacao("ESTADUAL", null, DataBase, "Data magna do estado", uf)]);
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be(CalendarioDiasUteisErrorCodes.UfFormatoInvalido);
+    }
+
+    [Theory(DisplayName = "Criar com UF fora da abrangência estadual falha")]
+    [InlineData("NACIONAL")]
+    [InlineData("INSTITUCIONAL")]
+    public void Criar_UfForaDeEstadual_Falha(string abrangencia)
+    {
+        Result<CalendarioDiasUteis> resultado = CalendarioDiasUteis.Criar(
+            "2027.1", [new DiaNaoUtilCriacao(abrangencia, null, DataBase, "Dia qualquer", "PA")]);
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be(CalendarioDiasUteisErrorCodes.UfApenasParaEstadual);
+    }
+
+    [Fact(DisplayName = "Criar com UF em minúsculas é normalizada para maiúsculas")]
+    public void Criar_UfMinuscula_Normaliza()
+    {
+        Result<CalendarioDiasUteis> resultado = CalendarioDiasUteis.Criar(
+            "2027.1", [new DiaNaoUtilCriacao("ESTADUAL", null, DataBase, "Data magna do estado", "pa")]);
+
+        resultado.IsSuccess.Should().BeTrue();
+        resultado.Value!.DiasNaoUteis.Should().Contain(d => d.Uf == "PA");
+    }
+
+    [Fact(DisplayName = "Criar com mesma data e UFs diferentes não é duplicata")]
+    public void Criar_MesmaDataUfsDiferentes_NaoEDuplicata()
+    {
+        Result<CalendarioDiasUteis> resultado = CalendarioDiasUteis.Criar(
+            "2027.1",
+            [
+                new DiaNaoUtilCriacao("ESTADUAL", null, DataBase, "Feriado do Pará", "PA"),
+                new DiaNaoUtilCriacao("ESTADUAL", null, DataBase, "Feriado de São Paulo", "SP"),
+            ]);
+
+        resultado.IsSuccess.Should().BeTrue();
+        resultado.Value!.DiasNaoUteis.Should().HaveCount(2);
     }
 
     [Theory(DisplayName = "Criar com descrição ausente ou em branco falha")]
@@ -190,7 +259,7 @@ public sealed class CalendarioDiasUteisTests
             "2027.1",
             [
                 new DiaNaoUtilCriacao("NACIONAL", null, DataBase, "Feriado nacional"),
-                new DiaNaoUtilCriacao("ESTADUAL", null, DataBase, "Feriado estadual"),
+                new DiaNaoUtilCriacao("ESTADUAL", null, DataBase, "Feriado estadual", "PA"),
             ]);
 
         resultado.IsSuccess.Should().BeTrue();

--- a/tests/Unifesspa.UniPlus.Configuracao.Domain.UnitTests/Entities/CalendarioDiasUteisTests.cs
+++ b/tests/Unifesspa.UniPlus.Configuracao.Domain.UnitTests/Entities/CalendarioDiasUteisTests.cs
@@ -146,6 +146,29 @@ public sealed class CalendarioDiasUteisTests
         resultado.Error!.Code.Should().Be(CalendarioDiasUteisErrorCodes.DescricaoTamanho);
     }
 
+    [Theory(DisplayName = "Criar com código IBGE do município em formato inválido falha")]
+    [InlineData("123456")]
+    [InlineData("123456789")]
+    [InlineData("150140A")]
+    public void Criar_MunicipioIbgeFormatoInvalido_Falha(string municipioIbge)
+    {
+        Result<CalendarioDiasUteis> resultado = CalendarioDiasUteis.Criar(
+            "2027.1", [Municipal(municipioIbge: municipioIbge)]);
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be(CalendarioDiasUteisErrorCodes.MunicipioIbgeFormatoInvalido);
+    }
+
+    [Fact(DisplayName = "Criar com item de dia não útil nulo na lista falha")]
+    public void Criar_DiaNaoUtilNulo_Falha()
+    {
+        Result<CalendarioDiasUteis> resultado = CalendarioDiasUteis.Criar(
+            "2027.1", [Nacional(), null!]);
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be(CalendarioDiasUteisErrorCodes.DiaNaoUtilNulo);
+    }
+
     [Fact(DisplayName = "Criar com mesma data, abrangência e município duplicados falha")]
     public void Criar_DataDuplicadaMesmaAbrangenciaEMunicipio_Falha()
     {

--- a/tests/Unifesspa.UniPlus.Configuracao.Domain.UnitTests/Entities/CalendarioDiasUteisTests.cs
+++ b/tests/Unifesspa.UniPlus.Configuracao.Domain.UnitTests/Entities/CalendarioDiasUteisTests.cs
@@ -148,6 +148,7 @@ public sealed class CalendarioDiasUteisTests
     [InlineData("P")]
     [InlineData("PAR")]
     [InlineData("P1")]
+    [InlineData("ZZ")]
     public void Criar_UfFormatoInvalido_Falha(string uf)
     {
         Result<CalendarioDiasUteis> resultado = CalendarioDiasUteis.Criar(
@@ -219,6 +220,7 @@ public sealed class CalendarioDiasUteisTests
     [InlineData("123456")]
     [InlineData("123456789")]
     [InlineData("150140A")]
+    [InlineData("0000000")]
     public void Criar_MunicipioIbgeFormatoInvalido_Falha(string municipioIbge)
     {
         Result<CalendarioDiasUteis> resultado = CalendarioDiasUteis.Criar(

--- a/tests/Unifesspa.UniPlus.Configuracao.Domain.UnitTests/Entities/CalendarioDiasUteisTests.cs
+++ b/tests/Unifesspa.UniPlus.Configuracao.Domain.UnitTests/Entities/CalendarioDiasUteisTests.cs
@@ -1,0 +1,227 @@
+namespace Unifesspa.UniPlus.Configuracao.Domain.UnitTests.Entities;
+
+using AwesomeAssertions;
+
+using Unifesspa.UniPlus.Configuracao.Domain.Entities;
+using Unifesspa.UniPlus.Configuracao.Domain.Enums;
+using Unifesspa.UniPlus.Configuracao.Domain.Errors;
+using Unifesspa.UniPlus.Kernel.Results;
+
+public sealed class CalendarioDiasUteisTests
+{
+    private static readonly DateOnly DataBase = new(2027, 1, 1);
+
+    private static DiaNaoUtilCriacao Nacional(DateOnly? data = null) =>
+        new("NACIONAL", null, data ?? DataBase, "Confraternização Universal");
+
+    private static DiaNaoUtilCriacao Estadual(DateOnly? data = null) =>
+        new("ESTADUAL", null, data ?? DataBase.AddDays(1), "Data magna do estado");
+
+    private static DiaNaoUtilCriacao Municipal(DateOnly? data = null, string municipioIbge = "1501402") =>
+        new("MUNICIPAL", municipioIbge, data ?? DataBase.AddDays(2), "Aniversário do município");
+
+    private static DiaNaoUtilCriacao Institucional(DateOnly? data = null) =>
+        new("INSTITUCIONAL", null, data ?? DataBase.AddDays(3), "Recesso da Unifesspa");
+
+    // ── Criar ──────────────────────────────────────────────────────────
+
+    [Fact(DisplayName = "Criar com dados válidos e abrangências variadas nasce não vigente")]
+    public void Criar_DadosValidos_NasceNaoVigente()
+    {
+        Result<CalendarioDiasUteis> resultado = CalendarioDiasUteis.Criar(
+            "2027.1", [Nacional(), Estadual(), Municipal(), Institucional()]);
+
+        resultado.IsSuccess.Should().BeTrue();
+        CalendarioDiasUteis calendario = resultado.Value!;
+        calendario.Id.Should().NotBe(Guid.Empty);
+        calendario.VersaoDataset.Should().Be("2027.1");
+        calendario.Vigente.Should().BeFalse();
+        calendario.IsDeleted.Should().BeFalse();
+    }
+
+    [Fact(DisplayName = "Criar preenche DiasNaoUteis com a contagem e os campos esperados")]
+    public void Criar_DadosValidos_PreencheDiasNaoUteis()
+    {
+        Result<CalendarioDiasUteis> resultado = CalendarioDiasUteis.Criar(
+            "2027.1", [Nacional(), Municipal()]);
+
+        resultado.IsSuccess.Should().BeTrue();
+        CalendarioDiasUteis calendario = resultado.Value!;
+        calendario.DiasNaoUteis.Should().HaveCount(2);
+
+        calendario.DiasNaoUteis.Should().Contain(d =>
+            d.Abrangencia == Abrangencia.Nacional
+            && d.MunicipioIbge == null
+            && d.Data == DataBase
+            && d.Descricao == "Confraternização Universal");
+
+        calendario.DiasNaoUteis.Should().Contain(d =>
+            d.Abrangencia == Abrangencia.Municipal
+            && d.MunicipioIbge == "1501402"
+            && d.Data == DataBase.AddDays(2)
+            && d.Descricao == "Aniversário do município");
+    }
+
+    [Theory(DisplayName = "Criar com versão do dataset ausente ou em branco falha")]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void Criar_VersaoDatasetVazia_Falha(string versaoDataset)
+    {
+        Result<CalendarioDiasUteis> resultado = CalendarioDiasUteis.Criar(versaoDataset, [Nacional()]);
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be(CalendarioDiasUteisErrorCodes.VersaoDatasetObrigatoria);
+    }
+
+    [Fact(DisplayName = "Criar com versão do dataset acima de 60 caracteres falha")]
+    public void Criar_VersaoDatasetMuitoLonga_Falha()
+    {
+        Result<CalendarioDiasUteis> resultado = CalendarioDiasUteis.Criar(new string('A', 61), [Nacional()]);
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be(CalendarioDiasUteisErrorCodes.VersaoDatasetTamanho);
+    }
+
+    [Fact(DisplayName = "Criar sem nenhum dia não útil falha")]
+    public void Criar_SemDiaNaoUtil_Falha()
+    {
+        Result<CalendarioDiasUteis> resultado = CalendarioDiasUteis.Criar("2027.1", []);
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be(CalendarioDiasUteisErrorCodes.SemDiaNaoUtil);
+    }
+
+    [Fact(DisplayName = "Criar com token de abrangência fora do domínio fechado falha")]
+    public void Criar_AbrangenciaInvalida_Falha()
+    {
+        Result<CalendarioDiasUteis> resultado = CalendarioDiasUteis.Criar(
+            "2027.1", [new DiaNaoUtilCriacao("INVALIDO", null, DataBase, "Dia qualquer")]);
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be(CalendarioDiasUteisErrorCodes.AbrangenciaInvalida);
+    }
+
+    [Fact(DisplayName = "Criar com abrangência municipal sem código IBGE do município falha")]
+    public void Criar_MunicipalSemMunicipioIbge_Falha()
+    {
+        Result<CalendarioDiasUteis> resultado = CalendarioDiasUteis.Criar(
+            "2027.1", [new DiaNaoUtilCriacao("MUNICIPAL", null, DataBase, "Aniversário do município")]);
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be(CalendarioDiasUteisErrorCodes.MunicipioIbgeObrigatorioParaMunicipal);
+    }
+
+    [Theory(DisplayName = "Criar com município IBGE fora da abrangência municipal falha")]
+    [InlineData("NACIONAL")]
+    [InlineData("ESTADUAL")]
+    [InlineData("INSTITUCIONAL")]
+    public void Criar_MunicipioIbgeForaDeMunicipal_Falha(string abrangencia)
+    {
+        Result<CalendarioDiasUteis> resultado = CalendarioDiasUteis.Criar(
+            "2027.1", [new DiaNaoUtilCriacao(abrangencia, "1501402", DataBase, "Dia qualquer")]);
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be(CalendarioDiasUteisErrorCodes.MunicipioIbgeApenasParaMunicipal);
+    }
+
+    [Theory(DisplayName = "Criar com descrição ausente ou em branco falha")]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void Criar_DescricaoVazia_Falha(string descricao)
+    {
+        Result<CalendarioDiasUteis> resultado = CalendarioDiasUteis.Criar(
+            "2027.1", [new DiaNaoUtilCriacao("NACIONAL", null, DataBase, descricao)]);
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be(CalendarioDiasUteisErrorCodes.DescricaoObrigatoria);
+    }
+
+    [Fact(DisplayName = "Criar com descrição acima de 200 caracteres falha")]
+    public void Criar_DescricaoMuitoLonga_Falha()
+    {
+        Result<CalendarioDiasUteis> resultado = CalendarioDiasUteis.Criar(
+            "2027.1", [new DiaNaoUtilCriacao("NACIONAL", null, DataBase, new string('A', 201))]);
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be(CalendarioDiasUteisErrorCodes.DescricaoTamanho);
+    }
+
+    [Fact(DisplayName = "Criar com mesma data, abrangência e município duplicados falha")]
+    public void Criar_DataDuplicadaMesmaAbrangenciaEMunicipio_Falha()
+    {
+        Result<CalendarioDiasUteis> resultado = CalendarioDiasUteis.Criar(
+            "2027.1",
+            [
+                new DiaNaoUtilCriacao("MUNICIPAL", "1501402", DataBase, "Aniversário do município"),
+                new DiaNaoUtilCriacao("MUNICIPAL", "1501402", DataBase, "Duplicata"),
+            ]);
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be(CalendarioDiasUteisErrorCodes.DataDuplicadaNoDataset);
+    }
+
+    [Fact(DisplayName = "Criar com mesma data e abrangências diferentes não é duplicata")]
+    public void Criar_MesmaDataAbrangenciasDiferentes_NaoEDuplicata()
+    {
+        Result<CalendarioDiasUteis> resultado = CalendarioDiasUteis.Criar(
+            "2027.1",
+            [
+                new DiaNaoUtilCriacao("NACIONAL", null, DataBase, "Feriado nacional"),
+                new DiaNaoUtilCriacao("ESTADUAL", null, DataBase, "Feriado estadual"),
+            ]);
+
+        resultado.IsSuccess.Should().BeTrue();
+        resultado.Value!.DiasNaoUteis.Should().HaveCount(2);
+    }
+
+    [Fact(DisplayName = "Criar com mesma data e municípios diferentes não é duplicata")]
+    public void Criar_MesmaDataMunicipiosDiferentes_NaoEDuplicata()
+    {
+        Result<CalendarioDiasUteis> resultado = CalendarioDiasUteis.Criar(
+            "2027.1",
+            [
+                new DiaNaoUtilCriacao("MUNICIPAL", "1501402", DataBase, "Aniversário de Marabá"),
+                new DiaNaoUtilCriacao("MUNICIPAL", "1500107", DataBase, "Aniversário de Abaetetuba"),
+            ]);
+
+        resultado.IsSuccess.Should().BeTrue();
+        resultado.Value!.DiasNaoUteis.Should().HaveCount(2);
+    }
+
+    // ── MarcarVigente / MarcarNaoVigente ──────────────────────────────
+
+    [Fact(DisplayName = "MarcarVigente em dataset recém-criado tem sucesso")]
+    public void MarcarVigente_DatasetRecemCriado_Sucesso()
+    {
+        CalendarioDiasUteis calendario = CalendarioDiasUteis.Criar("2027.1", [Nacional()]).Value!;
+
+        Result resultado = calendario.MarcarVigente();
+
+        resultado.IsSuccess.Should().BeTrue();
+        calendario.Vigente.Should().BeTrue();
+    }
+
+    [Fact(DisplayName = "MarcarVigente chamado duas vezes falha na segunda chamada (JaVigente)")]
+    public void MarcarVigente_ChamadoDuasVezes_FalhaNaSegunda()
+    {
+        CalendarioDiasUteis calendario = CalendarioDiasUteis.Criar("2027.1", [Nacional()]).Value!;
+        calendario.MarcarVigente();
+
+        Result resultado = calendario.MarcarVigente();
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be(CalendarioDiasUteisErrorCodes.JaVigente);
+        calendario.Vigente.Should().BeTrue();
+    }
+
+    [Fact(DisplayName = "MarcarNaoVigente volta Vigente para false")]
+    public void MarcarNaoVigente_VoltaParaFalse()
+    {
+        CalendarioDiasUteis calendario = CalendarioDiasUteis.Criar("2027.1", [Nacional()]).Value!;
+        calendario.MarcarVigente();
+
+        calendario.MarcarNaoVigente();
+
+        calendario.Vigente.Should().BeFalse();
+    }
+}

--- a/tests/Unifesspa.UniPlus.Configuracao.IntegrationTests/CalendariosDiasUteis/CalendarioDiasUteisEndpointTests.cs
+++ b/tests/Unifesspa.UniPlus.Configuracao.IntegrationTests/CalendariosDiasUteis/CalendarioDiasUteisEndpointTests.cs
@@ -1,0 +1,233 @@
+namespace Unifesspa.UniPlus.Configuracao.IntegrationTests.CalendariosDiasUteis;
+
+using System.Diagnostics.CodeAnalysis;
+using System.Net;
+using System.Net.Http.Json;
+using System.Text;
+using System.Text.Json;
+
+using AwesomeAssertions;
+
+using Unifesspa.UniPlus.Configuracao.IntegrationTests.Infrastructure;
+using Unifesspa.UniPlus.IntegrationTests.Fixtures.Authentication;
+
+/// <summary>
+/// Smoke + caminho de escrita dos endpoints de <c>CalendarioDiasUteis</c>
+/// (UNI-REQ-0080): routing, vendor media type, HATEOAS, autenticação/autorização,
+/// idempotência, invariante de vigência única e bloqueio de remoção do dataset
+/// vigente, com Wolverine rodando contra Postgres efêmero.
+/// </summary>
+[Collection(ConfiguracaoEndpointCollection.Name)]
+[SuppressMessage(
+    "Performance",
+    "CA1515:Consider making public types internal",
+    Justification = "xUnit collection fixture exige tipo de teste público.")]
+public sealed class CalendarioDiasUteisEndpointTests
+{
+    private const string VendorMime = "application/vnd.uniplus.calendario-dias-uteis.v1+json";
+    private const string ColecaoPath = "/api/configuracao/calendarios-dias-uteis";
+    private const string AdminPath = "/api/configuracao/admin/calendarios-dias-uteis";
+
+    private readonly ConfiguracaoEndpointFixture _fixture;
+
+    public CalendarioDiasUteisEndpointTests(ConfiguracaoEndpointFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    [Fact(DisplayName = "GET coleção retorna 200 com Content-Type vendor MIME")]
+    public async Task Listar_Retorna200ComVendorMime()
+    {
+        using HttpClient client = _fixture.Factory.CreateClient();
+
+        HttpResponseMessage response = await client.GetAsync(new Uri(ColecaoPath, UriKind.Relative));
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        response.Content.Headers.ContentType?.MediaType.Should().Be(VendorMime);
+    }
+
+    [Fact(DisplayName = "GET por id retorna 404 quando inexistente")]
+    public async Task ObterPorId_NaoExiste_Retorna404()
+    {
+        using HttpClient client = _fixture.Factory.CreateClient();
+
+        HttpResponseMessage response = await client.GetAsync(
+            new Uri($"{ColecaoPath}/{Guid.NewGuid()}", UriKind.Relative));
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [Fact(DisplayName = "POST admin sem autenticação retorna 401")]
+    public async Task Criar_SemAuth_Retorna401()
+    {
+        using HttpClient client = _fixture.Factory.CreateDefaultClient();
+        using HttpRequestMessage request = new(HttpMethod.Post, new Uri(AdminPath, UriKind.Relative));
+        request.Headers.Add("Idempotency-Key", Guid.NewGuid().ToString());
+        request.Content = new StringContent("{}", Encoding.UTF8, "application/json");
+
+        HttpResponseMessage response = await client.SendAsync(request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+
+    [Fact(DisplayName = "POST admin autenticado sem role plataforma-admin retorna 403")]
+    public async Task Criar_SemRoleAdmin_Retorna403()
+    {
+        using HttpClient client = _fixture.Factory.CreateClient();
+        using HttpRequestMessage request = new(HttpMethod.Post, new Uri(AdminPath, UriKind.Relative));
+        request.Headers.Add("Authorization", $"{TestAuthHandler.AuthorizationScheme} {TestAuthHandler.TokenValue}");
+        request.Headers.Add(TestAuthHandler.RolesHeader, "candidato");
+        request.Headers.Add("Idempotency-Key", Guid.NewGuid().ToString());
+        request.Content = JsonContent.Create(CorpoValido());
+
+        HttpResponseMessage response = await client.SendAsync(request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+    }
+
+    [Fact(DisplayName = "POST admin cria (201 + Location) e o GET subsequente retorna os dias não úteis + _links")]
+    public async Task Criar_ComAuthEIdempotency_Retorna201EPersiste()
+    {
+        using HttpClient client = _fixture.Factory.CreateClient();
+        HttpResponseMessage criar = await EnviarPostAdmin(client, AdminPath, CorpoValido(VersaoUnica()));
+
+        criar.StatusCode.Should().Be(HttpStatusCode.Created);
+        criar.Headers.Location.Should().NotBeNull();
+        Guid id = await criar.Content.ReadFromJsonAsync<Guid>();
+        id.Should().NotBe(Guid.Empty);
+
+        HttpResponseMessage obter = await client.GetAsync(new Uri($"{ColecaoPath}/{id}", UriKind.Relative));
+        obter.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        using JsonDocument doc = JsonDocument.Parse(await obter.Content.ReadAsStringAsync());
+        JsonElement root = doc.RootElement;
+        root.GetProperty("vigente").GetBoolean().Should().BeFalse("todo dataset nasce não vigente");
+        JsonElement dias = root.GetProperty("diasNaoUteis");
+        dias.GetArrayLength().Should().Be(2);
+        dias.EnumerateArray().Should().Contain(d => d.GetProperty("abrangencia").GetString() == "NACIONAL");
+        dias.EnumerateArray().Should().Contain(d =>
+            d.GetProperty("abrangencia").GetString() == "MUNICIPAL"
+            && d.GetProperty("municipioIbge").GetString() == "1501402");
+        root.TryGetProperty("_links", out _).Should().BeTrue("HATEOAS Level 1 expõe _links.self (ADR-0029)");
+    }
+
+    [Fact(DisplayName = "GET coleção não inclui diasNaoUteis — a listagem projeta só o resumo")]
+    public async Task Listar_NaoIncluiDiasNaoUteis()
+    {
+        using HttpClient client = _fixture.Factory.CreateClient();
+        HttpResponseMessage criar = await EnviarPostAdmin(client, AdminPath, CorpoValido(VersaoUnica()));
+        criar.StatusCode.Should().Be(HttpStatusCode.Created);
+
+        HttpResponseMessage listar = await client.GetAsync(new Uri(ColecaoPath, UriKind.Relative));
+
+        listar.StatusCode.Should().Be(HttpStatusCode.OK);
+        using JsonDocument doc = JsonDocument.Parse(await listar.Content.ReadAsStringAsync());
+        JsonElement itens = doc.RootElement;
+        itens.GetArrayLength().Should().BeGreaterThan(0);
+        foreach (JsonElement item in itens.EnumerateArray())
+        {
+            item.TryGetProperty("diasNaoUteis", out _).Should().BeFalse(
+                "a listagem não carrega a coleção filha — use ObterPorId para o dataset completo");
+        }
+    }
+
+    [Fact(DisplayName = "POST .../{id}/vigente marca o novo vigente e desmarca o vigente anterior")]
+    public async Task MarcarVigente_DesmarcaOAnterior()
+    {
+        using HttpClient client = _fixture.Factory.CreateClient();
+
+        Guid primeiroId = await CriarDataset(client, VersaoUnica());
+        HttpResponseMessage marcarPrimeiro = await EnviarPostAdmin(
+            client, $"{AdminPath}/{primeiroId}/vigente", null);
+        marcarPrimeiro.StatusCode.Should().Be(HttpStatusCode.NoContent);
+
+        (await ObterVigente(client, primeiroId)).Should().BeTrue();
+
+        Guid segundoId = await CriarDataset(client, VersaoUnica());
+        HttpResponseMessage marcarSegundo = await EnviarPostAdmin(
+            client, $"{AdminPath}/{segundoId}/vigente", null);
+        marcarSegundo.StatusCode.Should().Be(HttpStatusCode.NoContent);
+
+        (await ObterVigente(client, segundoId)).Should().BeTrue();
+        (await ObterVigente(client, primeiroId)).Should().BeFalse("no máximo um dataset é vigente por vez");
+    }
+
+    [Fact(DisplayName = "DELETE em dataset vigente retorna 409 com o código de erro NaoRemoveVigente")]
+    public async Task Remover_DatasetVigente_Retorna409()
+    {
+        using HttpClient client = _fixture.Factory.CreateClient();
+        Guid id = await CriarDataset(client, VersaoUnica());
+        HttpResponseMessage marcarVigente = await EnviarPostAdmin(client, $"{AdminPath}/{id}/vigente", null);
+        marcarVigente.StatusCode.Should().Be(HttpStatusCode.NoContent);
+
+        HttpResponseMessage response = await EnviarDeleteAdmin(client, id);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Conflict);
+        (await LerCodigoDeErro(response)).Should().Be(
+            "uniplus.configuracao.calendario_dias_uteis.nao_remove_vigente");
+    }
+
+    [Fact(DisplayName = "DELETE em dataset não vigente retorna 204")]
+    public async Task Remover_DatasetNaoVigente_Retorna204()
+    {
+        using HttpClient client = _fixture.Factory.CreateClient();
+        Guid id = await CriarDataset(client, VersaoUnica());
+
+        HttpResponseMessage response = await EnviarDeleteAdmin(client, id);
+
+        response.StatusCode.Should().Be(HttpStatusCode.NoContent);
+    }
+
+    private static object CorpoValido(string? versaoDataset = null) => new
+    {
+        versaoDataset = versaoDataset ?? "2027.1",
+        diasNaoUteis = new object[]
+        {
+            new { abrangencia = "NACIONAL", municipioIbge = (string?)null, data = "2027-01-01", descricao = "Confraternização Universal" },
+            new { abrangencia = "MUNICIPAL", municipioIbge = "1501402", data = "2027-05-08", descricao = "Aniversário de Marabá" },
+        },
+    };
+
+    // Versão de até 60 chars, única por teste — não é chave natural, mas a
+    // unicidade evita confundir datasets entre testes que rodam na mesma coleção.
+    private static string VersaoUnica() => $"cal-{Guid.NewGuid():N}"[..20];
+
+    private static async Task<Guid> CriarDataset(HttpClient client, string versaoDataset)
+    {
+        HttpResponseMessage criar = await EnviarPostAdmin(client, AdminPath, CorpoValido(versaoDataset));
+        criar.StatusCode.Should().Be(HttpStatusCode.Created);
+        return await criar.Content.ReadFromJsonAsync<Guid>();
+    }
+
+    private static async Task<bool> ObterVigente(HttpClient client, Guid id)
+    {
+        HttpResponseMessage obter = await client.GetAsync(new Uri($"{ColecaoPath}/{id}", UriKind.Relative));
+        using JsonDocument doc = JsonDocument.Parse(await obter.Content.ReadAsStringAsync());
+        return doc.RootElement.GetProperty("vigente").GetBoolean();
+    }
+
+    private static async Task<string?> LerCodigoDeErro(HttpResponseMessage response)
+    {
+        using JsonDocument doc = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        return doc.RootElement.GetProperty("code").GetString();
+    }
+
+    private static async Task<HttpResponseMessage> EnviarPostAdmin(HttpClient client, string path, object? body)
+    {
+        using HttpRequestMessage request = new(HttpMethod.Post, new Uri(path, UriKind.Relative));
+        request.Headers.Add("Authorization", $"{TestAuthHandler.AuthorizationScheme} {TestAuthHandler.TokenValue}");
+        request.Headers.Add(TestAuthHandler.RolesHeader, "plataforma-admin");
+        request.Headers.Add("Idempotency-Key", Guid.NewGuid().ToString());
+        request.Content = JsonContent.Create(body);
+        return await client.SendAsync(request);
+    }
+
+    private static async Task<HttpResponseMessage> EnviarDeleteAdmin(HttpClient client, Guid id)
+    {
+        using HttpRequestMessage request = new(
+            HttpMethod.Delete, new Uri($"{AdminPath}/{id}", UriKind.Relative));
+        request.Headers.Add("Authorization", $"{TestAuthHandler.AuthorizationScheme} {TestAuthHandler.TokenValue}");
+        request.Headers.Add(TestAuthHandler.RolesHeader, "plataforma-admin");
+        return await client.SendAsync(request);
+    }
+}

--- a/tests/Unifesspa.UniPlus.Configuracao.IntegrationTests/CalendariosDiasUteis/CalendarioDiasUteisPersistenceTests.cs
+++ b/tests/Unifesspa.UniPlus.Configuracao.IntegrationTests/CalendariosDiasUteis/CalendarioDiasUteisPersistenceTests.cs
@@ -1,0 +1,164 @@
+namespace Unifesspa.UniPlus.Configuracao.IntegrationTests.CalendariosDiasUteis;
+
+using System.Diagnostics.CodeAnalysis;
+
+using AwesomeAssertions;
+
+using Microsoft.EntityFrameworkCore;
+
+using Unifesspa.UniPlus.Configuracao.Domain.Entities;
+using Unifesspa.UniPlus.Configuracao.Domain.Enums;
+using Unifesspa.UniPlus.Configuracao.Infrastructure.Persistence;
+using Unifesspa.UniPlus.Configuracao.IntegrationTests.Infrastructure;
+
+/// <summary>
+/// Integração ponta-a-ponta do calendário de dias úteis contra Postgres real
+/// (UNI-REQ-0080): persistência do dataset e dos dias não úteis (token de
+/// <c>Abrangencia</c> via <c>AbrangenciaValueConverter</c>), índice único
+/// parcial de vigência, CHECK de coerência de município e soft-delete
+/// preservando os dias não úteis filhos (<c>ClientNoAction</c>).
+/// </summary>
+[Collection(ConfiguracaoDbCollection.Name)]
+[SuppressMessage(
+    "Performance",
+    "CA1515:Consider making public types internal",
+    Justification = "xUnit collection fixture exige tipo de teste público.")]
+public sealed class CalendarioDiasUteisPersistenceTests
+{
+    private const string AdminA = "admin-a";
+    private const string AdminB = "admin-b";
+
+    private readonly ConfiguracaoDbFixture _fixture;
+
+    public CalendarioDiasUteisPersistenceTests(ConfiguracaoDbFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    [Fact(DisplayName = "Persistir com DiasNaoUteis e reler com Include devolve os dias corretos")]
+    public async Task Insert_PersisteDiasNaoUteisComTokenCorreto()
+    {
+        CalendarioDiasUteis calendario = Nova(
+            VersaoUnica(),
+            new DiaNaoUtilCriacao("NACIONAL", null, new DateOnly(2027, 1, 1), "Confraternização Universal"),
+            new DiaNaoUtilCriacao("MUNICIPAL", "1501402", new DateOnly(2027, 5, 8), "Aniversário de Marabá"));
+
+        await using (ConfiguracaoDbContext ctx = _fixture.CreateDbContext(AdminA))
+        {
+            ctx.CalendariosDiasUteis.Add(calendario);
+            await ctx.SaveChangesAsync();
+        }
+
+        await using ConfiguracaoDbContext readCtx = _fixture.CreateDbContext(userId: null);
+        CalendarioDiasUteis persistido = await readCtx.CalendariosDiasUteis
+            .Include(c => c.DiasNaoUteis)
+            .SingleAsync(c => c.Id == calendario.Id);
+
+        persistido.CreatedBy.Should().Be(AdminA);
+        persistido.Vigente.Should().BeFalse();
+        persistido.DiasNaoUteis.Should().HaveCount(2);
+        persistido.DiasNaoUteis.Should().Contain(d =>
+            d.Abrangencia == Abrangencia.Nacional && d.MunicipioIbge == null && d.Data == new DateOnly(2027, 1, 1));
+        persistido.DiasNaoUteis.Should().Contain(d =>
+            d.Abrangencia == Abrangencia.Municipal
+            && d.MunicipioIbge == "1501402"
+            && d.Data == new DateOnly(2027, 5, 8));
+    }
+
+    [Fact(DisplayName = "Exclusion constraint (vigente) rejeita um segundo dataset vigente")]
+    public async Task ExclusionConstraint_Vigente_RejeitaSegundoVigenteAtivo()
+    {
+        CalendarioDiasUteis primeiro = Nova(VersaoUnica());
+        primeiro.MarcarVigente();
+        await using (ConfiguracaoDbContext ctx = _fixture.CreateDbContext(AdminA))
+        {
+            ctx.CalendariosDiasUteis.Add(primeiro);
+            await ctx.SaveChangesAsync();
+        }
+
+        CalendarioDiasUteis segundo = Nova(VersaoUnica());
+        segundo.MarcarVigente();
+        await using ConfiguracaoDbContext ctx2 = _fixture.CreateDbContext(AdminA);
+        ctx2.CalendariosDiasUteis.Add(segundo);
+
+        Func<Task> act = async () => await ctx2.SaveChangesAsync();
+
+        // ex_calendario_dias_uteis_vigente_unico é DEFERRABLE INITIALLY DEFERRED
+        // (issue #1016 — SaveChangesAsync desmarca o vigente anterior e marca o novo
+        // na mesma transação; um índice não-deferível colidiria por-statement mesmo
+        // quando a transação termina num estado final válido). A checagem só roda no
+        // COMMIT, então a violação chega como PostgresException bruta do
+        // NpgsqlTransaction.Commit — não embrulhada em DbUpdateException, que o EF Core
+        // só produz para falhas durante a execução do batch de comandos.
+        Npgsql.PostgresException pg = (await act.Should().ThrowAsync<Npgsql.PostgresException>()).Which;
+        pg.SqlState.Should().Be("23P01");
+        pg.ConstraintName.Should().Be("ex_calendario_dias_uteis_vigente_unico");
+    }
+
+    [Fact(DisplayName = "CHECK de banco rejeita dia não útil municipal sem código IBGE via SQL cru")]
+    public async Task Check_RejeitaMunicipalSemMunicipioIbgeViaSqlCru()
+    {
+        CalendarioDiasUteis pai = Nova(VersaoUnica());
+        await using (ConfiguracaoDbContext ctx = _fixture.CreateDbContext(AdminA))
+        {
+            ctx.CalendariosDiasUteis.Add(pai);
+            await ctx.SaveChangesAsync();
+        }
+
+        await using ConfiguracaoDbContext ctx2 = _fixture.CreateDbContext(userId: null);
+
+        Func<Task> act = async () => await ctx2.Database.ExecuteSqlAsync(
+            $"""
+             INSERT INTO configuracao.dia_nao_util
+                 (id, calendario_dias_uteis_id, abrangencia, municipio_ibge, data, descricao, created_at)
+             VALUES
+                 ({Guid.CreateVersion7()}, {pai.Id}, {"MUNICIPAL"}, {(string?)null}, {new DateOnly(2027, 1, 1)}, {"Sem município"}, {DateTimeOffset.UtcNow})
+             """);
+
+        await act.Should().ThrowAsync<Npgsql.PostgresException>(
+            "o CHECK ck_dia_nao_util_municipio_coerente exige municipio_ibge quando abrangencia = MUNICIPAL");
+    }
+
+    [Fact(DisplayName = "Soft-delete de dataset não vigente preserva os dias não úteis filhos (ClientNoAction)")]
+    public async Task SoftDelete_PreservaDiasNaoUteisFilhos()
+    {
+        CalendarioDiasUteis calendario = Nova(
+            VersaoUnica(),
+            new DiaNaoUtilCriacao("NACIONAL", null, new DateOnly(2027, 1, 1), "Confraternização Universal"),
+            new DiaNaoUtilCriacao("INSTITUCIONAL", null, new DateOnly(2027, 12, 24), "Recesso da Unifesspa"));
+
+        await using (ConfiguracaoDbContext ctx = _fixture.CreateDbContext(AdminA))
+        {
+            ctx.CalendariosDiasUteis.Add(calendario);
+            await ctx.SaveChangesAsync();
+        }
+
+        await using (ConfiguracaoDbContext ctx = _fixture.CreateDbContext(AdminB))
+        {
+            CalendarioDiasUteis tracked = await ctx.CalendariosDiasUteis
+                .SingleAsync(c => c.Id == calendario.Id);
+            ctx.CalendariosDiasUteis.Remove(tracked);
+            await ctx.SaveChangesAsync();
+        }
+
+        await using ConfiguracaoDbContext readCtx = _fixture.CreateDbContext(userId: null);
+        CalendarioDiasUteis excluido = await readCtx.CalendariosDiasUteis
+            .IgnoreQueryFilters()
+            .Include(c => c.DiasNaoUteis)
+            .SingleAsync(c => c.Id == calendario.Id);
+
+        excluido.IsDeleted.Should().BeTrue();
+        excluido.DeletedBy.Should().Be(AdminB);
+        excluido.DiasNaoUteis.Should().HaveCount(2, "os dias não úteis não têm soft-delete próprio e permanecem sob a linha soft-deleted");
+    }
+
+    private static string VersaoUnica() => $"cal-{Guid.NewGuid():N}"[..20];
+
+    private static CalendarioDiasUteis Nova(string versaoDataset, params DiaNaoUtilCriacao[] dias)
+    {
+        DiaNaoUtilCriacao[] diasNaoUteis = dias.Length == 0
+            ? [new DiaNaoUtilCriacao("NACIONAL", null, new DateOnly(2027, 1, 1), "Confraternização Universal")]
+            : dias;
+        return CalendarioDiasUteis.Criar(versaoDataset, diasNaoUteis).Value!;
+    }
+}

--- a/tests/Unifesspa.UniPlus.Configuracao.IntegrationTests/CalendariosDiasUteis/CalendarioDiasUteisPersistenceTests.cs
+++ b/tests/Unifesspa.UniPlus.Configuracao.IntegrationTests/CalendariosDiasUteis/CalendarioDiasUteisPersistenceTests.cs
@@ -105,6 +105,49 @@ public sealed class CalendarioDiasUteisPersistenceTests
         await cleanupCtx.SaveChangesAsync();
     }
 
+    [Fact(DisplayName = "Sob transação ambiente, só ForcarChecagemImediataDeConstraints detecta a colisão")]
+    public async Task ExclusionConstraint_SobTransacaoAmbiente_SoDetectaNaChecagemForcada()
+    {
+        CalendarioDiasUteis primeiro = Nova(VersaoUnica());
+        primeiro.MarcarVigente();
+        await using (ConfiguracaoDbContext ctx = _fixture.CreateDbContext(AdminA))
+        {
+            ctx.CalendariosDiasUteis.Add(primeiro);
+            await ctx.SaveChangesAsync();
+        }
+
+        CalendarioDiasUteis segundo = Nova(VersaoUnica());
+        segundo.MarcarVigente();
+        await using ConfiguracaoDbContext ctx2 = _fixture.CreateDbContext(AdminA);
+
+        // Abre a transação ANTES do SaveChanges — reproduz o outbox do Wolverine
+        // (UseEntityFrameworkCoreTransactions + AutoApplyTransactions, ADR-0004), que
+        // abre a transação ANTES do handler rodar e só comita DEPOIS dele retornar.
+        await using Microsoft.EntityFrameworkCore.Storage.IDbContextTransaction tx =
+            await ctx2.Database.BeginTransactionAsync();
+        ctx2.CalendariosDiasUteis.Add(segundo);
+
+        // Sob transação já aberta, SaveChangesAsync só executa os comandos — quem
+        // comita é o `using` da transação, não este método. A exclusion constraint
+        // DEFERRED não é checada aqui: exatamente o cenário que fazia o handler
+        // devolver 500 em vez de 409 (o commit real só rodaria no outbox do
+        // Wolverine, fora do try/catch do handler — achado de revisão do Codex).
+        await ctx2.SaveChangesAsync();
+
+        Func<Task> act = async () => await ctx2.ForcarChecagemImediataDeConstraintsAsync();
+
+        Npgsql.PostgresException pg = (await act.Should().ThrowAsync<Npgsql.PostgresException>()).Which;
+        pg.SqlState.Should().Be("23P01");
+        pg.ConstraintName.Should().Be("ex_calendario_dias_uteis_vigente_unico");
+
+        // "segundo" nunca commitou (a transação nunca chegou a Commit), mas "primeiro"
+        // segue vigente=true na base compartilhada da fixture.
+        await using ConfiguracaoDbContext cleanupCtx = _fixture.CreateDbContext(AdminA);
+        CalendarioDiasUteis primeiroTracked = await cleanupCtx.CalendariosDiasUteis.SingleAsync(c => c.Id == primeiro.Id);
+        primeiroTracked.MarcarNaoVigente();
+        await cleanupCtx.SaveChangesAsync();
+    }
+
     [Fact(DisplayName = "CHECK de banco rejeita dia não útil municipal sem código IBGE via SQL cru")]
     public async Task Check_RejeitaMunicipalSemMunicipioIbgeViaSqlCru()
     {

--- a/tests/Unifesspa.UniPlus.Configuracao.IntegrationTests/CalendariosDiasUteis/CalendarioDiasUteisPersistenceTests.cs
+++ b/tests/Unifesspa.UniPlus.Configuracao.IntegrationTests/CalendariosDiasUteis/CalendarioDiasUteisPersistenceTests.cs
@@ -6,9 +6,11 @@ using AwesomeAssertions;
 
 using Microsoft.EntityFrameworkCore;
 
+using Unifesspa.UniPlus.Configuracao.Contracts;
 using Unifesspa.UniPlus.Configuracao.Domain.Entities;
 using Unifesspa.UniPlus.Configuracao.Domain.Enums;
 using Unifesspa.UniPlus.Configuracao.Infrastructure.Persistence;
+using Unifesspa.UniPlus.Configuracao.Infrastructure.Readers;
 using Unifesspa.UniPlus.Configuracao.IntegrationTests.Infrastructure;
 
 /// <summary>
@@ -93,6 +95,14 @@ public sealed class CalendarioDiasUteisPersistenceTests
         Npgsql.PostgresException pg = (await act.Should().ThrowAsync<Npgsql.PostgresException>()).Which;
         pg.SqlState.Should().Be("23P01");
         pg.ConstraintName.Should().Be("ex_calendario_dias_uteis_vigente_unico");
+
+        // "segundo" nunca commitou (transação abortada pela exclusion constraint), mas
+        // "primeiro" ficou vigente=true na base compartilhada da fixture — desmarca para
+        // não colidir com outros testes deste arquivo que também marcam vigente.
+        await using ConfiguracaoDbContext cleanupCtx = _fixture.CreateDbContext(AdminA);
+        CalendarioDiasUteis primeiroTracked = await cleanupCtx.CalendariosDiasUteis.SingleAsync(c => c.Id == primeiro.Id);
+        primeiroTracked.MarcarNaoVigente();
+        await cleanupCtx.SaveChangesAsync();
     }
 
     [Fact(DisplayName = "CHECK de banco rejeita dia não útil municipal sem código IBGE via SQL cru")]
@@ -150,6 +160,35 @@ public sealed class CalendarioDiasUteisPersistenceTests
         excluido.IsDeleted.Should().BeTrue();
         excluido.DeletedBy.Should().Be(AdminB);
         excluido.DiasNaoUteis.Should().HaveCount(2, "os dias não úteis não têm soft-delete próprio e permanecem sob a linha soft-deleted");
+    }
+
+    [Fact(DisplayName = "ICalendarioVigenteReader preserva abrangência e município por dia")]
+    public async Task VigenteReader_PreservaAbrangenciaEMunicipioPorDia()
+    {
+        CalendarioDiasUteis calendario = Nova(
+            VersaoUnica(),
+            new DiaNaoUtilCriacao("NACIONAL", null, new DateOnly(2027, 1, 1), "Confraternização Universal"),
+            new DiaNaoUtilCriacao("MUNICIPAL", "1501402", new DateOnly(2027, 5, 8), "Aniversário de Marabá"));
+        calendario.MarcarVigente();
+
+        await using (ConfiguracaoDbContext ctx = _fixture.CreateDbContext(AdminA))
+        {
+            ctx.CalendariosDiasUteis.Add(calendario);
+            await ctx.SaveChangesAsync();
+        }
+
+        await using ConfiguracaoDbContext readCtx = _fixture.CreateDbContext(userId: null);
+        var reader = new CalendarioVigenteReader(readCtx);
+
+        CalendarioVigenteView? vigente = await reader.ObterVigenteAsync();
+
+        vigente.Should().NotBeNull();
+        vigente!.Id.Should().Be(calendario.Id);
+        vigente.DiasNaoUteis.Should().HaveCount(2);
+        vigente.DiasNaoUteis.Should().Contain(d =>
+            d.Data == new DateOnly(2027, 1, 1) && d.Abrangencia == "NACIONAL" && d.MunicipioIbge == null);
+        vigente.DiasNaoUteis.Should().Contain(d =>
+            d.Data == new DateOnly(2027, 5, 8) && d.Abrangencia == "MUNICIPAL" && d.MunicipioIbge == "1501402");
     }
 
     private static string VersaoUnica() => $"cal-{Guid.NewGuid():N}"[..20];

--- a/tests/Unifesspa.UniPlus.Kernel.UnitTests/Domain/Cidades/ReferenciaCidadeGeoTests.cs
+++ b/tests/Unifesspa.UniPlus.Kernel.UnitTests/Domain/Cidades/ReferenciaCidadeGeoTests.cs
@@ -108,4 +108,33 @@ public sealed class ReferenciaCidadeGeoTests
         ReferenciaCidadeGeo.EhValida("1504208", "Marabá", "PA").Should().BeTrue();
         ReferenciaCidadeGeo.EhValida("150420", "Marabá", "PA").Should().BeFalse();
     }
+
+    [Theory(DisplayName = "TemPrefixoDeUfValido aceita prefixos de UF reais")]
+    [InlineData("1504208")]
+    [InlineData("3550308")]
+    public void TemPrefixoDeUfValido_PrefixoReal_Aceita(string codigoIbge)
+    {
+        ReferenciaCidadeGeo.TemPrefixoDeUfValido(codigoIbge).Should().BeTrue();
+    }
+
+    [Fact(DisplayName = "TemPrefixoDeUfValido rejeita prefixo fora do mapa de UF (lacuna 17-21)")]
+    public void TemPrefixoDeUfValido_PrefixoInexistente_Rejeita()
+    {
+        ReferenciaCidadeGeo.TemPrefixoDeUfValido("2012345").Should().BeFalse();
+    }
+
+    [Theory(DisplayName = "EhUfValida aceita as 27 siglas de UF do Brasil")]
+    [InlineData("PA")]
+    [InlineData("SP")]
+    [InlineData("DF")]
+    public void EhUfValida_UfReal_Aceita(string uf)
+    {
+        ReferenciaCidadeGeo.EhUfValida(uf).Should().BeTrue();
+    }
+
+    [Fact(DisplayName = "EhUfValida rejeita sigla que não corresponde a nenhuma UF")]
+    public void EhUfValida_UfInexistente_Rejeita()
+    {
+        ReferenciaCidadeGeo.EhUfValida("ZZ").Should().BeFalse();
+    }
 }


### PR DESCRIPTION
## Resumo

Implementa o cadastro de calendário de dias úteis (UNI-REQ-0080), um dos gaps de cadastro base identificados como pré-requisito da Feature #40 (criação de processo seletivo).

- `CalendarioDiasUteis` (agregado, versionado por dataset) + `DiaNaoUtil` (filha, sem soft-delete próprio — corrigir o calendário publica um dataset novo, nunca edita um existente).
- CRUD administrativo completo (criar, listar, obter por id, remover) e a operação de marcar um dataset como vigente, desmarcando o anterior na mesma transação.
- No máximo um dataset vigente por vez: garantido pelo handler e reforçado por `EXCLUDE ... DEFERRABLE INITIALLY DEFERRED` (não um índice único comum — ver nota abaixo).
- `ICalendarioVigenteReader` (ADR-0056): leitor cross-módulo para o futuro motor de contagem de prazos em dias úteis do módulo de Recursos (RN13), que fica fora do escopo desta issue.

### Nota técnica: por que `EXCLUDE` e não índice único

`MarcarVigenteCalendarioDiasUteisCommandHandler` desmarca o dataset vigente anterior e marca o novo na mesma `SaveChangesAsync`. Um índice único comum é verificado por-statement, e o EF Core não garante a ordem entre os dois `UPDATE`s dentro do mesmo batch — quando a ordem sai invertida, há um instante com duas linhas `vigente = true` simultâneas, violando um índice não-deferível mesmo a transação terminando num estado final válido. A solução replica o padrão já usado em `nos_exigencia` (`ex_nos_exigencia_irmaos_ordem`) e `tipo_ato_publicado` (`ex_tipo_ato_publicado_codigo_vigencia`): uma exclusion constraint GiST `DEFERRABLE INITIALLY DEFERRED`, que só é checada no `COMMIT`.

## Escopo

- Domain, Application, Infrastructure, API — camadas completas, Clean Architecture.
- Migration `CriaCalendarioDiasUteis`.
- Testes: unitários de Domain (20) e Application (17), integração ponta-a-ponta contra Postgres real via Testcontainers (13), incluindo a prova de que a exclusion constraint realmente dispara e que o CHECK de coerência de município rejeita SQL cru inválido.

## Fora de escopo

- Motor de contagem de dias úteis (algoritmo de prazo) — Feature #46.
- Carga real de feriados/recessos — operacional, não código.

Closes #1016

## Test plan

- [x] `dotnet build UniPlus.slnx` — 0 avisos, 0 erros
- [x] `dotnet format --verify-no-changes --exclude-diagnostics CA1515 --exclude "**/Migrations/**"` — limpo
- [x] Domain.UnitTests — 20/20
- [x] Application.UnitTests — 17/17
- [x] Configuracao.IntegrationTests (Testcontainers) — 13/13
- [x] ArchTests — 58/58
