### PR TITLE
docs(adr): confirma que exclusion constraint DEFERRED não precisa de ChangeTracker.Clear()

### DIFF
--- a/docs/adrs/0119-padrao-concorrencia-otimista-handlers-wolverine.md
+++ b/docs/adrs/0119-padrao-concorrencia-otimista-handlers-wolverine.md
@@ -79,7 +79,7 @@ desse achado — issue #1027).
 - **Endpoint SEM `[RequiresIdempotencyKey]`** (ex.: `DELETE`, naturalmente idempotente por semântica HTTP, como os dois handlers `Remover` migrados nesta ADR): o handler **não captura** `DbUpdateConcurrencyException` — deixa propagar. O `GlobalExceptionMiddleware` (`Infrastructure.Core/Middleware/GlobalExceptionMiddleware.cs`) mapeia centralmente para `409 Conflict`, `code=uniplus.concorrencia.conflito`, um único branch para todo o monólito modular.
 - **Endpoint COM `[RequiresIdempotencyKey]`**: o handler **continua capturando** `DbUpdateConcurrencyException` localmente e chamando `unitOfWork.DescartarAlteracoesNaoSalvas()` (`ChangeTracker.Clear()`) antes de devolver `Result.Failure` — o padrão do PR #1019, mantido explicitamente enquanto o gap do `IdempotencyFilter` não for corrigido.
 - **Escopo restrito ao caminho síncrono HTTP request/reply.** Um handler Wolverine invocado por consumidor durável/background (sem `HttpContext`, fora do `GlobalExceptionMiddleware`) segue as políticas de retry/dead-letter do próprio Wolverine quando lança — comportamento correto para esse contexto, não coberto por esta ADR.
-- **Fora do escopo desta ADR:** a exclusion constraint `DEFERRABLE INITIALLY DEFERRED` de `MarcarVigenteCalendarioDiasUteisCommandHandler` (`ex_calendario_dias_uteis_vigente_unico`). Diferente de `DbUpdateConcurrencyException`, essa violação chega como `Npgsql.PostgresException` bruta no `COMMIT` externo do outbox — mecanismo distinto (transação Postgres abortada, não apenas `ChangeTracker` desatualizado) que não foi empiricamente verificado nesta investigação. Esse handler mantém o catch local sem `ChangeTracker.Clear()` (débito pré-existente, não deste PR) até investigação própria — rastreado em `uniplus-api#1032`.
+- **Investigado por emenda (issue #1032):** a exclusion constraint `DEFERRABLE INITIALLY DEFERRED` de `MarcarVigenteCalendarioDiasUteisCommandHandler` (`ex_calendario_dias_uteis_vigente_unico`) — ver "Emenda (issue #1032)" abaixo. Conclusão: nenhuma mudança de código foi necessária para esse handler no shape atual.
 
 Handlers migrados nesta ADR: `RemoverTermoConsentimentoCommandHandler` e
 `RemoverCalendarioDiasUteisCommandHandler` — ambos atrás de endpoints `DELETE` sem
@@ -155,6 +155,49 @@ código — ver nota nos arquivos de teste):
 - Bom, porque não introduz a regressão de B nem mantém 100% do débito de A.
 - Ruim, porque exige que quem escreve o handler saiba qual padrão usar — mitigado por
   documentação no `CLAUDE.md`.
+
+## Emenda (issue #1032)
+
+Investigação empírica, via teste de corrida real contra Postgres
+(`MarcarVigenteExclusionConstraintConcorrenciaTests`), do mecanismo deixado em
+aberto acima: duas ativações concorrentes de `MarcarVigenteCalendarioDiasUteisCommand`
+para calendários **diferentes** (sem xmin em comum — nenhuma das duas toca a mesma
+linha, já que nenhum calendário está vigente no estado committado quando as duas
+começam) forçadas a colidir na exclusion constraint via `SET CONSTRAINTS ALL IMMEDIATE`
+(`ForcarChecagemImediataDeConstraintsAsync`).
+
+**Achado:** diferente do caso `xmin`, aqui a violação NÃO acontece dentro do
+`SaveChangesAsync()` do handler — acontece num comando separado
+(`ExecuteSqlRawAsync("SET CONSTRAINTS ALL IMMEDIATE")`) executado DEPOIS que
+`SalvarAlteracoesAsync()` já teve sucesso e o EF Core já resetou o `ChangeTracker`
+para `Unchanged`. Não sobra, portanto, nenhuma entidade `Added`/`Modified` pendente
+para o `SaveChangesAsync` automático do outbox reprocessar — a causa raiz que o
+`ChangeTracker.Clear()` resolve no caso `xmin` (entidades ainda rastreadas de uma
+tentativa fracassada) simplesmente não existe aqui; `ChangeTracker.Clear()` seria um
+no-op neste ponto.
+
+O comando que falha (`SET CONSTRAINTS ALL IMMEDIATE`) deixa a transação Postgres
+subjacente em estado abortado — mas esse handler não emite domain events/mensagens
+cascateadas em nenhum branch (`Task<Result>` puro, nunca `Task<(Result,
+IEnumerable<object>)>`), então o único comando que o outbox do Wolverine ainda
+precisa emitir depois que o handler retorna é o `COMMIT` da transação ambiente —
+sem nenhum `INSERT` de envelope pelo meio. Um `COMMIT` contra uma transação Postgres
+já abortada é tratado pelo próprio protocolo como um `ROLLBACK` implícito, sem erro
+adicional (comportamento documentado do Postgres, não específico deste código) — é
+esse mecanismo, não `ChangeTracker.Clear()`, que evita o vazamento fora do catch:
+o `Result.Failure` do handler chega limpo ao chamador, e a escrita não commitada de
+`SalvarAlteracoesAsync()` é descartada junto com o resto da transação abortada.
+
+**Conclusão:** nenhuma mudança de código foi necessária em
+`MarcarVigenteCalendarioDiasUteisCommandHandler` — o catch atual, mesmo sem
+`ChangeTracker.Clear()`, já produz o resultado correto para este handler no shape
+atual. **Risco condicional documentado:** se este handler (ou qualquer handler que
+use o padrão `ForcarChecagemImediataDeConstraintsAsync`) passar a emitir domain
+events também no caminho de falha, a proteção do "`COMMIT` vira `ROLLBACK`" deixa de
+bastar — o outbox precisaria fazer um `INSERT` de envelope dentro da transação já
+abortada, o que falharia com `25P02` fora de qualquer `catch` do handler. Nesse caso,
+o handler precisaria descartar a transação explicitamente antes de retornar, não só
+o `ChangeTracker`.
 
 ## Mais informações
 

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/CalendariosDiasUteis/MarcarVigenteCalendarioDiasUteisCommandHandler.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Commands/CalendariosDiasUteis/MarcarVigenteCalendarioDiasUteisCommandHandler.cs
@@ -62,13 +62,24 @@ public static class MarcarVigenteCalendarioDiasUteisCommandHandler
         {
             // Corrida entre duas ativações concorrentes: exclusion constraint,
             // dois registros disputando o mesmo "vigente = true". Diferente de
-            // DbUpdateConcurrencyException (xmin, tratado no catch abaixo), essa
-            // violação chega DEFERRED, no COMMIT que o outbox do Wolverine
-            // executa fora deste handler (ADR-0004) — mecanismo não coberto pela
-            // investigação empírica da ADR-0119, então este branch mantém o
-            // catch local sem `ChangeTracker.Clear()` como débito pré-existente
-            // rastreado à parte (a checagem imediata acima só antecipa QUANDO a
-            // violação aparece, não muda o mecanismo em si).
+            // DbUpdateConcurrencyException (xmin, tratado no catch abaixo), a
+            // violação aqui acontece no ExecuteSqlRawAsync da checagem forçada
+            // acima, DEPOIS que SalvarAlteracoesAsync já teve sucesso e o
+            // ChangeTracker já foi resetado — não sobra entidade Added/Modified
+            // pendente para o SaveChangesAsync automático do outbox reprocessar,
+            // então ChangeTracker.Clear() seria um no-op aqui (investigação
+            // empírica da emenda à ADR-0119, issue #1032). O que evita o
+            // vazamento fora deste catch é a transação Postgres ter sido deixada
+            // abortada pelo comando que falhou: o único comando que o outbox
+            // ainda precisa emitir depois que este handler retorna (este
+            // handler não emite domain events em nenhum branch) é o COMMIT da
+            // transação ambiente, e um COMMIT contra transação já abortada é
+            // tratado pelo protocolo Postgres como ROLLBACK implícito, sem erro
+            // adicional — descarta a escrita não commitada junto com o resto.
+            // Se este handler um dia passar a emitir domain events também no
+            // caminho de falha, essa proteção deixa de bastar (o outbox
+            // precisaria inserir um envelope DENTRO da transação abortada, o
+            // que falharia com 25P02 fora de qualquer catch).
             return Result.Failure(new DomainError(
                 CalendarioDiasUteisErrorCodes.ConflitoDeConcorrencia,
                 "Outra alteração concorrente já marcou um dataset como vigente. Tente novamente."));

--- a/tests/Unifesspa.UniPlus.Configuracao.IntegrationTests/CalendariosDiasUteis/MarcarVigenteExclusionConstraintConcorrenciaTests.cs
+++ b/tests/Unifesspa.UniPlus.Configuracao.IntegrationTests/CalendariosDiasUteis/MarcarVigenteExclusionConstraintConcorrenciaTests.cs
@@ -79,6 +79,18 @@ public sealed class MarcarVigenteExclusionConstraintConcorrenciaTests
         await using (AsyncServiceScope setupScope = api.Services.CreateAsyncScope())
         {
             ConfiguracaoDbContext db = setupScope.ServiceProvider.GetRequiredService<ConfiguracaoDbContext>();
+
+            // ConfiguracaoEndpointFixture é compartilhado por toda a
+            // ConfiguracaoEndpointCollection — outro teste da mesma collection
+            // (ex.: CalendarioDiasUteisEndpointTests.MarcarVigente_DesmarcaOAnterior)
+            // pode ter deixado um terceiro calendário vigente=true para trás.
+            // Sem desmarcá-lo aqui, o handler de A leria ESSE terceiro registro
+            // como vigenteAnterior e tentaria demarcá-lo dentro da própria
+            // transação — um xmin extra fora do controle deste teste, alheio à
+            // corrida A-vs-B que ele quer provar.
+            await db.Database.ExecuteSqlInterpolatedAsync(
+                $"UPDATE configuracao.calendario_dias_uteis SET vigente = false WHERE vigente = true");
+
             CalendarioDiasUteis calendarioA = CalendarioDiasUteis.Criar(
                 $"exc-a-{Guid.NewGuid():N}"[..20],
                 [new DiaNaoUtilCriacao("NACIONAL", null, new DateOnly(2099, 1, 1), "Ano novo")]).Value!;

--- a/tests/Unifesspa.UniPlus.Configuracao.IntegrationTests/CalendariosDiasUteis/MarcarVigenteExclusionConstraintConcorrenciaTests.cs
+++ b/tests/Unifesspa.UniPlus.Configuracao.IntegrationTests/CalendariosDiasUteis/MarcarVigenteExclusionConstraintConcorrenciaTests.cs
@@ -91,16 +91,16 @@ public sealed class MarcarVigenteExclusionConstraintConcorrenciaTests
             await db.Database.ExecuteSqlInterpolatedAsync(
                 $"UPDATE configuracao.calendario_dias_uteis SET vigente = false WHERE vigente = true");
 
-            CalendarioDiasUteis calendarioA = CalendarioDiasUteis.Criar(
+            CalendarioDiasUteis calendarA = CalendarioDiasUteis.Criar(
                 $"exc-a-{Guid.NewGuid():N}"[..20],
                 [new DiaNaoUtilCriacao("NACIONAL", null, new DateOnly(2099, 1, 1), "Ano novo")]).Value!;
-            CalendarioDiasUteis calendarioB = CalendarioDiasUteis.Criar(
+            CalendarioDiasUteis calendarB = CalendarioDiasUteis.Criar(
                 $"exc-b-{Guid.NewGuid():N}"[..20],
                 [new DiaNaoUtilCriacao("NACIONAL", null, new DateOnly(2099, 1, 1), "Ano novo")]).Value!;
-            db.CalendariosDiasUteis.AddRange(calendarioA, calendarioB);
+            db.CalendariosDiasUteis.AddRange(calendarA, calendarB);
             await db.SaveChangesAsync();
-            idA = calendarioA.Id;
-            idB = calendarioB.Id;
+            idA = calendarA.Id;
+            idB = calendarB.Id;
         }
 
         // txB: marca B como vigente via UPDATE cru, sem commitar — nenhum calendário
@@ -121,15 +121,15 @@ public sealed class MarcarVigenteExclusionConstraintConcorrenciaTests
         // tempo. Diferente do teste de xmin, o texto da query bloqueada não contém o
         // nome da tabela (é o comando SET CONSTRAINTS em si), por isso o filtro é por
         // esse texto, não pela tabela.
-        await AguardarChecagemDeConstraintBloqueadaAsync(api, taskA);
+        await WaitForConstraintCheckToBlockAsync(api, taskA);
 
         await txB.CommitAsync();
 
-        Result resultado = await taskA;
+        Result result = await taskA;
 
         // Registra o resultado observado para orientar a decisão de fix — o valor
         // desta asserção é DOCUMENTAR o comportamento real, não presumi-lo.
-        resultado.IsFailure.Should().BeTrue(
+        result.IsFailure.Should().BeTrue(
             "as duas linhas (A e B) ficaram vigente=true simultaneamente assim que txB commitou — " +
             "a exclusion constraint deve ter estourado dentro do próprio catch do handler");
 
@@ -144,29 +144,29 @@ public sealed class MarcarVigenteExclusionConstraintConcorrenciaTests
         // não relançou.
         await using AsyncServiceScope readScope = api.Services.CreateAsyncScope();
         ConfiguracaoDbContext readDb = readScope.ServiceProvider.GetRequiredService<ConfiguracaoDbContext>();
-        CalendarioDiasUteis persistidoA = await readDb.CalendariosDiasUteis.SingleAsync(c => c.Id == idA);
-        CalendarioDiasUteis persistidoB = await readDb.CalendariosDiasUteis.SingleAsync(c => c.Id == idB);
+        CalendarioDiasUteis persistedA = await readDb.CalendariosDiasUteis.SingleAsync(c => c.Id == idA);
+        CalendarioDiasUteis persistedB = await readDb.CalendariosDiasUteis.SingleAsync(c => c.Id == idB);
 
-        persistidoA.Vigente.Should().BeFalse(
+        persistedA.Vigente.Should().BeFalse(
             "a transação do handler de A abortou na checagem da constraint — nada dela deveria ter persistido");
-        persistidoB.Vigente.Should().BeTrue(
+        persistedB.Vigente.Should().BeTrue(
             "txB commitou isolada da corrida de A e deve refletir exatamente o que ela escreveu");
     }
 
-    private static async Task AguardarChecagemDeConstraintBloqueadaAsync(MonolitoApiFactory api, Task tarefaQueDeveriaBloquear)
+    private static async Task WaitForConstraintCheckToBlockAsync(MonolitoApiFactory api, Task taskExpectedToBlock)
     {
         await using AsyncServiceScope pollScope = api.Services.CreateAsyncScope();
         ConfiguracaoDbContext pollDb = pollScope.ServiceProvider.GetRequiredService<ConfiguracaoDbContext>();
 
-        DateTimeOffset prazo = DateTimeOffset.UtcNow.AddSeconds(5);
-        while (DateTimeOffset.UtcNow < prazo)
+        DateTimeOffset deadline = DateTimeOffset.UtcNow.AddSeconds(5);
+        while (DateTimeOffset.UtcNow < deadline)
         {
-            if (tarefaQueDeveriaBloquear.IsCompleted)
+            if (taskExpectedToBlock.IsCompleted)
             {
                 Assert.Fail("A tarefa completou antes de bloquear na checagem da constraint — a corrida não foi forçada como esperado.");
             }
 
-            int backendsBloqueados = await pollDb.Database
+            int blockedBackends = await pollDb.Database
                 .SqlQuery<int>(
                     $"""
                     SELECT count(*)::int AS "Value" FROM pg_stat_activity
@@ -174,7 +174,7 @@ public sealed class MarcarVigenteExclusionConstraintConcorrenciaTests
                     """)
                 .SingleAsync();
 
-            if (backendsBloqueados > 0)
+            if (blockedBackends > 0)
             {
                 return;
             }

--- a/tests/Unifesspa.UniPlus.Configuracao.IntegrationTests/CalendariosDiasUteis/MarcarVigenteExclusionConstraintConcorrenciaTests.cs
+++ b/tests/Unifesspa.UniPlus.Configuracao.IntegrationTests/CalendariosDiasUteis/MarcarVigenteExclusionConstraintConcorrenciaTests.cs
@@ -1,0 +1,175 @@
+namespace Unifesspa.UniPlus.Configuracao.IntegrationTests.CalendariosDiasUteis;
+
+using System.Diagnostics.CodeAnalysis;
+
+using AwesomeAssertions;
+
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Storage;
+using Microsoft.Extensions.DependencyInjection;
+
+using Unifesspa.UniPlus.Configuracao.Application.Commands.CalendariosDiasUteis;
+using Unifesspa.UniPlus.Configuracao.Domain.Entities;
+using Unifesspa.UniPlus.Configuracao.Infrastructure.Persistence;
+using Unifesspa.UniPlus.Configuracao.IntegrationTests.Infrastructure;
+using Unifesspa.UniPlus.IntegrationTests.Fixtures.Hosting;
+using Unifesspa.UniPlus.Kernel.Results;
+
+using Wolverine;
+
+/// <summary>
+/// Investigação empírica da issue #1032: observa, contra Postgres real, o que
+/// acontece quando a exclusion constraint <c>ex_calendario_dias_uteis_vigente_unico</c>
+/// (<c>DEFERRABLE INITIALLY DEFERRED</c>) é violada por duas ativações concorrentes
+/// que não disputam a MESMA linha (portanto não colidem por xmin — cada uma marca
+/// um calendário DIFERENTE como vigente, e nenhuma delas tem um "vigente anterior"
+/// em comum para demarcar).
+/// </summary>
+/// <remarks>
+/// <para>A corrida é forçada de forma determinística, mesmo padrão de
+/// <c>CalendarioDiasUteisConcorrenciaTests</c>: uma transação explícita (<c>txB</c>)
+/// faz um UPDATE cru marcando o calendário B como vigente, sem commitar. O handler
+/// real (<c>busA</c>) marca o calendário A como vigente — como nenhum registro está
+/// vigente no estado COMMITADO, <c>vigenteAnterior</c> é <see langword="null"/> e o
+/// handler não toca a linha de B. O <c>SaveChangesAsync</c> do handler grava A
+/// normalmente (nenhum conflito de xmin: A e B são linhas diferentes). O handler
+/// então força a checagem da constraint DEFERRED via <c>SET CONSTRAINTS ALL
+/// IMMEDIATE</c> (<c>ForcarChecagemImediataDeConstraintsAsync</c>) — como B tem uma
+/// escrita concorrente ainda não resolvida que também tornaria a constraint
+/// potencialmente violada, o Postgres bloqueia essa checagem até <c>txB</c>
+/// terminar (mesmo mecanismo de espera por transação concorrente que unique/exclusion
+/// constraints usam para não decidir prematuramente sobre uma linha ainda em voo).</para>
+/// <para>Ao liberar <c>txB</c> com commit, a checagem de <c>busA</c> é resolvida: as
+/// duas linhas (A e B) ficam vigente=true simultaneamente e a constraint estoura
+/// dentro do próprio <c>try</c> do handler — mas via <c>Npgsql.PostgresException</c>
+/// bruta do <c>ExecuteSqlRawAsync("SET CONSTRAINTS ALL IMMEDIATE")</c>, não de
+/// <c>SaveChangesAsync</c>. Esse comando falhando marca a transação Postgres
+/// subjacente como ABORTADA — diferente do caso xmin (onde o UPDATE afetando 0
+/// linhas não aborta a transação, é só um resultado de rowcount que o EF Core
+/// interpreta como <c>DbUpdateConcurrencyException</c>). O teste observa se
+/// <c>ChangeTracker.Clear()</c> sozinho basta para o <c>SaveChangesAsync</c>
+/// automático do outbox (que roda depois que o handler retorna, ADR-0004) não
+/// relançar — ou se a transação abortada faz esse segundo SaveChanges falhar de um
+/// jeito diferente (<c>25P02</c>), o que exigiria descartar a transação inteira, não
+/// só o rastreamento do EF Core.</para>
+/// </remarks>
+[Collection(ConfiguracaoEndpointCollection.Name)]
+[Trait("Category", "Integration")]
+[SuppressMessage(
+    "Performance",
+    "CA1515:Consider making public types internal",
+    Justification = "xUnit collection fixture exige tipo de teste público.")]
+public sealed class MarcarVigenteExclusionConstraintConcorrenciaTests
+{
+    private readonly ConfiguracaoEndpointFixture _fixture;
+
+    public MarcarVigenteExclusionConstraintConcorrenciaTests(ConfiguracaoEndpointFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    [Fact(DisplayName =
+        "Duas ativações concorrentes de calendários DIFERENTES colidem na exclusion constraint DEFERRED, não por xmin")]
+    public async Task MarcarVigente_DuasAtivacoesConcorrentesDeCalendariosDiferentes_ColideNaExclusionConstraint()
+    {
+        MonolitoApiFactory api = _fixture.Factory;
+
+        Guid idA;
+        Guid idB;
+        await using (AsyncServiceScope setupScope = api.Services.CreateAsyncScope())
+        {
+            ConfiguracaoDbContext db = setupScope.ServiceProvider.GetRequiredService<ConfiguracaoDbContext>();
+            CalendarioDiasUteis calendarioA = CalendarioDiasUteis.Criar(
+                $"exc-a-{Guid.NewGuid():N}"[..20],
+                [new DiaNaoUtilCriacao("NACIONAL", null, new DateOnly(2099, 1, 1), "Ano novo")]).Value!;
+            CalendarioDiasUteis calendarioB = CalendarioDiasUteis.Criar(
+                $"exc-b-{Guid.NewGuid():N}"[..20],
+                [new DiaNaoUtilCriacao("NACIONAL", null, new DateOnly(2099, 1, 1), "Ano novo")]).Value!;
+            db.CalendariosDiasUteis.AddRange(calendarioA, calendarioB);
+            await db.SaveChangesAsync();
+            idA = calendarioA.Id;
+            idB = calendarioB.Id;
+        }
+
+        // txB: marca B como vigente via UPDATE cru, sem commitar — nenhum calendário
+        // fica vigente=true no estado COMMITADO enquanto txB está aberta, então o
+        // handler de A não vê "vigenteAnterior" nenhum e não toca a linha de B.
+        await using AsyncServiceScope scopeB = api.Services.CreateAsyncScope();
+        ConfiguracaoDbContext dbB = scopeB.ServiceProvider.GetRequiredService<ConfiguracaoDbContext>();
+        await using IDbContextTransaction txB = await dbB.Database.BeginTransactionAsync();
+        await dbB.Database.ExecuteSqlInterpolatedAsync(
+            $"UPDATE configuracao.calendario_dias_uteis SET vigente = true WHERE id = {idB}");
+
+        await using AsyncServiceScope scopeA = api.Services.CreateAsyncScope();
+        IMessageBus busA = scopeA.ServiceProvider.GetRequiredService<IMessageBus>();
+        Task<Result> taskA = busA.InvokeAsync<Result>(new MarcarVigenteCalendarioDiasUteisCommand(idA));
+
+        // Prova direta de que a checagem forçada (SET CONSTRAINTS ALL IMMEDIATE) do
+        // handler de A está bloqueada esperando txB resolver — não uma aposta de
+        // tempo. Diferente do teste de xmin, o texto da query bloqueada não contém o
+        // nome da tabela (é o comando SET CONSTRAINTS em si), por isso o filtro é por
+        // esse texto, não pela tabela.
+        await AguardarChecagemDeConstraintBloqueadaAsync(api, taskA);
+
+        await txB.CommitAsync();
+
+        Result resultado = await taskA;
+
+        // Registra o resultado observado para orientar a decisão de fix — o valor
+        // desta asserção é DOCUMENTAR o comportamento real, não presumi-lo.
+        resultado.IsFailure.Should().BeTrue(
+            "as duas linhas (A e B) ficaram vigente=true simultaneamente assim que txB commitou — " +
+            "a exclusion constraint deve ter estourado dentro do próprio catch do handler");
+
+        // Comportamento crítico sob investigação: o SaveChangesAsync automático do
+        // outbox do Wolverine roda LOGO APÓS o handler retornar, na MESMA
+        // transação/DbContext (ADR-0004). Se ChangeTracker.Clear() não bastar porque
+        // a transação Postgres ficou ABORTADA pelo "SET CONSTRAINTS ALL IMMEDIATE"
+        // que falhou, esse SaveChangesAsync automático relança — e como ele roda FORA
+        // de qualquer catch do handler, vira 500 em vez do 409 que o handler já
+        // decidiu. `taskA` já awaitou o ciclo completo do Wolverine (incluindo o
+        // outbox); chegar aqui sem exceção não capturada é a prova de que o outbox
+        // não relançou.
+        await using AsyncServiceScope readScope = api.Services.CreateAsyncScope();
+        ConfiguracaoDbContext readDb = readScope.ServiceProvider.GetRequiredService<ConfiguracaoDbContext>();
+        CalendarioDiasUteis persistidoA = await readDb.CalendariosDiasUteis.SingleAsync(c => c.Id == idA);
+        CalendarioDiasUteis persistidoB = await readDb.CalendariosDiasUteis.SingleAsync(c => c.Id == idB);
+
+        persistidoA.Vigente.Should().BeFalse(
+            "a transação do handler de A abortou na checagem da constraint — nada dela deveria ter persistido");
+        persistidoB.Vigente.Should().BeTrue(
+            "txB commitou isolada da corrida de A e deve refletir exatamente o que ela escreveu");
+    }
+
+    private static async Task AguardarChecagemDeConstraintBloqueadaAsync(MonolitoApiFactory api, Task tarefaQueDeveriaBloquear)
+    {
+        await using AsyncServiceScope pollScope = api.Services.CreateAsyncScope();
+        ConfiguracaoDbContext pollDb = pollScope.ServiceProvider.GetRequiredService<ConfiguracaoDbContext>();
+
+        DateTimeOffset prazo = DateTimeOffset.UtcNow.AddSeconds(5);
+        while (DateTimeOffset.UtcNow < prazo)
+        {
+            if (tarefaQueDeveriaBloquear.IsCompleted)
+            {
+                Assert.Fail("A tarefa completou antes de bloquear na checagem da constraint — a corrida não foi forçada como esperado.");
+            }
+
+            int backendsBloqueados = await pollDb.Database
+                .SqlQuery<int>(
+                    $"""
+                    SELECT count(*)::int AS "Value" FROM pg_stat_activity
+                    WHERE wait_event_type = 'Lock' AND query ILIKE '%SET CONSTRAINTS%'
+                    """)
+                .SingleAsync();
+
+            if (backendsBloqueados > 0)
+            {
+                return;
+            }
+
+            await Task.Delay(20);
+        }
+
+        Assert.Fail("Nenhum backend ficou bloqueado na checagem da constraint dentro do prazo — a corrida não foi forçada.");
+    }
+}


### PR DESCRIPTION
## Contexto

`MarcarVigenteCalendarioDiasUteisCommandHandler` captura a violação da exclusion constraint `ex_calendario_dias_uteis_vigente_unico` (`DEFERRABLE INITIALLY DEFERRED`, forçada a checar imediatamente via `SET CONSTRAINTS ALL IMMEDIATE`) sem chamar `ChangeTracker.Clear()` antes de devolver a falha — mesma lacuna aparente do padrão corrigido na ADR-0119 (PR #1030) para o caso `DbUpdateConcurrencyException` (xmin), mas deliberadamente deixada fora do escopo daquela ADR por ser um mecanismo estruturalmente diferente (transação abortada, não apenas `ChangeTracker` desatualizado) — issue #1032.

## Investigação

Escrevi um teste de corrida real contra Postgres (`MarcarVigenteExclusionConstraintConcorrenciaTests`) que força duas ativações concorrentes de `MarcarVigenteCalendarioDiasUteisCommand` para calendários **diferentes** — sem xmin em comum, já que nenhum dos dois toca a mesma linha (nenhum calendário está vigente no estado committado quando as duas ativações começam) — a colidir genuinamente na exclusion constraint.

**Achado, documentado na emenda à ADR-0119:** diferente do caso xmin, a violação aqui acontece num comando SEPARADO (`ExecuteSqlRawAsync("SET CONSTRAINTS ALL IMMEDIATE")`), executado DEPOIS que `SalvarAlteracoesAsync()` já teve sucesso e o EF Core já resetou o `ChangeTracker` para `Unchanged`. Não sobra nenhuma entidade `Added`/`Modified` pendente para o `SaveChangesAsync` automático do outbox reprocessar — `ChangeTracker.Clear()` seria um no-op nesse ponto. O comando que falha deixa a transação Postgres abortada, mas como o handler não emite domain events em nenhum branch, o único comando que o outbox ainda precisa emitir é o `COMMIT` da transação ambiente — e um `COMMIT` contra transação já abortada é tratado pelo protocolo Postgres como `ROLLBACK` implícito, sem erro adicional. É esse mecanismo, não `ChangeTracker.Clear()`, que evita o vazamento fora do catch.

**Conclusão: nenhuma mudança de comportamento foi necessária.** O catch atual já produz o resultado correto. Risco condicional documentado na ADR: se este handler (ou qualquer handler que use `ForcarChecagemImediataDeConstraintsAsync`) passar a emitir domain events também no caminho de falha, essa proteção deixa de bastar.

Closes #1032

## O que muda

- Teste de regressão novo (`MarcarVigenteExclusionConstraintConcorrenciaTests`), estável em execuções repetidas (3x local), provando o mecanismo contra Postgres real.
- Emenda à ADR-0119 documentando a investigação e a conclusão.
- Comentário do catch atualizado no handler — de "débito pré-existente" para a explicação do mecanismo, sem mudança de comportamento.

## Teste

- `dotnet test` local: suíte completa de Configuração (306 integração + 360 application + 586 domínio) verde, incluindo o novo teste (rodado isoladamente 3x para confirmar estabilidade).
- `dotnet format --verify-no-changes` limpo.
