### PR TITLE
fix(idempotencia): não cacheia sucesso em exceção pendente do resource filter

### DIFF
--- a/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Idempotency/IdempotencyFilter.cs
+++ b/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Idempotency/IdempotencyFilter.cs
@@ -211,21 +211,27 @@ public sealed class IdempotencyFilter<TDbContext> : IAsyncResourceFilter
             // context normalmente para este filtro, só relançando DEPOIS que
             // todos os resource filters retornarem sem marcar
             // `ExceptionHandled`. Sem esta checagem, o código abaixo trataria
-            // isso como sucesso: nenhum IActionResult executou, então
-            // `httpContext.Response.StatusCode` ainda está no valor default
-            // (não é >= 500), e a resposta cacheada seria um 200 com corpo
-            // vazio — um replay subsequente da mesma Idempotency-Key devolveria
-            // esse sucesso fabricado em vez do erro real que o
-            // GlobalExceptionMiddleware está prestes a produzir (a exceção
-            // continua propagando normalmente depois deste `return`, já que
-            // `ExceptionHandled` não é tocado aqui).
+            // isso como sucesso: nenhum IActionResult produziu um status
+            // conhecido, e a resposta cacheada seria um 200 com corpo vazio.
+            //
+            // Deliberadamente NÃO deleta a reservation aqui (diferente do
+            // branch de >= 500 abaixo, que sabe que a action *completou* e
+            // decidiu 500 deliberadamente): `next()` cobre tanto a execução da
+            // action quanto a execução/serialização do `IActionResult`
+            // devolvido — uma exceção pendente pode ter surgido DEPOIS que o
+            // comando já persistiu (ex.: falha ao serializar a resposta). Sem
+            // saber em qual etapa a exceção nasceu, apagar a reservation
+            // permitiria que um retry do cliente com a mesma chave reexecutasse
+            // uma mutação já aplicada — a mesma preocupação que a política
+            // conservadora do catch mais abaixo já trata para exceções que
+            // propagam sincronamente do próprio `next()` (ali distinguida por
+            // `handlerCompleted`; aqui `handlerCompleted` já é sempre `true`,
+            // então a política equivalente é nunca apagar). A entrada fica em
+            // Processing até o TTL (ADR-0027 §"Atomicidade parcial" já aceita
+            // essa janela); a exceção continua propagando normalmente depois
+            // deste `return`, já que `ExceptionHandled` não é tocado aqui.
             if (executed.Exception is not null && !executed.ExceptionHandled)
             {
-                await _store.DeleteAsync(scope, endpoint, idempotencyKey, CancellationToken.None)
-                    .ConfigureAwait(false);
-                reservationStillValid = false;
-                captureStream.Position = 0;
-                await captureStream.CopyToAsync(originalBody, httpContext.RequestAborted).ConfigureAwait(false);
                 return;
             }
 

--- a/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Idempotency/IdempotencyFilter.cs
+++ b/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Idempotency/IdempotencyFilter.cs
@@ -205,6 +205,30 @@ public sealed class IdempotencyFilter<TDbContext> : IAsyncResourceFilter
             ResourceExecutedContext executed = await next().ConfigureAwait(false);
             handlerCompleted = true;
 
+            // Exceção não tratada por nenhum filtro/action mais interno: o
+            // ResourceInvoker do ASP.NET Core MVC não relança sincronamente do
+            // próprio `next()` — ele popula `executed.Exception` e devolve o
+            // context normalmente para este filtro, só relançando DEPOIS que
+            // todos os resource filters retornarem sem marcar
+            // `ExceptionHandled`. Sem esta checagem, o código abaixo trataria
+            // isso como sucesso: nenhum IActionResult executou, então
+            // `httpContext.Response.StatusCode` ainda está no valor default
+            // (não é >= 500), e a resposta cacheada seria um 200 com corpo
+            // vazio — um replay subsequente da mesma Idempotency-Key devolveria
+            // esse sucesso fabricado em vez do erro real que o
+            // GlobalExceptionMiddleware está prestes a produzir (a exceção
+            // continua propagando normalmente depois deste `return`, já que
+            // `ExceptionHandled` não é tocado aqui).
+            if (executed.Exception is not null && !executed.ExceptionHandled)
+            {
+                await _store.DeleteAsync(scope, endpoint, idempotencyKey, CancellationToken.None)
+                    .ConfigureAwait(false);
+                reservationStillValid = false;
+                captureStream.Position = 0;
+                await captureStream.CopyToAsync(originalBody, httpContext.RequestAborted).ConfigureAwait(false);
+                return;
+            }
+
             int status = httpContext.Response.StatusCode;
 
             // 5xx nunca é cacheado (ADR-0027 §"Status codes em cache" + draft

--- a/tests/Unifesspa.UniPlus.Configuracao.IntegrationTests/Idempotency/IdempotencyFilterExceptionTests.cs
+++ b/tests/Unifesspa.UniPlus.Configuracao.IntegrationTests/Idempotency/IdempotencyFilterExceptionTests.cs
@@ -1,0 +1,177 @@
+namespace Unifesspa.UniPlus.Configuracao.IntegrationTests.Idempotency;
+
+using System.Diagnostics.CodeAnalysis;
+using System.Reflection;
+using System.Text;
+
+using AwesomeAssertions;
+
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Abstractions;
+using Microsoft.AspNetCore.Mvc.Controllers;
+using Microsoft.AspNetCore.Mvc.Filters;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+
+using NSubstitute;
+
+using Unifesspa.UniPlus.Application.Abstractions.Authentication;
+using Unifesspa.UniPlus.Configuracao.API.Controllers;
+using Unifesspa.UniPlus.Configuracao.Infrastructure.Persistence;
+using Unifesspa.UniPlus.Configuracao.IntegrationTests.Infrastructure;
+using Unifesspa.UniPlus.Infrastructure.Core.Cryptography;
+using Unifesspa.UniPlus.Infrastructure.Core.Errors;
+using Unifesspa.UniPlus.Infrastructure.Core.Idempotency;
+using Unifesspa.UniPlus.IntegrationTests.Fixtures.Hosting;
+
+/// <summary>
+/// Prova de correção do fix da issue #1028: <see cref="IdempotencyFilter{TDbContext}"/>
+/// não deve cachear uma resposta de sucesso quando o <c>next()</c> devolve um
+/// <see cref="ResourceExecutedContext"/> com uma exceção pendente e não tratada
+/// — o cenário que o <c>ResourceInvoker</c> do ASP.NET Core MVC produz quando a
+/// action (ou algo mais interno na pipeline) lança sem que nenhum filtro marque
+/// <c>ExceptionHandled</c>.
+/// </summary>
+/// <remarks>
+/// Instancia o filtro diretamente (não via HTTP completo) para controlar o
+/// <c>next()</c> com precisão: nenhum endpoint de produção deste monólito
+/// deveria, por design (ADR-0046, ADR-0119), deixar uma exceção não tratada
+/// escapar de um handler atrás de <c>[RequiresIdempotencyKey]</c> — é
+/// exatamente por isso que esse caminho nunca foi exercitado antes deste
+/// achado. O teste usa dependências reais (store EF Core contra Postgres
+/// efêmero, criptografia real) e só substitui <see cref="IUserContext"/> (não
+/// há uma requisição HTTP real autenticando via Keycloak aqui).
+/// </remarks>
+[Collection(ConfiguracaoEndpointCollection.Name)]
+[SuppressMessage(
+    "Performance",
+    "CA1515:Consider making public types internal",
+    Justification = "xUnit collection fixture exige tipo de teste público.")]
+public sealed class IdempotencyFilterExceptionTests
+{
+    private readonly ConfiguracaoEndpointFixture _fixture;
+
+    public IdempotencyFilterExceptionTests(ConfiguracaoEndpointFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    [Fact(DisplayName =
+        "Exceção pendente e não tratada no next() não é cacheada como sucesso, e a reservation é liberada")]
+    public async Task OnResourceExecutionAsync_ComExcecaoPendente_NaoCachearELiberaReservation()
+    {
+        MonolitoApiFactory api = _fixture.Factory;
+        string idempotencyKey = Guid.NewGuid().ToString();
+        string endpoint = "POST /api/configuracao/admin/termos-consentimento/idempotency-filter-exception-test";
+
+        await using AsyncServiceScope scope = api.Services.CreateAsyncScope();
+        IServiceProvider services = scope.ServiceProvider;
+
+        EfCoreIdempotencyStore<ConfiguracaoDbContext> store = ActivatorUtilities
+            .CreateInstance<EfCoreIdempotencyStore<ConfiguracaoDbContext>>(services);
+        IUniPlusEncryptionService encryption = services.GetRequiredService<IUniPlusEncryptionService>();
+        IDomainErrorMapper errorMapper = services.GetRequiredService<IDomainErrorMapper>();
+        TimeProvider time = services.GetRequiredService<TimeProvider>();
+        IOptions<IdempotencyOptions> options = services.GetRequiredService<IOptions<IdempotencyOptions>>();
+
+        IUserContext userContext = Substitute.For<IUserContext>();
+        userContext.IsAuthenticated.Returns(true);
+        userContext.UserId.Returns("idempotency-filter-exception-test-user");
+
+        IdempotencyFilter<ConfiguracaoDbContext> filter = new(store, encryption, errorMapper, time, userContext, options);
+
+        MethodInfo metodoIdempotente = typeof(TermosConsentimentoController)
+            .GetMethod(nameof(TermosConsentimentoController.EditarRascunho))!;
+        ControllerActionDescriptor actionDescriptor = new()
+        {
+            MethodInfo = metodoIdempotente,
+            ControllerTypeInfo = typeof(TermosConsentimentoController).GetTypeInfo(),
+        };
+
+        DefaultHttpContext httpContext = new()
+        {
+            RequestServices = services,
+        };
+        httpContext.Request.Method = "POST";
+        httpContext.Request.Path = "/api/configuracao/admin/termos-consentimento/idempotency-filter-exception-test";
+        httpContext.Request.Headers["Idempotency-Key"] = idempotencyKey;
+        byte[] corpo = Encoding.UTF8.GetBytes("""{"texto":"corpo de teste"}""");
+        httpContext.Request.Body = new MemoryStream(corpo);
+        httpContext.Request.ContentLength = corpo.Length;
+        httpContext.Response.Body = new MemoryStream();
+
+        ActionContext actionContext = new(httpContext, new RouteData(), actionDescriptor);
+        List<IFilterMetadata> filtros = [];
+
+        // --- Primeira chamada: next() simula uma exceção não tratada por
+        // nenhum filtro mais interno (o cenário real que o ResourceInvoker
+        // produz quando a action lança sem que ninguém marque ExceptionHandled).
+        ResourceExecutingContext executingContext = new(actionContext, filtros, []);
+        static Task<ResourceExecutedContext> NextComExcecaoPendente(ActionContext ctx, IList<IFilterMetadata> f)
+        {
+            ResourceExecutedContext executed = new(ctx, f)
+            {
+                Exception = new InvalidOperationException("erro sintético não relacionado a idempotência"),
+                ExceptionHandled = false,
+            };
+            return Task.FromResult(executed);
+        }
+
+        await filter.OnResourceExecutionAsync(
+            executingContext,
+            () => NextComExcecaoPendente(actionContext, filtros));
+
+        // O bodyHash do lookup precisa bater com o mesmo corpo — o filtro já
+        // reposicionou o stream do request para 0 internamente.
+        string bodyHash = ComputarBodyHash(corpo);
+        string scopeChave = $"user:idempotency-filter-exception-test-user";
+
+        IdempotencyLookupResult lookupAposExcecao = await store.LookupAsync(
+            scopeChave, endpoint, idempotencyKey, bodyHash, CancellationToken.None);
+
+        lookupAposExcecao.Outcome.Should().Be(
+            IdempotencyOutcome.Miss,
+            "uma exceção pendente e não tratada não deve deixar entrada cacheada — nem Completed (200 fabricado), nem Processing pendurada");
+
+        // --- Segunda chamada: replay da MESMA chave, desta vez com sucesso —
+        // prova que a reservation foi de fato liberada, não deixada presa em
+        // Processing (o que devolveria 409 ProcessingConflict indefinidamente).
+        DefaultHttpContext httpContext2 = new() { RequestServices = services };
+        httpContext2.Request.Method = "POST";
+        httpContext2.Request.Path = "/api/configuracao/admin/termos-consentimento/idempotency-filter-exception-test";
+        httpContext2.Request.Headers["Idempotency-Key"] = idempotencyKey;
+        httpContext2.Request.Body = new MemoryStream(corpo);
+        httpContext2.Request.ContentLength = corpo.Length;
+        httpContext2.Response.Body = new MemoryStream();
+
+        ActionContext actionContext2 = new(httpContext2, new RouteData(), actionDescriptor);
+        ResourceExecutingContext executingContext2 = new(actionContext2, filtros, []);
+
+        static Task<ResourceExecutedContext> NextComSucesso(ActionContext ctx, IList<IFilterMetadata> f, HttpContext http)
+        {
+            http.Response.StatusCode = StatusCodes.Status204NoContent;
+            ResourceExecutedContext executed = new(ctx, f);
+            return Task.FromResult(executed);
+        }
+
+        await filter.OnResourceExecutionAsync(
+            executingContext2,
+            () => NextComSucesso(actionContext2, filtros, httpContext2));
+
+        IdempotencyLookupResult lookupAposSucesso = await store.LookupAsync(
+            scopeChave, endpoint, idempotencyKey, bodyHash, CancellationToken.None);
+
+        lookupAposSucesso.Outcome.Should().Be(
+            IdempotencyOutcome.HitMatch,
+            "depois que a exceção liberou a reservation, um segundo request com a mesma chave deve rodar e cachear normalmente — não ficar preso em Processing");
+    }
+
+    private static string ComputarBodyHash(byte[] bytes)
+    {
+        Span<byte> hash = stackalloc byte[32];
+        System.Security.Cryptography.SHA256.HashData(bytes, hash);
+        return Convert.ToHexStringLower(hash);
+    }
+}

--- a/tests/Unifesspa.UniPlus.Configuracao.IntegrationTests/Idempotency/IdempotencyFilterExceptionTests.cs
+++ b/tests/Unifesspa.UniPlus.Configuracao.IntegrationTests/Idempotency/IdempotencyFilterExceptionTests.cs
@@ -56,6 +56,7 @@ using Unifesspa.UniPlus.IntegrationTests.Fixtures.Hosting;
 /// reexecução da mutação.</para>
 /// </remarks>
 [Collection(ConfiguracaoEndpointCollection.Name)]
+[Trait("Category", "Integration")]
 [SuppressMessage(
     "Performance",
     "CA1515:Consider making public types internal",
@@ -71,7 +72,7 @@ public sealed class IdempotencyFilterExceptionTests
 
     [Fact(DisplayName =
         "Exceção pendente e não tratada no next() não é cacheada como sucesso — reservation fica em Processing, não é liberada")]
-    public async Task OnResourceExecutionAsync_ComExcecaoPendente_NaoCachearEMantemProcessing()
+    public async Task OnResourceExecutionAsync_WithPendingException_DoesNotCacheAndKeepsProcessing()
     {
         MonolitoApiFactory api = _fixture.Factory;
         string idempotencyKey = Guid.NewGuid().ToString();
@@ -93,11 +94,11 @@ public sealed class IdempotencyFilterExceptionTests
 
         IdempotencyFilter<ConfiguracaoDbContext> filter = new(store, encryption, errorMapper, time, userContext, options);
 
-        MethodInfo metodoIdempotente = typeof(TermosConsentimentoController)
+        MethodInfo idempotentMethod = typeof(TermosConsentimentoController)
             .GetMethod(nameof(TermosConsentimentoController.MarcarRevisado))!;
         ControllerActionDescriptor actionDescriptor = new()
         {
-            MethodInfo = metodoIdempotente,
+            MethodInfo = idempotentMethod,
             ControllerTypeInfo = typeof(TermosConsentimentoController).GetTypeInfo(),
         };
 
@@ -108,13 +109,13 @@ public sealed class IdempotencyFilterExceptionTests
         httpContext.Request.Method = "POST";
         httpContext.Request.Path = "/api/configuracao/admin/termos-consentimento/00000000-0000-0000-0000-000000000001/revisar";
         httpContext.Request.Headers["Idempotency-Key"] = idempotencyKey;
-        byte[] corpo = Encoding.UTF8.GetBytes("""{"texto":"corpo de teste"}""");
-        httpContext.Request.Body = new MemoryStream(corpo);
-        httpContext.Request.ContentLength = corpo.Length;
+        byte[] body = Encoding.UTF8.GetBytes("""{"texto":"corpo de teste"}""");
+        httpContext.Request.Body = new MemoryStream(body);
+        httpContext.Request.ContentLength = body.Length;
         httpContext.Response.Body = new MemoryStream();
 
         ActionContext actionContext = new(httpContext, new RouteData(), actionDescriptor);
-        List<IFilterMetadata> filtros = [];
+        List<IFilterMetadata> filters = [];
 
         // --- Primeira chamada: next() simula uma exceção não tratada por
         // nenhum filtro mais interno (o cenário real que o ResourceInvoker
@@ -122,8 +123,8 @@ public sealed class IdempotencyFilterExceptionTests
         // lança sem que ninguém marque ExceptionHandled). A chamada ao filtro
         // em si NÃO relança (isso é responsabilidade do ResourceInvoker
         // externo, não simulado aqui): o filtro só decide se cacheia ou não.
-        ResourceExecutingContext executingContext = new(actionContext, filtros, []);
-        static Task<ResourceExecutedContext> NextComExcecaoPendente(ActionContext ctx, IList<IFilterMetadata> f)
+        ResourceExecutingContext executingContext = new(actionContext, filters, []);
+        static Task<ResourceExecutedContext> NextWithPendingException(ActionContext ctx, IList<IFilterMetadata> f)
         {
             ResourceExecutedContext executed = new(ctx, f)
             {
@@ -135,17 +136,17 @@ public sealed class IdempotencyFilterExceptionTests
 
         await filter.OnResourceExecutionAsync(
             executingContext,
-            () => NextComExcecaoPendente(actionContext, filtros));
+            () => NextWithPendingException(actionContext, filters));
 
         // O bodyHash do lookup precisa bater com o mesmo corpo — o filtro já
         // reposicionou o stream do request para 0 internamente.
-        string bodyHash = ComputarBodyHash(corpo);
-        string scopeChave = "user:idempotency-filter-exception-test-user";
+        string bodyHash = ComputeBodyHash(body);
+        string idempotencyScope = "user:idempotency-filter-exception-test-user";
 
-        IdempotencyLookupResult lookupAposExcecao = await store.LookupAsync(
-            scopeChave, endpoint, idempotencyKey, bodyHash, CancellationToken.None);
+        IdempotencyLookupResult lookupAfterException = await store.LookupAsync(
+            idempotencyScope, endpoint, idempotencyKey, bodyHash, CancellationToken.None);
 
-        lookupAposExcecao.Outcome.Should().Be(
+        lookupAfterException.Outcome.Should().Be(
             IdempotencyOutcome.Processing,
             "uma exceção pendente e não tratada não deve deixar entrada Completed (200 fabricado) nem ser apagada — "
             + "apagar arriscaria reexecutar uma mutação que já pode ter persistido antes da exceção");
@@ -159,29 +160,29 @@ public sealed class IdempotencyFilterExceptionTests
         httpContext2.Request.Method = "POST";
         httpContext2.Request.Path = "/api/configuracao/admin/termos-consentimento/00000000-0000-0000-0000-000000000001/revisar";
         httpContext2.Request.Headers["Idempotency-Key"] = idempotencyKey;
-        httpContext2.Request.Body = new MemoryStream(corpo);
-        httpContext2.Request.ContentLength = corpo.Length;
+        httpContext2.Request.Body = new MemoryStream(body);
+        httpContext2.Request.ContentLength = body.Length;
         httpContext2.Response.Body = new MemoryStream();
 
         ActionContext actionContext2 = new(httpContext2, new RouteData(), actionDescriptor);
-        ResourceExecutingContext executingContext2 = new(actionContext2, filtros, []);
+        ResourceExecutingContext executingContext2 = new(actionContext2, filters, []);
 
-        bool nextChamado = false;
-        Task<ResourceExecutedContext> NextNuncaDeveriaRodar()
+        bool nextInvoked = false;
+        Task<ResourceExecutedContext> NextShouldNeverRun()
         {
-            nextChamado = true;
-            return Task.FromResult(new ResourceExecutedContext(actionContext2, filtros));
+            nextInvoked = true;
+            return Task.FromResult(new ResourceExecutedContext(actionContext2, filters));
         }
 
-        await filter.OnResourceExecutionAsync(executingContext2, NextNuncaDeveriaRodar);
+        await filter.OnResourceExecutionAsync(executingContext2, NextShouldNeverRun);
 
-        nextChamado.Should().BeFalse(
+        nextInvoked.Should().BeFalse(
             "o retry imediato deve ser rejeitado pelo lookup de Processing, sem nunca chegar a invocar a action de novo");
         executingContext2.Result.Should().NotBeNull(
             "o filtro deve ter produzido a resposta 409 ProcessingConflict via short-circuit");
     }
 
-    private static string ComputarBodyHash(byte[] bytes)
+    private static string ComputeBodyHash(byte[] bytes)
     {
         Span<byte> hash = stackalloc byte[32];
         System.Security.Cryptography.SHA256.HashData(bytes, hash);

--- a/tests/Unifesspa.UniPlus.Configuracao.IntegrationTests/Idempotency/IdempotencyFilterExceptionTests.cs
+++ b/tests/Unifesspa.UniPlus.Configuracao.IntegrationTests/Idempotency/IdempotencyFilterExceptionTests.cs
@@ -31,18 +31,29 @@ using Unifesspa.UniPlus.IntegrationTests.Fixtures.Hosting;
 /// não deve cachear uma resposta de sucesso quando o <c>next()</c> devolve um
 /// <see cref="ResourceExecutedContext"/> com uma exceção pendente e não tratada
 /// — o cenário que o <c>ResourceInvoker</c> do ASP.NET Core MVC produz quando a
-/// action (ou algo mais interno na pipeline) lança sem que nenhum filtro marque
-/// <c>ExceptionHandled</c>.
+/// action (ou a execução/serialização do resultado que ela devolveu) lança sem
+/// que nenhum filtro marque <c>ExceptionHandled</c>.
 /// </summary>
 /// <remarks>
-/// Instancia o filtro diretamente (não via HTTP completo) para controlar o
+/// <para>Instancia o filtro diretamente (não via HTTP completo) para controlar o
 /// <c>next()</c> com precisão: nenhum endpoint de produção deste monólito
 /// deveria, por design (ADR-0046, ADR-0119), deixar uma exceção não tratada
 /// escapar de um handler atrás de <c>[RequiresIdempotencyKey]</c> — é
 /// exatamente por isso que esse caminho nunca foi exercitado antes deste
 /// achado. O teste usa dependências reais (store EF Core contra Postgres
 /// efêmero, criptografia real) e só substitui <see cref="IUserContext"/> (não
-/// há uma requisição HTTP real autenticando via Keycloak aqui).
+/// há uma requisição HTTP real autenticando via Keycloak aqui).</para>
+/// <para><b>Por que a reservation não é liberada</b> (revisão de PR): o
+/// <c>next()</c> cobre tanto a execução da action quanto a
+/// execução/serialização do <c>IActionResult</c> que ela devolveu — uma
+/// exceção pendente pode ter surgido DEPOIS que o comando já persistiu (ex.:
+/// falha ao serializar a resposta). Sem saber em qual etapa a exceção nasceu,
+/// apagar a reservation permitiria que um retry do cliente com a mesma chave
+/// reexecutasse uma mutação já aplicada. A política é a mesma já aceita pela
+/// ADR-0027 §"Atomicidade parcial" para falhas pós-handler: a entrada fica em
+/// <c>Processing</c> até o TTL, e o cliente recebe 409 <c>ProcessingConflict</c>
+/// num retry imediato — não uma resposta fabricada, mas também não uma
+/// reexecução da mutação.</para>
 /// </remarks>
 [Collection(ConfiguracaoEndpointCollection.Name)]
 [SuppressMessage(
@@ -59,12 +70,12 @@ public sealed class IdempotencyFilterExceptionTests
     }
 
     [Fact(DisplayName =
-        "Exceção pendente e não tratada no next() não é cacheada como sucesso, e a reservation é liberada")]
-    public async Task OnResourceExecutionAsync_ComExcecaoPendente_NaoCachearELiberaReservation()
+        "Exceção pendente e não tratada no next() não é cacheada como sucesso — reservation fica em Processing, não é liberada")]
+    public async Task OnResourceExecutionAsync_ComExcecaoPendente_NaoCachearEMantemProcessing()
     {
         MonolitoApiFactory api = _fixture.Factory;
         string idempotencyKey = Guid.NewGuid().ToString();
-        string endpoint = "POST /api/configuracao/admin/termos-consentimento/idempotency-filter-exception-test";
+        string endpoint = "POST /api/configuracao/admin/termos-consentimento/00000000-0000-0000-0000-000000000001/revisar";
 
         await using AsyncServiceScope scope = api.Services.CreateAsyncScope();
         IServiceProvider services = scope.ServiceProvider;
@@ -83,7 +94,7 @@ public sealed class IdempotencyFilterExceptionTests
         IdempotencyFilter<ConfiguracaoDbContext> filter = new(store, encryption, errorMapper, time, userContext, options);
 
         MethodInfo metodoIdempotente = typeof(TermosConsentimentoController)
-            .GetMethod(nameof(TermosConsentimentoController.EditarRascunho))!;
+            .GetMethod(nameof(TermosConsentimentoController.MarcarRevisado))!;
         ControllerActionDescriptor actionDescriptor = new()
         {
             MethodInfo = metodoIdempotente,
@@ -95,7 +106,7 @@ public sealed class IdempotencyFilterExceptionTests
             RequestServices = services,
         };
         httpContext.Request.Method = "POST";
-        httpContext.Request.Path = "/api/configuracao/admin/termos-consentimento/idempotency-filter-exception-test";
+        httpContext.Request.Path = "/api/configuracao/admin/termos-consentimento/00000000-0000-0000-0000-000000000001/revisar";
         httpContext.Request.Headers["Idempotency-Key"] = idempotencyKey;
         byte[] corpo = Encoding.UTF8.GetBytes("""{"texto":"corpo de teste"}""");
         httpContext.Request.Body = new MemoryStream(corpo);
@@ -107,7 +118,10 @@ public sealed class IdempotencyFilterExceptionTests
 
         // --- Primeira chamada: next() simula uma exceção não tratada por
         // nenhum filtro mais interno (o cenário real que o ResourceInvoker
-        // produz quando a action lança sem que ninguém marque ExceptionHandled).
+        // produz quando a action — ou a serialização do resultado dela —
+        // lança sem que ninguém marque ExceptionHandled). A chamada ao filtro
+        // em si NÃO relança (isso é responsabilidade do ResourceInvoker
+        // externo, não simulado aqui): o filtro só decide se cacheia ou não.
         ResourceExecutingContext executingContext = new(actionContext, filtros, []);
         static Task<ResourceExecutedContext> NextComExcecaoPendente(ActionContext ctx, IList<IFilterMetadata> f)
         {
@@ -126,21 +140,24 @@ public sealed class IdempotencyFilterExceptionTests
         // O bodyHash do lookup precisa bater com o mesmo corpo — o filtro já
         // reposicionou o stream do request para 0 internamente.
         string bodyHash = ComputarBodyHash(corpo);
-        string scopeChave = $"user:idempotency-filter-exception-test-user";
+        string scopeChave = "user:idempotency-filter-exception-test-user";
 
         IdempotencyLookupResult lookupAposExcecao = await store.LookupAsync(
             scopeChave, endpoint, idempotencyKey, bodyHash, CancellationToken.None);
 
         lookupAposExcecao.Outcome.Should().Be(
-            IdempotencyOutcome.Miss,
-            "uma exceção pendente e não tratada não deve deixar entrada cacheada — nem Completed (200 fabricado), nem Processing pendurada");
+            IdempotencyOutcome.Processing,
+            "uma exceção pendente e não tratada não deve deixar entrada Completed (200 fabricado) nem ser apagada — "
+            + "apagar arriscaria reexecutar uma mutação que já pode ter persistido antes da exceção");
 
-        // --- Segunda chamada: replay da MESMA chave, desta vez com sucesso —
-        // prova que a reservation foi de fato liberada, não deixada presa em
-        // Processing (o que devolveria 409 ProcessingConflict indefinidamente).
+        // --- Segunda chamada: retry imediato do cliente com a MESMA chave —
+        // prova que ele recebe 409 ProcessingConflict (não uma reexecução da
+        // mutação, não uma resposta fabricada). O filtro faz o short-circuit
+        // antes de chamar next(), então o `next` desta chamada nunca deveria
+        // ser invocado.
         DefaultHttpContext httpContext2 = new() { RequestServices = services };
         httpContext2.Request.Method = "POST";
-        httpContext2.Request.Path = "/api/configuracao/admin/termos-consentimento/idempotency-filter-exception-test";
+        httpContext2.Request.Path = "/api/configuracao/admin/termos-consentimento/00000000-0000-0000-0000-000000000001/revisar";
         httpContext2.Request.Headers["Idempotency-Key"] = idempotencyKey;
         httpContext2.Request.Body = new MemoryStream(corpo);
         httpContext2.Request.ContentLength = corpo.Length;
@@ -149,23 +166,19 @@ public sealed class IdempotencyFilterExceptionTests
         ActionContext actionContext2 = new(httpContext2, new RouteData(), actionDescriptor);
         ResourceExecutingContext executingContext2 = new(actionContext2, filtros, []);
 
-        static Task<ResourceExecutedContext> NextComSucesso(ActionContext ctx, IList<IFilterMetadata> f, HttpContext http)
+        bool nextChamado = false;
+        Task<ResourceExecutedContext> NextNuncaDeveriaRodar()
         {
-            http.Response.StatusCode = StatusCodes.Status204NoContent;
-            ResourceExecutedContext executed = new(ctx, f);
-            return Task.FromResult(executed);
+            nextChamado = true;
+            return Task.FromResult(new ResourceExecutedContext(actionContext2, filtros));
         }
 
-        await filter.OnResourceExecutionAsync(
-            executingContext2,
-            () => NextComSucesso(actionContext2, filtros, httpContext2));
+        await filter.OnResourceExecutionAsync(executingContext2, NextNuncaDeveriaRodar);
 
-        IdempotencyLookupResult lookupAposSucesso = await store.LookupAsync(
-            scopeChave, endpoint, idempotencyKey, bodyHash, CancellationToken.None);
-
-        lookupAposSucesso.Outcome.Should().Be(
-            IdempotencyOutcome.HitMatch,
-            "depois que a exceção liberou a reservation, um segundo request com a mesma chave deve rodar e cachear normalmente — não ficar preso em Processing");
+        nextChamado.Should().BeFalse(
+            "o retry imediato deve ser rejeitado pelo lookup de Processing, sem nunca chegar a invocar a action de novo");
+        executingContext2.Result.Should().NotBeNull(
+            "o filtro deve ter produzido a resposta 409 ProcessingConflict via short-circuit");
     }
 
     private static string ComputarBodyHash(byte[] bytes)


### PR DESCRIPTION
## Contexto

`IdempotencyFilter<TDbContext>` é um `IAsyncResourceFilter` do ASP.NET Core MVC. Quando uma exceção não tratada ocorre na action (ou na execução/serialização do `IActionResult` que ela devolveu), o `ResourceInvoker` não relança sincronamente do `next()` — ele popula `ResourceExecutedContext.Exception`/`ExceptionHandled` e devolve o context normalmente para o filtro, só relançando depois que todos os resource filters retornarem sem marcar `ExceptionHandled = true`.

O filtro nunca verificava essa condição: seguia o caminho de sucesso, lia `httpContext.Response.StatusCode` (ainda no valor default, já que nenhum `IActionResult` foi produzido), e cacheava uma entrada `Completed` com status 200 e corpo vazio sob a Idempotency-Key. Um replay subsequente da mesma chave devolveria esse sucesso fabricado em vez do erro real que o `GlobalExceptionMiddleware` estava prestes a produzir.

Vale para qualquer endpoint `[RequiresIdempotencyKey]` do monólito onde a action (ou algo abaixo dela na pipeline MVC) lance uma exceção não tratada.

## O que muda

- `IdempotencyFilter<TDbContext>`: detecta `executed.Exception is not null && !executed.ExceptionHandled` e simplesmente `return;`, sem cachear e sem tocar o `IIdempotencyStore`.
- **Decisão deliberada de não deletar a reservation** nesse branch (diferente do branch de status `>= 500`, que sabe que a action *completou* e decidiu 500): `next()` cobre tanto a execução da action quanto a execução/serialização do resultado que ela devolveu, então uma exceção pendente pode ter surgido DEPOIS que o comando já persistiu (ex.: falha ao serializar a resposta). Apagar a reservation nesse cenário permitiria que um retry do cliente com a mesma chave reexecutasse uma mutação já aplicada. A reservation fica em `Processing` até o TTL — a mesma política já aceita pela ADR-0027 §"Atomicidade parcial" para falhas pós-handler — e o cliente recebe 409 `ProcessingConflict` num retry imediato em vez de uma reexecução ou de uma resposta fabricada.
- Teste de integração novo (`IdempotencyFilterExceptionTests`) que instancia o filtro diretamente, simula um `next()` com exceção pendente e prova: (1) a entrada fica `Processing`, não `Completed` nem apagada; (2) um retry imediato com a mesma chave é rejeitado via short-circuit (409) sem invocar `next()` de novo.

Closes #1028

## Teste

- `dotnet test` local: suíte completa de Configuração (306 integração + 360 application + 586 domínio) verde, incluindo o novo teste.
- `dotnet format --verify-no-changes` limpo.
