### PR TITLE
fix(publicacoes): descarta rastreamento no conflito de vigência de tipo de ato

### DIFF
--- a/src/publicacoes/Unifesspa.UniPlus.Publicacoes.Application/Abstractions/IPublicacoesUnitOfWork.cs
+++ b/src/publicacoes/Unifesspa.UniPlus.Publicacoes.Application/Abstractions/IPublicacoesUnitOfWork.cs
@@ -11,4 +11,16 @@ using Unifesspa.UniPlus.Application.Abstractions.Interfaces;
 /// </summary>
 public interface IPublicacoesUnitOfWork : IUnitOfWork
 {
+    /// <summary>
+    /// Descarta o rastreamento de entidades Added/Modified de uma tentativa de
+    /// <see cref="IUnitOfWork.SalvarAlteracoesAsync"/> que falhou. Necessário
+    /// no catch de handlers que traduzem exceção de conflito (exclusion
+    /// constraint, concorrência otimista) em <c>DomainError</c>: sem isso, o
+    /// <c>SaveChangesAsync</c> automático do outbox do Wolverine
+    /// (<c>AutoApplyTransactions</c>, ADR-0004) tenta gravar as mesmas
+    /// entidades de novo depois que o handler retorna, e a mesma exceção
+    /// estoura fora de qualquer catch — 500 em vez do <c>DomainError</c> já
+    /// traduzido.
+    /// </summary>
+    void DescartarAlteracoesNaoSalvas();
 }

--- a/src/publicacoes/Unifesspa.UniPlus.Publicacoes.Application/Commands/TiposAtoPublicado/AtualizarTipoAtoPublicadoCommandHandler.cs
+++ b/src/publicacoes/Unifesspa.UniPlus.Publicacoes.Application/Commands/TiposAtoPublicado/AtualizarTipoAtoPublicadoCommandHandler.cs
@@ -64,6 +64,15 @@ public static class AtualizarTipoAtoPublicadoCommandHandler
         catch (Exception ex) when (ExclusionConstraintViolation.GetViolatedConstraint(ex) is { } constraint
             && ExclusionConstraintViolation.IsVigenciaConflict(constraint))
         {
+            // A exclusion constraint é DEFERRABLE INITIALLY IMMEDIATE — checada
+            // dentro do próprio SalvarAlteracoesAsync acima, não num commit
+            // externo (diferente de constraints INITIALLY DEFERRED). Descarta o
+            // rastreamento do agregado Modified ANTES de devolver a falha: o
+            // SaveChangesAsync automático do outbox do Wolverine
+            // (AutoApplyTransactions, ADR-0004) roda de novo depois que este
+            // handler retorna, e sem isso a mesma exceção estouraria de novo
+            // fora deste catch, virando 500 em vez do DomainError já traduzido.
+            unitOfWork.DescartarAlteracoesNaoSalvas();
             return Result.Failure(CriarTipoAtoPublicadoCommandHandler.VigenciaSobrepostaErro(command.Codigo));
         }
 

--- a/src/publicacoes/Unifesspa.UniPlus.Publicacoes.Application/Commands/TiposAtoPublicado/CriarTipoAtoPublicadoCommandHandler.cs
+++ b/src/publicacoes/Unifesspa.UniPlus.Publicacoes.Application/Commands/TiposAtoPublicado/CriarTipoAtoPublicadoCommandHandler.cs
@@ -61,6 +61,15 @@ public static class CriarTipoAtoPublicadoCommandHandler
         catch (Exception ex) when (ExclusionConstraintViolation.GetViolatedConstraint(ex) is { } constraint
             && ExclusionConstraintViolation.IsVigenciaConflict(constraint))
         {
+            // A exclusion constraint é DEFERRABLE INITIALLY IMMEDIATE — checada
+            // dentro do próprio SalvarAlteracoesAsync acima, não num commit
+            // externo (diferente de constraints INITIALLY DEFERRED). Descarta o
+            // rastreamento do agregado Added ANTES de devolver a falha: o
+            // SaveChangesAsync automático do outbox do Wolverine
+            // (AutoApplyTransactions, ADR-0004) roda de novo depois que este
+            // handler retorna, e sem isso a mesma exceção estouraria de novo
+            // fora deste catch, virando 500 em vez do DomainError já traduzido.
+            unitOfWork.DescartarAlteracoesNaoSalvas();
             return Result<Guid>.Failure(VigenciaSobrepostaErro(command.Codigo));
         }
 

--- a/src/publicacoes/Unifesspa.UniPlus.Publicacoes.Infrastructure/Persistence/PublicacoesDbContext.cs
+++ b/src/publicacoes/Unifesspa.UniPlus.Publicacoes.Infrastructure/Persistence/PublicacoesDbContext.cs
@@ -73,4 +73,9 @@ public sealed class PublicacoesDbContext : DbContext, IPublicacoesUnitOfWork
     {
         return await SaveChangesAsync(cancellationToken).ConfigureAwait(false);
     }
+
+    public void DescartarAlteracoesNaoSalvas()
+    {
+        ChangeTracker.Clear();
+    }
 }

--- a/tests/Unifesspa.UniPlus.Publicacoes.Application.UnitTests/Commands/AtualizarTipoAtoPublicadoCommandHandlerTests.cs
+++ b/tests/Unifesspa.UniPlus.Publicacoes.Application.UnitTests/Commands/AtualizarTipoAtoPublicadoCommandHandlerTests.cs
@@ -4,11 +4,15 @@ using System.Diagnostics.CodeAnalysis;
 
 using AwesomeAssertions;
 
+using Microsoft.EntityFrameworkCore;
+
 using NSubstitute;
+using NSubstitute.ExceptionExtensions;
 
 using Unifesspa.UniPlus.Kernel.Results;
 using Unifesspa.UniPlus.Publicacoes.Application.Abstractions;
 using Unifesspa.UniPlus.Publicacoes.Application.Commands.TiposAtoPublicado;
+using Unifesspa.UniPlus.Publicacoes.Application.UnitTests.TestSupport;
 using Unifesspa.UniPlus.Publicacoes.Domain.Entities;
 using Unifesspa.UniPlus.Publicacoes.Domain.Errors;
 using Unifesspa.UniPlus.Publicacoes.Domain.Interfaces;
@@ -115,6 +119,28 @@ public sealed class AtualizarTipoAtoPublicadoCommandHandlerTests
         resultado.IsFailure.Should().BeTrue();
         resultado.Error!.Code.Should().Be(TipoAtoPublicadoErrorCodes.NomeTamanho);
         await _unitOfWork.DidNotReceive().SalvarAlteracoesAsync(Arg.Any<CancellationToken>());
+    }
+
+    [Fact(DisplayName = "Violação da exclusion constraint de vigência descarta o rastreamento antes de devolver o conflito")]
+    public async Task Handle_ColisaoNaExclusionConstraint_DescartaRastreamentoERetornaConflito()
+    {
+        TipoAtoPublicado existente = Existente();
+        _repository.ObterPorIdAsync(existente.Id, Arg.Any<CancellationToken>()).Returns(existente);
+        _repository.ExisteSobreposicaoDeVigenciaAsync(
+            Arg.Any<string>(), Arg.Any<DateOnly>(), Arg.Any<DateOnly?>(), Arg.Any<Guid?>(), Arg.Any<CancellationToken>())
+            .Returns(false);
+        _unitOfWork.SalvarAlteracoesAsync(Arg.Any<CancellationToken>())
+            .ThrowsAsync(new DbUpdateException(
+                "conflito sintético de teste",
+                PostgresExceptionFactory.Create("23P01", "ex_tipo_ato_publicado_codigo_vigencia")));
+
+        Result resultado = await AtualizarTipoAtoPublicadoCommandHandler.Handle(
+            Comando(existente.Id) with { VigenciaInicio = Inicio.AddMonths(2) },
+            _repository, _unitOfWork, CancellationToken.None);
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be(TipoAtoPublicadoErrorCodes.VigenciaSobreposta);
+        _unitOfWork.Received(1).DescartarAlteracoesNaoSalvas();
     }
 
     private static TipoAtoPublicado Existente() =>

--- a/tests/Unifesspa.UniPlus.Publicacoes.Application.UnitTests/Commands/CriarTipoAtoPublicadoCommandHandlerTests.cs
+++ b/tests/Unifesspa.UniPlus.Publicacoes.Application.UnitTests/Commands/CriarTipoAtoPublicadoCommandHandlerTests.cs
@@ -4,11 +4,15 @@ using System.Diagnostics.CodeAnalysis;
 
 using AwesomeAssertions;
 
+using Microsoft.EntityFrameworkCore;
+
 using NSubstitute;
+using NSubstitute.ExceptionExtensions;
 
 using Unifesspa.UniPlus.Kernel.Results;
 using Unifesspa.UniPlus.Publicacoes.Application.Abstractions;
 using Unifesspa.UniPlus.Publicacoes.Application.Commands.TiposAtoPublicado;
+using Unifesspa.UniPlus.Publicacoes.Application.UnitTests.TestSupport;
 using Unifesspa.UniPlus.Publicacoes.Domain.Entities;
 using Unifesspa.UniPlus.Publicacoes.Domain.Errors;
 using Unifesspa.UniPlus.Publicacoes.Domain.Interfaces;
@@ -86,6 +90,25 @@ public sealed class CriarTipoAtoPublicadoCommandHandlerTests
 
         await _repository.Received(1).ExisteSobreposicaoDeVigenciaAsync(
             "EDITAL_ABERTURA", Inicio, fim, null, Arg.Any<CancellationToken>());
+    }
+
+    [Fact(DisplayName = "Violação da exclusion constraint de vigência descarta o rastreamento antes de devolver o conflito")]
+    public async Task Handle_ColisaoNaExclusionConstraint_DescartaRastreamentoERetornaConflito()
+    {
+        _repository.ExisteSobreposicaoDeVigenciaAsync(
+            Arg.Any<string>(), Arg.Any<DateOnly>(), Arg.Any<DateOnly?>(), Arg.Any<Guid?>(), Arg.Any<CancellationToken>())
+            .Returns(false);
+        _unitOfWork.SalvarAlteracoesAsync(Arg.Any<CancellationToken>())
+            .ThrowsAsync(new DbUpdateException(
+                "conflito sintético de teste",
+                PostgresExceptionFactory.Create("23P01", "ex_tipo_ato_publicado_codigo_vigencia")));
+
+        Result<Guid> resultado = await CriarTipoAtoPublicadoCommandHandler.Handle(
+            Comando(), _repository, _unitOfWork, CancellationToken.None);
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be(TipoAtoPublicadoErrorCodes.VigenciaSobreposta);
+        _unitOfWork.Received(1).DescartarAlteracoesNaoSalvas();
     }
 
     private static CriarTipoAtoPublicadoCommand Comando() =>

--- a/tests/Unifesspa.UniPlus.Publicacoes.Application.UnitTests/TestSupport/PostgresExceptionFactory.cs
+++ b/tests/Unifesspa.UniPlus.Publicacoes.Application.UnitTests/TestSupport/PostgresExceptionFactory.cs
@@ -1,0 +1,30 @@
+namespace Unifesspa.UniPlus.Publicacoes.Application.UnitTests.TestSupport;
+
+using System.Reflection;
+
+using Npgsql;
+
+/// <summary>
+/// Constrói <see cref="PostgresException"/> sintéticas para testar a tradução de
+/// exceção em <c>ExclusionConstraintViolation</c> sem precisar de um Postgres real.
+/// <c>ConstraintName</c> só tem setter privado no driver (populado normalmente a
+/// partir da mensagem de erro do protocolo) — o backing field é setado via
+/// reflection, técnica restrita a este helper de teste.
+/// </summary>
+public static class PostgresExceptionFactory
+{
+    public static PostgresException Create(string sqlState, string? constraintName = null)
+    {
+        var ex = new PostgresException("ERROR", "ERROR", "mensagem sintética de teste", sqlState);
+
+        if (constraintName is not null)
+        {
+            FieldInfo field = typeof(PostgresException)
+                .GetField("<ConstraintName>k__BackingField", BindingFlags.NonPublic | BindingFlags.Instance)
+                ?? throw new InvalidOperationException("Backing field de ConstraintName não encontrado — API do Npgsql mudou.");
+            field.SetValue(ex, constraintName);
+        }
+
+        return ex;
+    }
+}

--- a/tests/Unifesspa.UniPlus.Publicacoes.Application.UnitTests/Unifesspa.UniPlus.Publicacoes.Application.UnitTests.csproj
+++ b/tests/Unifesspa.UniPlus.Publicacoes.Application.UnitTests/Unifesspa.UniPlus.Publicacoes.Application.UnitTests.csproj
@@ -11,6 +11,8 @@
     <PackageReference Include="xunit" />
     <PackageReference Include="xunit.runner.visualstudio" />
     <PackageReference Include="AwesomeAssertions" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" />
+    <PackageReference Include="Npgsql" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Unifesspa.UniPlus.Publicacoes.Application.UnitTests/packages.lock.json
+++ b/tests/Unifesspa.UniPlus.Publicacoes.Application.UnitTests/packages.lock.json
@@ -14,6 +14,18 @@
         "resolved": "8.0.1",
         "contentHash": "heVQl5tKYnnIDYlR1QMVGueYH6iriZTcZB6AjDczQNwZzxkjDIt9C84Pt4cCiZYrbo7jkZOYGWbs6Lo9wAtVLg=="
       },
+      "Microsoft.EntityFrameworkCore": {
+        "type": "Direct",
+        "requested": "[10.0.10, )",
+        "resolved": "10.0.10",
+        "contentHash": "a0V7zj/VbYP6dTdWpUgE/r2PuLKtUGe2aJ0lVKkn/wP9ZhaxUz2kQydVfvOjCv2SKxlrqdBfHhPD4Cvlf+4ffA==",
+        "dependencies": {
+          "Microsoft.EntityFrameworkCore.Abstractions": "10.0.10",
+          "Microsoft.EntityFrameworkCore.Analyzers": "10.0.10",
+          "Microsoft.Extensions.Caching.Memory": "10.0.10",
+          "Microsoft.Extensions.Logging": "10.0.10"
+        }
+      },
       "Microsoft.NET.Test.Sdk": {
         "type": "Direct",
         "requested": "[18.8.1, )",
@@ -22,6 +34,15 @@
         "dependencies": {
           "Microsoft.CodeCoverage": "18.8.1",
           "Microsoft.TestPlatform.TestHost": "18.8.1"
+        }
+      },
+      "Npgsql": {
+        "type": "Direct",
+        "requested": "[10.0.3, )",
+        "resolved": "10.0.3",
+        "contentHash": "7nb5YzXuvWWJxB0J8DiyL3we+X4FOctZrt0fIBnucOIaIevFEEwGQVZKtiu9olXdlNAK1eNgqSral6r/jlhI4w==",
+        "dependencies": {
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.0"
         }
       },
       "NSubstitute": {
@@ -239,24 +260,34 @@
         "resolved": "18.8.1",
         "contentHash": "Eclse/ZZjr4lmWzZFNN9h/OluhKL+SK/QbUyKUewgX139aGeyMEO/DkMPwuFs2MixvanTnz6891rF8UHDg+W4Q=="
       },
+      "Microsoft.EntityFrameworkCore.Abstractions": {
+        "type": "Transitive",
+        "resolved": "10.0.10",
+        "contentHash": "bOzrFCl6uZCjaSh2bG1ToRQRdx+iXvxosCg9hFyG9OWeAzOFI4xev9OqKeWfKf/kAHyox2JnbcvLVf2ceA7sqA=="
+      },
+      "Microsoft.EntityFrameworkCore.Analyzers": {
+        "type": "Transitive",
+        "resolved": "10.0.10",
+        "contentHash": "2gLDordUCGf3aNOOuqtTbP5mxhiP9nk6TnvGiE3RnqT891O+Zf/qKu1PIREubs1M16A0SImr4vULBfU5BTDs1Q=="
+      },
       "Microsoft.Extensions.Caching.Abstractions": {
         "type": "Transitive",
-        "resolved": "10.0.0",
-        "contentHash": "Zcoy6H9mSoGyvr7UvlGokEZrlZkcPCICPZr8mCsSt9U/N8eeCwCXwKF5bShdA66R0obxBCwP4AxomQHvVkC/uA==",
+        "resolved": "10.0.10",
+        "contentHash": "4ZFBNE+jzR+CrWWlhOesnmywCW7pYKT0dxyAQRdL11yJwxe4jvcAu31eorFtEkoFeCDcUTeNssgPv2yaRRptaQ==",
         "dependencies": {
-          "Microsoft.Extensions.Primitives": "10.0.0"
+          "Microsoft.Extensions.Primitives": "10.0.10"
         }
       },
       "Microsoft.Extensions.Caching.Memory": {
         "type": "Transitive",
-        "resolved": "10.0.0",
-        "contentHash": "krK19MKp0BNiR9rpBDW7PKSrTMLVlifS9am3CVc4O1Jq6GWz0o4F+sw5OSL4L3mVd56W8l6JRgghUa2KB51vOw==",
+        "resolved": "10.0.10",
+        "contentHash": "N1w5H7uK6gCTnCBZAWzE0/EQYSPysij/uYwDqntqBVvBa6bjMmBKitsnEFd6yh/SX3wLm67nO6+OnZ84K+gZWg==",
         "dependencies": {
-          "Microsoft.Extensions.Caching.Abstractions": "10.0.0",
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.0",
-          "Microsoft.Extensions.Logging.Abstractions": "10.0.0",
-          "Microsoft.Extensions.Options": "10.0.0",
-          "Microsoft.Extensions.Primitives": "10.0.0"
+          "Microsoft.Extensions.Caching.Abstractions": "10.0.10",
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.10",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.10",
+          "Microsoft.Extensions.Options": "10.0.10",
+          "Microsoft.Extensions.Primitives": "10.0.10"
         }
       },
       "Microsoft.Extensions.Configuration": {
@@ -339,16 +370,16 @@
       },
       "Microsoft.Extensions.DependencyInjection": {
         "type": "Transitive",
-        "resolved": "10.0.0",
-        "contentHash": "f0RBabswJq+gRu5a+hWIobrLWiUYPKMhCD9WO3sYBAdSy3FFH14LMvLVFZc2kPSCimBLxSuitUhsd6tb0TAY6A==",
+        "resolved": "10.0.10",
+        "contentHash": "ANyvsgkNBRvcJh2XLgn8veGmajf+8m0AbKK+HPWdRL1yraSNVVSmQhFntLtdz/C795jxqqup+k05cs/3jZQPOA==",
         "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.0"
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.10"
         }
       },
       "Microsoft.Extensions.DependencyInjection.Abstractions": {
         "type": "Transitive",
-        "resolved": "10.0.7",
-        "contentHash": "Z6mfFEaFcwCfSboxJwOLfu7/31npCY9q70WUamHW/vRQhDvBKOT4Vf9YkZj5J6hLvJpb0oDEYfHunQZj0xxvKw=="
+        "resolved": "10.0.10",
+        "contentHash": "z/2xXlFw2aLGjHyEm6E0tQ+In6VfzQzTrtArbQ2c0TQE16ZbyDCMGPvaUT9I0s8rgy9sRWlU2P9waW37qV04qA=="
       },
       "Microsoft.Extensions.Diagnostics": {
         "type": "Transitive",
@@ -440,12 +471,12 @@
       },
       "Microsoft.Extensions.Logging": {
         "type": "Transitive",
-        "resolved": "10.0.0",
-        "contentHash": "BStFkd5CcnEtarlcgYDBcFzGYCuuNMzPs02wN3WBsOFoYIEmYoUdAiU+au6opzoqfTYJsMTW00AeqDdnXH2CvA==",
+        "resolved": "10.0.10",
+        "contentHash": "Tf6z5HsL0VDYRTfvsoNrTGHGheCwkTsZBA2FFh5ATJUbkAwug+FFNISJK2gjpUNemlAOoWllAK52HOWCjto3EQ==",
         "dependencies": {
-          "Microsoft.Extensions.DependencyInjection": "10.0.0",
-          "Microsoft.Extensions.Logging.Abstractions": "10.0.0",
-          "Microsoft.Extensions.Options": "10.0.0"
+          "Microsoft.Extensions.DependencyInjection": "10.0.10",
+          "Microsoft.Extensions.Logging.Abstractions": "10.0.10",
+          "Microsoft.Extensions.Options": "10.0.10"
         }
       },
       "Microsoft.Extensions.Logging.Configuration": {
@@ -516,11 +547,11 @@
       },
       "Microsoft.Extensions.Options": {
         "type": "Transitive",
-        "resolved": "10.0.0",
-        "contentHash": "8oCAgXOow5XDrY9HaXX1QmH3ORsyZO/ANVHBlhLyCeWTH5Sg4UuqZeOTWJi6484M+LqSx0RqQXDJtdYy2BNiLQ==",
+        "resolved": "10.0.10",
+        "contentHash": "srnhnk7nE8krBiIXp71LvBmKBtraBONWSRzdjJgRv1Ko9Mp8IVNqv4vIS9hGeVteBig8aQkva9ZG+sC+o5sVcA==",
         "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.0",
-          "Microsoft.Extensions.Primitives": "10.0.0"
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.10",
+          "Microsoft.Extensions.Primitives": "10.0.10"
         }
       },
       "Microsoft.Extensions.Options.ConfigurationExtensions": {
@@ -537,8 +568,8 @@
       },
       "Microsoft.Extensions.Primitives": {
         "type": "Transitive",
-        "resolved": "10.0.0",
-        "contentHash": "inRnbpCS0nwO/RuoZIAqxQUuyjaknOOnCEZB55KSMMjRhl0RQDttSmLSGsUJN3RQ3ocf5NDLFd2mOQViHqMK5w=="
+        "resolved": "10.0.10",
+        "contentHash": "5wu/GrYVd8mG2DVUw3vFJzF+O336TyTGg/Kmcgw9bfwYhCoFiV5lR5QeEmKecJyrW4W54nMfD3p3589E8a7czQ=="
       },
       "Microsoft.TestPlatform.ObjectModel": {
         "type": "Transitive",
@@ -736,10 +767,10 @@
       "Microsoft.Extensions.Logging.Abstractions": {
         "type": "CentralTransitive",
         "requested": "[10.0.7, )",
-        "resolved": "10.0.7",
-        "contentHash": "tIEcQ2gvERrH2KiCjdsVcHGhXt9lIsuDStfOIeZWr7/fP8IXhGiYfx0/80PNI7WPO2IYuFtlZLSlnTS8+/Mchw==",
+        "resolved": "10.0.10",
+        "contentHash": "zkFxGYUvdxAvIKTyXHrmW+Sux53D4SezD9dMyZ6hrwwzPQJNuwCRy1f5W7AvYTqacEGhWF2XderRQG1OvbV8og==",
         "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.7"
+          "Microsoft.Extensions.DependencyInjection.Abstractions": "10.0.10"
         }
       },
       "WolverineFx": {

--- a/tests/Unifesspa.UniPlus.Publicacoes.IntegrationTests/TiposAtoPublicado/CriarTipoAtoPublicadoCorridaTests.cs
+++ b/tests/Unifesspa.UniPlus.Publicacoes.IntegrationTests/TiposAtoPublicado/CriarTipoAtoPublicadoCorridaTests.cs
@@ -67,6 +67,40 @@ public sealed class CriarTipoAtoPublicadoCorridaTests
         segunda.Error!.Code.Should().Be(TipoAtoPublicadoErrorCodes.VigenciaSobreposta);
     }
 
+    [Fact(DisplayName =
+        "Após o conflito capturado, descartar o rastreamento evita a segunda exceção do SaveChanges do outbox")]
+    public async Task Handle_AposConflito_DescartarRastreamentoEvitaSegundaExcecao()
+    {
+        // Reproduz o mesmo achado da ADR-0119 (issue #1027/PR #1019), agora para a
+        // exclusion constraint de vigência de Publicações: o outbox do Wolverine
+        // (AutoApplyTransactions, ADR-0004) chama SaveChangesAsync no MESMO
+        // DbContext DEPOIS que o handler retorna. Se o handler capturar a
+        // violação e devolver a falha sem descartar o rastreamento da entidade
+        // Added da tentativa fracassada, essa segunda chamada tenta gravar a
+        // MESMA entidade de novo e a mesma exceção estoura fora do catch do
+        // handler — 500 em vez do DomainError já traduzido.
+        string codigo = CodigoUnico();
+
+        await using PublicacoesDbContext ctx = _fixture.CreateDbContext("admin");
+        var real = new TipoAtoPublicadoRepository(ctx, TimeProvider.System);
+        (await CriarTipoAtoPublicadoCommandHandler.Handle(Comando(codigo), real, ctx, CancellationToken.None))
+            .IsSuccess.Should().BeTrue();
+
+        await using PublicacoesDbContext ctx2 = _fixture.CreateDbContext("admin");
+        var cego = new RepositorioComConsultaObsoleta(new TipoAtoPublicadoRepository(ctx2, TimeProvider.System));
+
+        Result<Guid> segunda = await CriarTipoAtoPublicadoCommandHandler.Handle(
+            Comando(codigo), cego, ctx2, CancellationToken.None);
+        segunda.IsFailure.Should().BeTrue();
+
+        // O handler (via unitOfWork.DescartarAlteracoesNaoSalvas() no catch) já
+        // limpou o rastreamento de ctx2 — o SaveChangesAsync automático do
+        // outbox, chamado DEPOIS que o handler já retornou a falha, é um no-op
+        // e não relança a exceção.
+        Func<Task> segundoSave = async () => await ctx2.SaveChangesAsync();
+        await segundoSave.Should().NotThrowAsync();
+    }
+
     [Fact(DisplayName = "Sem corrida, a consulta prévia recusa antes de tocar o banco")]
     public async Task Handle_ComSobreposicaoConhecida_RecusaPelaConsultaPrevia()
     {


### PR DESCRIPTION
## Contexto

`CriarTipoAtoPublicadoCommandHandler` e `AtualizarTipoAtoPublicadoCommandHandler` (módulo Publicações) capturam a violação da exclusion constraint `ex_tipo_ato_publicado_codigo_vigencia` (Postgres, `DEFERRABLE INITIALLY IMMEDIATE` — checada dentro do próprio `SaveChangesAsync` do handler) e devolvem `VigenciaSobreposta` em vez de deixar a exceção escapar como 500.

O catch não chamava `ChangeTracker.Clear()` antes de retornar a falha. As entidades que tentaram ser persistidas continuavam rastreadas pelo EF Core; o `SaveChangesAsync` automático do outbox (ADR-0004, `AutoApplyTransactions`) tentava salvar de novo ao final do pipeline Wolverine e relançava a MESMA exceção, agora fora do catch do handler — virando 500 mesmo o handler tendo "tratado" o erro.

Mesma lacuna original do PR #1019 (Termo de Consentimento), corrigida para o branch de `DbUpdateConcurrencyException` (xmin) no PR #1030 (ADR-0119), mas deliberadamente não estendida na época — esse achado é objeto da issue #1029, aberta durante a investigação da ADR-0119. A exclusion constraint deste PR (`DEFERRABLE INITIALLY IMMEDIATE`) é estruturalmente diferente do caso `xmin`, mas a mesma técnica de correção se aplica: `ChangeTracker.Clear()` descarta o rastreamento das entidades que falharam antes do outbox tentar salvar de novo.

## O que muda

- `IPublicacoesUnitOfWork` ganha `DescartarAlteracoesNaoSalvas()`, implementado em `PublicacoesDbContext` como `ChangeTracker.Clear()` — mesmo padrão já estabelecido em `IConfiguracaoUnitOfWork`.
- Os dois handlers (`Criar` e `Atualizar`) chamam `unitOfWork.DescartarAlteracoesNaoSalvas()` no catch da colisão de exclusion constraint, antes de retornar a falha de domínio.
- Testes unitários (mock de `DbUpdateException`/`PostgresException` via `PostgresExceptionFactory`) provam a chamada ao método de descarte.
- Teste de integração de corrida real contra Postgres (`CriarTipoAtoPublicadoCorridaTests`) prova que, após o conflito capturado, um segundo `SaveChangesAsync` (simulando o flush automático do outbox) não relança.

Closes #1029

## Teste

- `dotnet test` local: suíte completa de Publicações (133 integração + 91 application + 67 domínio) verde, incluindo os novos testes.
- `dotnet format --verify-no-changes` limpo.
