### PR TITLE
test(configuracao): identifica backend bloqueado por PID, não texto de query

### DIFF
--- a/tests/Unifesspa.UniPlus.Configuracao.IntegrationTests/CalendariosDiasUteis/CalendarioDiasUteisConcorrenciaTests.cs
+++ b/tests/Unifesspa.UniPlus.Configuracao.IntegrationTests/CalendariosDiasUteis/CalendarioDiasUteisConcorrenciaTests.cs
@@ -84,16 +84,18 @@ public sealed class CalendarioDiasUteisConcorrenciaTests
         // aqui até txB liberar.
         await dbB.Database.ExecuteSqlInterpolatedAsync(
             $"UPDATE configuracao.calendario_dias_uteis SET updated_at = now() WHERE id = {id}");
+        int pidDbB = await ConcorrenciaTestHelpers.ObterPidDaConexaoAsync(dbB);
 
         await using AsyncServiceScope scopeA = api.Services.CreateAsyncScope();
         IMessageBus busA = scopeA.ServiceProvider.GetRequiredService<IMessageBus>();
         Task<Result> taskA = busA.InvokeAsync<Result>(new RemoverCalendarioDiasUteisCommand(id));
 
         // Prova direta (não uma aposta de tempo) de que busA já leu o xmin
-        // antigo e está bloqueado tentando escrever: poll em pg_locks até
-        // aparecer um lock NÃO concedido na tabela — só existe se alguém além
-        // de txB está esperando a linha.
-        await ConcorrenciaTestHelpers.AguardarLockPendenteAsync(api, "calendario_dias_uteis", taskA);
+        // antigo e está bloqueado tentando escrever: poll em pg_stat_activity
+        // até aparecer um backend em wait_event_type='Lock' que não é nem a
+        // conexão de poll nem dbB (issue #1031 — identificação por PID, não
+        // por texto de query).
+        await ConcorrenciaTestHelpers.AguardarBackendBloqueadoAsync(api, taskA, [pidDbB]);
 
         await txB.CommitAsync();
 

--- a/tests/Unifesspa.UniPlus.Configuracao.IntegrationTests/CalendariosDiasUteis/CalendarioDiasUteisConcorrenciaTests.cs
+++ b/tests/Unifesspa.UniPlus.Configuracao.IntegrationTests/CalendariosDiasUteis/CalendarioDiasUteisConcorrenciaTests.cs
@@ -84,7 +84,7 @@ public sealed class CalendarioDiasUteisConcorrenciaTests
         // aqui até txB liberar.
         await dbB.Database.ExecuteSqlInterpolatedAsync(
             $"UPDATE configuracao.calendario_dias_uteis SET updated_at = now() WHERE id = {id}");
-        int pidDbB = await ConcorrenciaTestHelpers.ObterPidDaConexaoAsync(dbB);
+        int pidDbB = await ConcorrenciaTestHelpers.GetConnectionPidAsync(dbB);
 
         await using AsyncServiceScope scopeA = api.Services.CreateAsyncScope();
         IMessageBus busA = scopeA.ServiceProvider.GetRequiredService<IMessageBus>();
@@ -95,7 +95,7 @@ public sealed class CalendarioDiasUteisConcorrenciaTests
         // até aparecer um backend em wait_event_type='Lock' que não é nem a
         // conexão de poll nem dbB (issue #1031 — identificação por PID, não
         // por texto de query).
-        await ConcorrenciaTestHelpers.AguardarBackendBloqueadoAsync(api, taskA, [pidDbB]);
+        await ConcorrenciaTestHelpers.WaitForBlockedBackendAsync(api, taskA, [pidDbB]);
 
         await txB.CommitAsync();
 

--- a/tests/Unifesspa.UniPlus.Configuracao.IntegrationTests/Infrastructure/ConcorrenciaTestHelpers.cs
+++ b/tests/Unifesspa.UniPlus.Configuracao.IntegrationTests/Infrastructure/ConcorrenciaTestHelpers.cs
@@ -25,12 +25,12 @@ using Xunit;
 /// </remarks>
 internal static class ConcorrenciaTestHelpers
 {
-    private static readonly TimeSpan PrazoPadrao = TimeSpan.FromSeconds(5);
+    private static readonly TimeSpan DefaultTimeout = TimeSpan.FromSeconds(5);
 
     /// <summary>
     /// Faz poll em <c>pg_stat_activity</c> até observar um backend com
     /// <c>wait_event_type = 'Lock'</c> que <c>pg_blocking_pids()</c> confirma
-    /// estar bloqueado especificamente por um dos <paramref name="pidsSeguradoresDoLock"/>
+    /// estar bloqueado especificamente por um dos <paramref name="lockHolderPids"/>
     /// — prova direta de que outro backend (o handler real sob teste) está
     /// esperando o lock que o chamador segura, sem depender de casar texto de
     /// query com o nome da tabela nem de simplesmente excluir PIDs conhecidos.
@@ -46,34 +46,34 @@ internal static class ConcorrenciaTestHelpers
     /// lock — não bloqueado por QUALQUER OUTRA coisa.
     /// </remarks>
     /// <param name="api">Factory da API sob teste, usada para abrir a conexão de poll.</param>
-    /// <param name="tarefaQueDeveriaBloquear">Tarefa do handler real sob teste — falha cedo se completar antes de bloquear.</param>
-    /// <param name="pidsSeguradoresDoLock">
+    /// <param name="taskExpectedToBlock">Tarefa do handler real sob teste — falha cedo se completar antes de bloquear.</param>
+    /// <param name="lockHolderPids">
     /// PID de toda conexão que o próprio chamador mantém aberta segurando o
     /// lock (ex.: a transação com o <c>UPDATE</c> ainda não commitado) —
-    /// capturado via <see cref="ObterPidDaConexaoAsync"/> ENQUANTO a conexão
+    /// capturado via <see cref="GetConnectionPidAsync"/> ENQUANTO a conexão
     /// está ociosa (nunca enquanto ela mesma está executando um comando
     /// bloqueado — a mesma conexão Npgsql não aceita um novo comando
     /// concorrente ao que já está em voo).
     /// </param>
-    /// <param name="prazo">Tempo máximo de espera; usa <see cref="PrazoPadrao"/> quando omitido.</param>
-    public static async Task AguardarBackendBloqueadoAsync(
+    /// <param name="timeout">Tempo máximo de espera; usa <see cref="DefaultTimeout"/> quando omitido.</param>
+    public static async Task WaitForBlockedBackendAsync(
         MonolitoApiFactory api,
-        Task tarefaQueDeveriaBloquear,
-        IReadOnlyCollection<int> pidsSeguradoresDoLock,
-        TimeSpan? prazo = null)
+        Task taskExpectedToBlock,
+        IReadOnlyCollection<int> lockHolderPids,
+        TimeSpan? timeout = null)
     {
         ArgumentNullException.ThrowIfNull(api);
-        ArgumentNullException.ThrowIfNull(tarefaQueDeveriaBloquear);
-        ArgumentNullException.ThrowIfNull(pidsSeguradoresDoLock);
+        ArgumentNullException.ThrowIfNull(taskExpectedToBlock);
+        ArgumentNullException.ThrowIfNull(lockHolderPids);
 
         await using AsyncServiceScope pollScope = api.Services.CreateAsyncScope();
         ConfiguracaoDbContext pollDb = pollScope.ServiceProvider.GetRequiredService<ConfiguracaoDbContext>();
-        int[] pidsHolders = [.. pidsSeguradoresDoLock];
+        int[] holderPids = [.. lockHolderPids];
 
-        DateTimeOffset limite = DateTimeOffset.UtcNow.Add(prazo ?? PrazoPadrao);
-        while (DateTimeOffset.UtcNow < limite)
+        DateTimeOffset deadline = DateTimeOffset.UtcNow.Add(timeout ?? DefaultTimeout);
+        while (DateTimeOffset.UtcNow < deadline)
         {
-            if (tarefaQueDeveriaBloquear.IsCompleted)
+            if (taskExpectedToBlock.IsCompleted)
             {
                 Assert.Fail("A tarefa completou antes de bloquear no lock — a corrida não foi forçada como esperado.");
             }
@@ -87,19 +87,19 @@ internal static class ConcorrenciaTestHelpers
             // já ter voltado ao pool do Npgsql e sido reaproveitado pelo
             // PRÓPRIO handler sob teste, excluindo exatamente o backend que
             // este método deveria encontrar (achado do Codex no PR #1036).
-            int backendsBloqueados = await pollDb.Database
+            int blockedBackends = await pollDb.Database
                 .SqlQuery<int>(
                     $"""
                     SELECT count(*)::int AS "Value" FROM pg_stat_activity psa
                     WHERE psa.wait_event_type = 'Lock'
                       AND EXISTS (
-                          SELECT 1 FROM unnest(pg_blocking_pids(psa.pid)) AS bloqueador(pid)
-                          WHERE bloqueador.pid = ANY({pidsHolders})
+                          SELECT 1 FROM unnest(pg_blocking_pids(psa.pid)) AS blocker(pid)
+                          WHERE blocker.pid = ANY({holderPids})
                       )
                     """)
                 .SingleAsync();
 
-            if (backendsBloqueados > 0)
+            if (blockedBackends > 0)
             {
                 return;
             }
@@ -111,16 +111,16 @@ internal static class ConcorrenciaTestHelpers
     }
 
     /// <summary>
-    /// PID real da conexão Postgres por trás de <paramref name="conexao"/>.
+    /// PID real da conexão Postgres por trás de <paramref name="connection"/>.
     /// Só é seguro chamar enquanto a conexão está ociosa — nunca enquanto ela
     /// mesma está executando um comando ainda em voo (ex.: bloqueada esperando
     /// um lock): o protocolo do Npgsql não aceita um novo comando concorrente
     /// ao que já está em andamento na mesma conexão.
     /// </summary>
-    public static async Task<int> ObterPidDaConexaoAsync(ConfiguracaoDbContext conexao)
+    public static async Task<int> GetConnectionPidAsync(ConfiguracaoDbContext connection)
     {
-        ArgumentNullException.ThrowIfNull(conexao);
-        return await conexao.Database
+        ArgumentNullException.ThrowIfNull(connection);
+        return await connection.Database
             .SqlQuery<int>($"""SELECT pg_backend_pid() AS "Value" """)
             .SingleAsync();
     }

--- a/tests/Unifesspa.UniPlus.Configuracao.IntegrationTests/Infrastructure/ConcorrenciaTestHelpers.cs
+++ b/tests/Unifesspa.UniPlus.Configuracao.IntegrationTests/Infrastructure/ConcorrenciaTestHelpers.cs
@@ -16,41 +16,64 @@ using Xunit;
 /// reproduzem a janela real de forma confiável sob carga (ver
 /// <c>CalendarioDiasUteisConcorrenciaTests</c>/<c>TermoConsentimentoConcorrenciaTests</c>).
 /// </summary>
+/// <remarks>
+/// A identificação por PID real da conexão bloqueada (em vez de por texto de
+/// query, issue #1031) só é confiável porque a collection que chama este
+/// helper roda com <c>DisableParallelization = true</c> (nenhum outro teste da
+/// mesma suíte roda ao mesmo tempo) e cada módulo usa seu próprio container
+/// Postgres isolado — não porque o método garanta isso por construção. O
+/// chamador ainda precisa enumerar toda conexão que ELE MESMO mantém aberta
+/// deliberadamente (ex.: a transação que segura o lock); qualquer atividade de
+/// fundo do framework (health check, etc.) que por coincidência ficasse
+/// bloqueada permaneceria fora do alcance desta proteção — cenário considerado
+/// extremamente improvável e fora de escopo, assim como já era para o texto de
+/// query antes desta issue.
+/// </remarks>
 internal static class ConcorrenciaTestHelpers
 {
+    private static readonly TimeSpan PrazoPadrao = TimeSpan.FromSeconds(5);
+
     /// <summary>
     /// Faz poll em <c>pg_stat_activity</c> até observar um backend com
-    /// <c>wait_event_type = 'Lock'</c> executando um <c>UPDATE</c> na tabela
-    /// informada — prova direta de que outro backend está bloqueado esperando
-    /// o lock que o chamador segura, em vez de inferir isso por um prazo
-    /// fixo. Um lock de escrita conflitante entre duas linhas da MESMA linha
-    /// aparece como espera por <c>transactionid</c> em <c>pg_locks</c> (não
-    /// como lock de relação não concedido — <c>RowExclusiveLock</c> na
-    /// relação é compatível consigo mesmo e fica concedido para os dois
-    /// lados), por isso <c>pg_stat_activity.wait_event_type</c> é o sinal
-    /// correto, não um join com <c>pg_class</c>. Usa uma conexão própria (não
-    /// a de quem segura o lock, que está ocupada dentro da própria transação).
+    /// <c>wait_event_type = 'Lock'</c> cujo PID não está em
+    /// <paramref name="pidsConhecidos"/> nem é o da própria conexão de poll —
+    /// prova direta de que outro backend (o handler real sob teste) está
+    /// bloqueado esperando o lock, sem depender de casar texto de query com o
+    /// nome da tabela. Isso evita o falso positivo de uma query concorrente não
+    /// relacionada que mencione a mesma tabela por coincidência (issue #1031)
+    /// — o problema do casamento por texto não era a possibilidade de haver
+    /// múltiplos backends bloqueados, e sim tratar QUALQUER um deles como prova
+    /// da corrida, mesmo quando o texto batia por acaso com algo alheio.
     /// </summary>
-    /// <remarks>
-    /// Identifica o backend bloqueado por texto da query (<c>ILIKE</c>), não
-    /// pelo PID real da conexão — seguro hoje porque a collection que chama
-    /// este helper roda com <c>DisableParallelization = true</c> (nenhum outro
-    /// teste da mesma suíte roda ao mesmo tempo) e cada módulo usa seu próprio
-    /// container Postgres isolado, não porque o método garanta isso por
-    /// construção. Tornar a identificação por PID é o objeto de acompanhamento
-    /// futuro.
-    /// </remarks>
-    public static async Task AguardarLockPendenteAsync(MonolitoApiFactory api, string tabela, Task tarefaQueDeveriaBloquear)
+    /// <param name="api">Factory da API sob teste, usada para abrir a conexão de poll.</param>
+    /// <param name="tarefaQueDeveriaBloquear">Tarefa do handler real sob teste — falha cedo se completar antes de bloquear.</param>
+    /// <param name="pidsConhecidos">
+    /// PID de toda conexão que o próprio chamador mantém aberta deliberadamente
+    /// (ex.: a transação que segura o lock de escrita) — capturado via
+    /// <see cref="ObterPidDaConexaoAsync"/> ENQUANTO a conexão está ociosa
+    /// (nunca enquanto ela mesma está executando um comando bloqueado — a
+    /// mesma conexão Npgsql não aceita um novo comando concorrente ao que já
+    /// está em voo). Excluído da checagem, para que só um backend genuinamente
+    /// alheio a essas conexões conhecidas conte como prova de bloqueio.
+    /// </param>
+    /// <param name="prazo">Tempo máximo de espera; usa <see cref="PrazoPadrao"/> quando omitido.</param>
+    public static async Task AguardarBackendBloqueadoAsync(
+        MonolitoApiFactory api,
+        Task tarefaQueDeveriaBloquear,
+        IReadOnlyCollection<int> pidsConhecidos,
+        TimeSpan? prazo = null)
     {
         ArgumentNullException.ThrowIfNull(api);
         ArgumentNullException.ThrowIfNull(tarefaQueDeveriaBloquear);
+        ArgumentNullException.ThrowIfNull(pidsConhecidos);
 
         await using AsyncServiceScope pollScope = api.Services.CreateAsyncScope();
         ConfiguracaoDbContext pollDb = pollScope.ServiceProvider.GetRequiredService<ConfiguracaoDbContext>();
-        string padraoQuery = $"%{tabela}%";
+        int pidDoPoll = await ObterPidDaConexaoAsync(pollDb);
+        int[] pidsExcluidos = [.. pidsConhecidos, pidDoPoll];
 
-        DateTimeOffset prazo = DateTimeOffset.UtcNow.AddSeconds(5);
-        while (DateTimeOffset.UtcNow < prazo)
+        DateTimeOffset limite = DateTimeOffset.UtcNow.Add(prazo ?? PrazoPadrao);
+        while (DateTimeOffset.UtcNow < limite)
         {
             if (tarefaQueDeveriaBloquear.IsCompleted)
             {
@@ -61,7 +84,8 @@ internal static class ConcorrenciaTestHelpers
                 .SqlQuery<int>(
                     $"""
                     SELECT count(*)::int AS "Value" FROM pg_stat_activity
-                    WHERE wait_event_type = 'Lock' AND query ILIKE {padraoQuery}
+                    WHERE wait_event_type = 'Lock'
+                      AND pid <> ALL({pidsExcluidos})
                     """)
                 .SingleAsync();
 
@@ -73,6 +97,21 @@ internal static class ConcorrenciaTestHelpers
             await Task.Delay(20);
         }
 
-        Assert.Fail("Nenhum backend ficou bloqueado esperando o lock dentro do prazo — a corrida não foi forçada.");
+        Assert.Fail("Nenhum backend alheio às conexões conhecidas ficou bloqueado esperando um lock dentro do prazo — a corrida não foi forçada.");
+    }
+
+    /// <summary>
+    /// PID real da conexão Postgres por trás de <paramref name="conexao"/>.
+    /// Só é seguro chamar enquanto a conexão está ociosa — nunca enquanto ela
+    /// mesma está executando um comando ainda em voo (ex.: bloqueada esperando
+    /// um lock): o protocolo do Npgsql não aceita um novo comando concorrente
+    /// ao que já está em andamento na mesma conexão.
+    /// </summary>
+    public static async Task<int> ObterPidDaConexaoAsync(ConfiguracaoDbContext conexao)
+    {
+        ArgumentNullException.ThrowIfNull(conexao);
+        return await conexao.Database
+            .SqlQuery<int>($"""SELECT pg_backend_pid() AS "Value" """)
+            .SingleAsync();
     }
 }

--- a/tests/Unifesspa.UniPlus.Configuracao.IntegrationTests/Infrastructure/ConcorrenciaTestHelpers.cs
+++ b/tests/Unifesspa.UniPlus.Configuracao.IntegrationTests/Infrastructure/ConcorrenciaTestHelpers.cs
@@ -21,13 +21,7 @@ using Xunit;
 /// query, issue #1031) só é confiável porque a collection que chama este
 /// helper roda com <c>DisableParallelization = true</c> (nenhum outro teste da
 /// mesma suíte roda ao mesmo tempo) e cada módulo usa seu próprio container
-/// Postgres isolado — não porque o método garanta isso por construção. O
-/// chamador ainda precisa enumerar toda conexão que ELE MESMO mantém aberta
-/// deliberadamente (ex.: a transação que segura o lock); qualquer atividade de
-/// fundo do framework (health check, etc.) que por coincidência ficasse
-/// bloqueada permaneceria fora do alcance desta proteção — cenário considerado
-/// extremamente improvável e fora de escopo, assim como já era para o texto de
-/// query antes desta issue.
+/// Postgres isolado — não porque o método garanta isso por construção.
 /// </remarks>
 internal static class ConcorrenciaTestHelpers
 {
@@ -35,42 +29,47 @@ internal static class ConcorrenciaTestHelpers
 
     /// <summary>
     /// Faz poll em <c>pg_stat_activity</c> até observar um backend com
-    /// <c>wait_event_type = 'Lock'</c> cujo PID não está em
-    /// <paramref name="pidsConhecidos"/> nem é o da própria conexão de poll —
-    /// prova direta de que outro backend (o handler real sob teste) está
-    /// bloqueado esperando o lock, sem depender de casar texto de query com o
-    /// nome da tabela. Isso evita o falso positivo de uma query concorrente não
-    /// relacionada que mencione a mesma tabela por coincidência (issue #1031)
-    /// — o problema do casamento por texto não era a possibilidade de haver
-    /// múltiplos backends bloqueados, e sim tratar QUALQUER um deles como prova
-    /// da corrida, mesmo quando o texto batia por acaso com algo alheio.
+    /// <c>wait_event_type = 'Lock'</c> que <c>pg_blocking_pids()</c> confirma
+    /// estar bloqueado especificamente por um dos <paramref name="pidsSeguradoresDoLock"/>
+    /// — prova direta de que outro backend (o handler real sob teste) está
+    /// esperando o lock que o chamador segura, sem depender de casar texto de
+    /// query com o nome da tabela nem de simplesmente excluir PIDs conhecidos.
     /// </summary>
+    /// <remarks>
+    /// Excluir PIDs conhecidos sozinho (versão anterior deste helper) ainda
+    /// arriscava falso positivo: qualquer backend alheio à corrida — atividade
+    /// de fundo do runtime Wolverine, por exemplo — que estivesse esperando
+    /// QUALQUER outro lock, não relacionado, também seria contado como prova.
+    /// Correlacionar via <c>pg_blocking_pids</c> (quem está bloqueando o
+    /// candidato) elimina esse risco: só conta um backend cujo bloqueador
+    /// comprovado é uma das conexões que o chamador sabe que está segurando o
+    /// lock — não bloqueado por QUALQUER OUTRA coisa.
+    /// </remarks>
     /// <param name="api">Factory da API sob teste, usada para abrir a conexão de poll.</param>
     /// <param name="tarefaQueDeveriaBloquear">Tarefa do handler real sob teste — falha cedo se completar antes de bloquear.</param>
-    /// <param name="pidsConhecidos">
-    /// PID de toda conexão que o próprio chamador mantém aberta deliberadamente
-    /// (ex.: a transação que segura o lock de escrita) — capturado via
-    /// <see cref="ObterPidDaConexaoAsync"/> ENQUANTO a conexão está ociosa
-    /// (nunca enquanto ela mesma está executando um comando bloqueado — a
-    /// mesma conexão Npgsql não aceita um novo comando concorrente ao que já
-    /// está em voo). Excluído da checagem, para que só um backend genuinamente
-    /// alheio a essas conexões conhecidas conte como prova de bloqueio.
+    /// <param name="pidsSeguradoresDoLock">
+    /// PID de toda conexão que o próprio chamador mantém aberta segurando o
+    /// lock (ex.: a transação com o <c>UPDATE</c> ainda não commitado) —
+    /// capturado via <see cref="ObterPidDaConexaoAsync"/> ENQUANTO a conexão
+    /// está ociosa (nunca enquanto ela mesma está executando um comando
+    /// bloqueado — a mesma conexão Npgsql não aceita um novo comando
+    /// concorrente ao que já está em voo).
     /// </param>
     /// <param name="prazo">Tempo máximo de espera; usa <see cref="PrazoPadrao"/> quando omitido.</param>
     public static async Task AguardarBackendBloqueadoAsync(
         MonolitoApiFactory api,
         Task tarefaQueDeveriaBloquear,
-        IReadOnlyCollection<int> pidsConhecidos,
+        IReadOnlyCollection<int> pidsSeguradoresDoLock,
         TimeSpan? prazo = null)
     {
         ArgumentNullException.ThrowIfNull(api);
         ArgumentNullException.ThrowIfNull(tarefaQueDeveriaBloquear);
-        ArgumentNullException.ThrowIfNull(pidsConhecidos);
+        ArgumentNullException.ThrowIfNull(pidsSeguradoresDoLock);
 
         await using AsyncServiceScope pollScope = api.Services.CreateAsyncScope();
         ConfiguracaoDbContext pollDb = pollScope.ServiceProvider.GetRequiredService<ConfiguracaoDbContext>();
         int pidDoPoll = await ObterPidDaConexaoAsync(pollDb);
-        int[] pidsExcluidos = [.. pidsConhecidos, pidDoPoll];
+        int[] pidsHolders = [.. pidsSeguradoresDoLock];
 
         DateTimeOffset limite = DateTimeOffset.UtcNow.Add(prazo ?? PrazoPadrao);
         while (DateTimeOffset.UtcNow < limite)
@@ -83,9 +82,13 @@ internal static class ConcorrenciaTestHelpers
             int backendsBloqueados = await pollDb.Database
                 .SqlQuery<int>(
                     $"""
-                    SELECT count(*)::int AS "Value" FROM pg_stat_activity
-                    WHERE wait_event_type = 'Lock'
-                      AND pid <> ALL({pidsExcluidos})
+                    SELECT count(*)::int AS "Value" FROM pg_stat_activity psa
+                    WHERE psa.wait_event_type = 'Lock'
+                      AND psa.pid <> {pidDoPoll}
+                      AND EXISTS (
+                          SELECT 1 FROM unnest(pg_blocking_pids(psa.pid)) AS bloqueador(pid)
+                          WHERE bloqueador.pid = ANY({pidsHolders})
+                      )
                     """)
                 .SingleAsync();
 
@@ -97,7 +100,7 @@ internal static class ConcorrenciaTestHelpers
             await Task.Delay(20);
         }
 
-        Assert.Fail("Nenhum backend alheio às conexões conhecidas ficou bloqueado esperando um lock dentro do prazo — a corrida não foi forçada.");
+        Assert.Fail("Nenhum backend bloqueado especificamente pelos seguradores do lock apareceu dentro do prazo — a corrida não foi forçada.");
     }
 
     /// <summary>

--- a/tests/Unifesspa.UniPlus.Configuracao.IntegrationTests/Infrastructure/ConcorrenciaTestHelpers.cs
+++ b/tests/Unifesspa.UniPlus.Configuracao.IntegrationTests/Infrastructure/ConcorrenciaTestHelpers.cs
@@ -68,7 +68,6 @@ internal static class ConcorrenciaTestHelpers
 
         await using AsyncServiceScope pollScope = api.Services.CreateAsyncScope();
         ConfiguracaoDbContext pollDb = pollScope.ServiceProvider.GetRequiredService<ConfiguracaoDbContext>();
-        int pidDoPoll = await ObterPidDaConexaoAsync(pollDb);
         int[] pidsHolders = [.. pidsSeguradoresDoLock];
 
         DateTimeOffset limite = DateTimeOffset.UtcNow.Add(prazo ?? PrazoPadrao);
@@ -79,12 +78,20 @@ internal static class ConcorrenciaTestHelpers
                 Assert.Fail("A tarefa completou antes de bloquear no lock — a corrida não foi forçada como esperado.");
             }
 
+            // Sem exclusão de PID da própria conexão de poll: o backend que
+            // está executando ESTA query não pode estar simultaneamente em
+            // wait_event_type='Lock' (ele está rodando, não esperando), então
+            // a exclusão seria redundante — e, pior, arriscada: o EF Core não
+            // mantém a conexão física aberta entre comandos fora de uma
+            // transação explícita, então o PID capturado antes do loop podia
+            // já ter voltado ao pool do Npgsql e sido reaproveitado pelo
+            // PRÓPRIO handler sob teste, excluindo exatamente o backend que
+            // este método deveria encontrar (achado do Codex no PR #1036).
             int backendsBloqueados = await pollDb.Database
                 .SqlQuery<int>(
                     $"""
                     SELECT count(*)::int AS "Value" FROM pg_stat_activity psa
                     WHERE psa.wait_event_type = 'Lock'
-                      AND psa.pid <> {pidDoPoll}
                       AND EXISTS (
                           SELECT 1 FROM unnest(pg_blocking_pids(psa.pid)) AS bloqueador(pid)
                           WHERE bloqueador.pid = ANY({pidsHolders})

--- a/tests/Unifesspa.UniPlus.Configuracao.IntegrationTests/Infrastructure/ConcorrenciaTestHelpersTests.cs
+++ b/tests/Unifesspa.UniPlus.Configuracao.IntegrationTests/Infrastructure/ConcorrenciaTestHelpersTests.cs
@@ -87,11 +87,16 @@ public sealed class ConcorrenciaTestHelpersTests
         // decoyBlockedTask continua bloqueado quando o `await using` de
         // txDecoyBlocked/scopeDecoyBlocked começar a descartar a conexão —
         // Npgsql não aceita descartar uma conexão com um comando ainda em
-        // voo. O finally garante que txDecoyHolder é liberado (destravando
-        // decoyBlockedTask) ANTES de qualquer descarte, seja qual for o
-        // caminho de saída (achado do Codex no PR #1036 — a 1ª versão deste
-        // fix ainda deixava a confirmação do decoy fora da proteção).
-        bool decoyReleased = false;
+        // voo. Dois flags distintos (achado do Codex no PR #1036, 4ª rodada):
+        // "o holder commitou" (não pode mais ser revertido por rollback) é
+        // diferente de "o decoy foi de fato aguardado e descartado" — commitar
+        // txDecoyHolder libera o lock do LADO DO SERVIDOR, mas não garante que
+        // o comando Npgsql bloqueado do LADO DO CLIENTE já retornou; se a
+        // asserção final (linha ~135) falhar depois do commit mas antes do
+        // await de decoyBlockedTask, o finally ainda precisa aguardá-lo e
+        // descartar txDecoyBlocked antes do `await using` de disposal.
+        bool decoyHolderCommitted = false;
+        bool decoyBlockedCleanedUp = false;
         try
         {
             // Prova de que o decoy está genuinamente bloqueado — pelo holder
@@ -129,7 +134,7 @@ public sealed class ConcorrenciaTestHelpersTests
 
             await txAlvoHolder.CommitAsync();
             await txDecoyHolder.CommitAsync();
-            decoyReleased = true;
+            decoyHolderCommitted = true;
 
             Func<Task> act = async () => await taskA;
             await act.Should().ThrowAsync<DbUpdateConcurrencyException>(
@@ -137,12 +142,21 @@ public sealed class ConcorrenciaTestHelpersTests
 
             await decoyBlockedTask;
             await txDecoyBlocked.RollbackAsync();
+            decoyBlockedCleanedUp = true;
         }
         finally
         {
-            if (!decoyReleased)
+            // txDecoyHolder só aceita Rollback se ainda não foi commitado.
+            if (!decoyHolderCommitted)
             {
                 await txDecoyHolder.RollbackAsync();
+            }
+
+            // decoyBlockedTask só é seguro aguardar/descartar depois que o
+            // lock que o prendia foi liberado — seja pelo commit acima, seja
+            // pelo rollback que acabou de rodar.
+            if (!decoyBlockedCleanedUp)
+            {
                 await decoyBlockedTask;
                 await txDecoyBlocked.RollbackAsync();
             }

--- a/tests/Unifesspa.UniPlus.Configuracao.IntegrationTests/Infrastructure/ConcorrenciaTestHelpersTests.cs
+++ b/tests/Unifesspa.UniPlus.Configuracao.IntegrationTests/Infrastructure/ConcorrenciaTestHelpersTests.cs
@@ -82,21 +82,23 @@ public sealed class ConcorrenciaTestHelpersTests
         Task decoyBlockedTask = dbDecoyBlocked.Database.ExecuteSqlInterpolatedAsync(
             $"UPDATE configuracao.calendario_dias_uteis SET updated_at = now() WHERE id = {idDecoy}");
 
-        // Prova de que o decoy está genuinamente bloqueado — pelo holder DELE,
-        // não pelo que a corrida real vai usar.
-        await ConcorrenciaTestHelpers.AguardarBackendBloqueadoAsync(
-            api, decoyBlockedTask, [pidDecoyHolder], TimeSpan.FromSeconds(5));
-
-        // Se qualquer asserção abaixo falhar antes de liberar txDecoyHolder,
+        // Se qualquer asserção abaixo — incluindo a própria confirmação de que
+        // o decoy está bloqueado — falhar antes de liberar txDecoyHolder,
         // decoyBlockedTask continua bloqueado quando o `await using` de
         // txDecoyBlocked/scopeDecoyBlocked começar a descartar a conexão —
         // Npgsql não aceita descartar uma conexão com um comando ainda em
         // voo. O finally garante que txDecoyHolder é liberado (destravando
         // decoyBlockedTask) ANTES de qualquer descarte, seja qual for o
-        // caminho de saída (achado do Codex no PR #1036).
+        // caminho de saída (achado do Codex no PR #1036 — a 1ª versão deste
+        // fix ainda deixava a confirmação do decoy fora da proteção).
         bool decoyReleased = false;
         try
         {
+            // Prova de que o decoy está genuinamente bloqueado — pelo holder
+            // DELE, não pelo que a corrida real vai usar.
+            await ConcorrenciaTestHelpers.AguardarBackendBloqueadoAsync(
+                api, decoyBlockedTask, [pidDecoyHolder], TimeSpan.FromSeconds(5));
+
             // --- Fase 1: com o decoy já bloqueado, a corrida real (busA) nem
             // começou. Pedir a espera correlacionada ao holder de A (que só vai
             // existir de verdade na Fase 2) não deve ser satisfeita pelo decoy —

--- a/tests/Unifesspa.UniPlus.Configuracao.IntegrationTests/Infrastructure/ConcorrenciaTestHelpersTests.cs
+++ b/tests/Unifesspa.UniPlus.Configuracao.IntegrationTests/Infrastructure/ConcorrenciaTestHelpersTests.cs
@@ -87,42 +87,63 @@ public sealed class ConcorrenciaTestHelpersTests
         await ConcorrenciaTestHelpers.AguardarBackendBloqueadoAsync(
             api, decoyBlockedTask, [pidDecoyHolder], TimeSpan.FromSeconds(5));
 
-        // --- Fase 1: com o decoy já bloqueado, a corrida real (busA) nem
-        // começou. Pedir a espera correlacionada ao holder de A (que só vai
-        // existir de verdade na Fase 2) não deve ser satisfeita pelo decoy —
-        // ele está bloqueado por pidDecoyHolder, não por pidAlvoHolder.
-        await using AsyncServiceScope scopeAlvoHolder = api.Services.CreateAsyncScope();
-        ConfiguracaoDbContext dbAlvoHolder = scopeAlvoHolder.ServiceProvider.GetRequiredService<ConfiguracaoDbContext>();
-        await using IDbContextTransaction txAlvoHolder = await dbAlvoHolder.Database.BeginTransactionAsync();
-        await dbAlvoHolder.Database.ExecuteSqlInterpolatedAsync(
-            $"UPDATE configuracao.calendario_dias_uteis SET updated_at = now() WHERE id = {idAlvo}");
-        int pidAlvoHolder = await ConcorrenciaTestHelpers.ObterPidDaConexaoAsync(dbAlvoHolder);
+        // Se qualquer asserção abaixo falhar antes de liberar txDecoyHolder,
+        // decoyBlockedTask continua bloqueado quando o `await using` de
+        // txDecoyBlocked/scopeDecoyBlocked começar a descartar a conexão —
+        // Npgsql não aceita descartar uma conexão com um comando ainda em
+        // voo. O finally garante que txDecoyHolder é liberado (destravando
+        // decoyBlockedTask) ANTES de qualquer descarte, seja qual for o
+        // caminho de saída (achado do Codex no PR #1036).
+        bool decoyReleased = false;
+        try
+        {
+            // --- Fase 1: com o decoy já bloqueado, a corrida real (busA) nem
+            // começou. Pedir a espera correlacionada ao holder de A (que só vai
+            // existir de verdade na Fase 2) não deve ser satisfeita pelo decoy —
+            // ele está bloqueado por pidDecoyHolder, não por pidAlvoHolder.
+            await using AsyncServiceScope scopeAlvoHolder = api.Services.CreateAsyncScope();
+            ConfiguracaoDbContext dbAlvoHolder = scopeAlvoHolder.ServiceProvider.GetRequiredService<ConfiguracaoDbContext>();
+            await using IDbContextTransaction txAlvoHolder = await dbAlvoHolder.Database.BeginTransactionAsync();
+            await dbAlvoHolder.Database.ExecuteSqlInterpolatedAsync(
+                $"UPDATE configuracao.calendario_dias_uteis SET updated_at = now() WHERE id = {idAlvo}");
+            int pidAlvoHolder = await ConcorrenciaTestHelpers.ObterPidDaConexaoAsync(dbAlvoHolder);
 
-        Task tarefaQueNuncaBloqueiaDeVerdade = Task.Delay(TimeSpan.FromMinutes(1));
-        Func<Task> aguardarSemBusA = () => ConcorrenciaTestHelpers.AguardarBackendBloqueadoAsync(
-            api, tarefaQueNuncaBloqueiaDeVerdade, [pidAlvoHolder], TimeSpan.FromMilliseconds(300));
+            Task tarefaQueNuncaBloqueiaDeVerdade = Task.Delay(TimeSpan.FromMinutes(1));
+            Func<Task> aguardarSemBusA = () => ConcorrenciaTestHelpers.AguardarBackendBloqueadoAsync(
+                api, tarefaQueNuncaBloqueiaDeVerdade, [pidAlvoHolder], TimeSpan.FromMilliseconds(300));
 
-        await aguardarSemBusA.Should().ThrowAsync<FailException>(
-            "o decoy está bloqueado por outro holder — pg_blocking_pids não o correlaciona com pidAlvoHolder");
+            await aguardarSemBusA.Should().ThrowAsync<FailException>(
+                "o decoy está bloqueado por outro holder — pg_blocking_pids não o correlaciona com pidAlvoHolder");
 
-        // --- Fase 2: agora a corrida real (busA) começa e disputa a MESMA
-        // linha que dbAlvoHolder está segurando — pg_blocking_pids vai
-        // confirmar que o bloqueador de busA é especificamente pidAlvoHolder.
-        await using AsyncServiceScope scopeA = api.Services.CreateAsyncScope();
-        IMessageBus busA = scopeA.ServiceProvider.GetRequiredService<IMessageBus>();
-        Task<Result> taskA = busA.InvokeAsync<Result>(new RemoverCalendarioDiasUteisCommand(idAlvo));
+            // --- Fase 2: agora a corrida real (busA) começa e disputa a MESMA
+            // linha que dbAlvoHolder está segurando — pg_blocking_pids vai
+            // confirmar que o bloqueador de busA é especificamente pidAlvoHolder.
+            await using AsyncServiceScope scopeA = api.Services.CreateAsyncScope();
+            IMessageBus busA = scopeA.ServiceProvider.GetRequiredService<IMessageBus>();
+            Task<Result> taskA = busA.InvokeAsync<Result>(new RemoverCalendarioDiasUteisCommand(idAlvo));
 
-        await ConcorrenciaTestHelpers.AguardarBackendBloqueadoAsync(
-            api, taskA, [pidAlvoHolder], TimeSpan.FromSeconds(5));
+            await ConcorrenciaTestHelpers.AguardarBackendBloqueadoAsync(
+                api, taskA, [pidAlvoHolder], TimeSpan.FromSeconds(5));
 
-        await txAlvoHolder.CommitAsync();
-        await txDecoyHolder.CommitAsync();
+            await txAlvoHolder.CommitAsync();
+            await txDecoyHolder.CommitAsync();
+            decoyReleased = true;
 
-        Func<Task> act = async () => await taskA;
-        await act.Should().ThrowAsync<DbUpdateConcurrencyException>(
-            "o xmin lido por busA ficou obsoleto assim que dbAlvoHolder commitou a própria escrita na mesma linha (ADR-0119 — RemoverCalendarioDiasUteisCommandHandler propaga sem catch)");
+            Func<Task> act = async () => await taskA;
+            await act.Should().ThrowAsync<DbUpdateConcurrencyException>(
+                "o xmin lido por busA ficou obsoleto assim que dbAlvoHolder commitou a própria escrita na mesma linha (ADR-0119 — RemoverCalendarioDiasUteisCommandHandler propaga sem catch)");
 
-        await decoyBlockedTask;
-        await txDecoyBlocked.RollbackAsync();
+            await decoyBlockedTask;
+            await txDecoyBlocked.RollbackAsync();
+        }
+        finally
+        {
+            if (!decoyReleased)
+            {
+                await txDecoyHolder.RollbackAsync();
+                await decoyBlockedTask;
+                await txDecoyBlocked.RollbackAsync();
+            }
+        }
     }
 }

--- a/tests/Unifesspa.UniPlus.Configuracao.IntegrationTests/Infrastructure/ConcorrenciaTestHelpersTests.cs
+++ b/tests/Unifesspa.UniPlus.Configuracao.IntegrationTests/Infrastructure/ConcorrenciaTestHelpersTests.cs
@@ -19,7 +19,7 @@ using Xunit.Sdk;
 using IMessageBus = Wolverine.IMessageBus;
 
 /// <summary>
-/// Prova de correção da issue #1031: <see cref="ConcorrenciaTestHelpers.AguardarBackendBloqueadoAsync"/>
+/// Prova de correção da issue #1031: <see cref="ConcorrenciaTestHelpers.WaitForBlockedBackendAsync"/>
 /// identifica o backend bloqueado correlacionando via <c>pg_blocking_pids</c> —
 /// imune tanto a texto de query coincidente quanto a qualquer OUTRO backend
 /// bloqueado por um lock não relacionado ao que o chamador está segurando (o
@@ -43,7 +43,7 @@ public sealed class ConcorrenciaTestHelpersTests
 
     [Fact(DisplayName =
         "Um backend bloqueado por um lock alheio (mesma tabela, holder diferente) não é confundido com o backend real sob teste")]
-    public async Task AguardarBackendBloqueadoAsync_ComBackendBloqueadoPorHolderAlheio_NaoDaFalsoPositivo()
+    public async Task WaitForBlockedBackendAsync_WithBackendBlockedByUnrelatedHolder_DoesNotFalsePositive()
     {
         MonolitoApiFactory api = _fixture.Factory;
 
@@ -74,7 +74,7 @@ public sealed class ConcorrenciaTestHelpersTests
         await using IDbContextTransaction txDecoyHolder = await dbDecoyHolder.Database.BeginTransactionAsync();
         await dbDecoyHolder.Database.ExecuteSqlInterpolatedAsync(
             $"UPDATE configuracao.calendario_dias_uteis SET updated_at = now() WHERE id = {idDecoy}");
-        int pidDecoyHolder = await ConcorrenciaTestHelpers.ObterPidDaConexaoAsync(dbDecoyHolder);
+        int pidDecoyHolder = await ConcorrenciaTestHelpers.GetConnectionPidAsync(dbDecoyHolder);
 
         await using AsyncServiceScope scopeDecoyBlocked = api.Services.CreateAsyncScope();
         ConfiguracaoDbContext dbDecoyBlocked = scopeDecoyBlocked.ServiceProvider.GetRequiredService<ConfiguracaoDbContext>();
@@ -101,7 +101,7 @@ public sealed class ConcorrenciaTestHelpersTests
         {
             // Prova de que o decoy está genuinamente bloqueado — pelo holder
             // DELE, não pelo que a corrida real vai usar.
-            await ConcorrenciaTestHelpers.AguardarBackendBloqueadoAsync(
+            await ConcorrenciaTestHelpers.WaitForBlockedBackendAsync(
                 api, decoyBlockedTask, [pidDecoyHolder], TimeSpan.FromSeconds(5));
 
             // --- Fase 1: com o decoy já bloqueado, a corrida real (busA) nem
@@ -113,13 +113,13 @@ public sealed class ConcorrenciaTestHelpersTests
             await using IDbContextTransaction txAlvoHolder = await dbAlvoHolder.Database.BeginTransactionAsync();
             await dbAlvoHolder.Database.ExecuteSqlInterpolatedAsync(
                 $"UPDATE configuracao.calendario_dias_uteis SET updated_at = now() WHERE id = {idAlvo}");
-            int pidAlvoHolder = await ConcorrenciaTestHelpers.ObterPidDaConexaoAsync(dbAlvoHolder);
+            int pidAlvoHolder = await ConcorrenciaTestHelpers.GetConnectionPidAsync(dbAlvoHolder);
 
-            Task tarefaQueNuncaBloqueiaDeVerdade = Task.Delay(TimeSpan.FromMinutes(1));
-            Func<Task> aguardarSemBusA = () => ConcorrenciaTestHelpers.AguardarBackendBloqueadoAsync(
-                api, tarefaQueNuncaBloqueiaDeVerdade, [pidAlvoHolder], TimeSpan.FromMilliseconds(300));
+            Task taskThatNeverActuallyBlocks = Task.Delay(TimeSpan.FromMinutes(1));
+            Func<Task> waitWithoutBusA = () => ConcorrenciaTestHelpers.WaitForBlockedBackendAsync(
+                api, taskThatNeverActuallyBlocks, [pidAlvoHolder], TimeSpan.FromMilliseconds(300));
 
-            await aguardarSemBusA.Should().ThrowAsync<FailException>(
+            await waitWithoutBusA.Should().ThrowAsync<FailException>(
                 "o decoy está bloqueado por outro holder — pg_blocking_pids não o correlaciona com pidAlvoHolder");
 
             // --- Fase 2: agora a corrida real (busA) começa e disputa a MESMA
@@ -129,7 +129,7 @@ public sealed class ConcorrenciaTestHelpersTests
             IMessageBus busA = scopeA.ServiceProvider.GetRequiredService<IMessageBus>();
             Task<Result> taskA = busA.InvokeAsync<Result>(new RemoverCalendarioDiasUteisCommand(idAlvo));
 
-            await ConcorrenciaTestHelpers.AguardarBackendBloqueadoAsync(
+            await ConcorrenciaTestHelpers.WaitForBlockedBackendAsync(
                 api, taskA, [pidAlvoHolder], TimeSpan.FromSeconds(5));
 
             await txAlvoHolder.CommitAsync();

--- a/tests/Unifesspa.UniPlus.Configuracao.IntegrationTests/Infrastructure/ConcorrenciaTestHelpersTests.cs
+++ b/tests/Unifesspa.UniPlus.Configuracao.IntegrationTests/Infrastructure/ConcorrenciaTestHelpersTests.cs
@@ -1,0 +1,131 @@
+namespace Unifesspa.UniPlus.Configuracao.IntegrationTests.Infrastructure;
+
+using System.Diagnostics.CodeAnalysis;
+
+using AwesomeAssertions;
+
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Storage;
+using Microsoft.Extensions.DependencyInjection;
+
+using Unifesspa.UniPlus.Configuracao.Application.Commands.CalendariosDiasUteis;
+using Unifesspa.UniPlus.Configuracao.Domain.Entities;
+using Unifesspa.UniPlus.Configuracao.Infrastructure.Persistence;
+using Unifesspa.UniPlus.IntegrationTests.Fixtures.Hosting;
+using Unifesspa.UniPlus.Kernel.Results;
+
+using Xunit.Sdk;
+
+using IMessageBus = Wolverine.IMessageBus;
+
+/// <summary>
+/// Prova de correção da issue #1031: <see cref="ConcorrenciaTestHelpers.AguardarBackendBloqueadoAsync"/>
+/// identifica o backend bloqueado por exclusão de PID, não por texto de query —
+/// imune a uma query concorrente sem relação com a corrida sob teste que
+/// mencione a mesma tabela por coincidência, DESDE QUE o chamador enumere essa
+/// conexão entre as conhecidas (o antigo <c>ILIKE '%tabela%'</c> não tinha
+/// como diferenciar as duas).
+/// </summary>
+[Collection(ConfiguracaoEndpointCollection.Name)]
+[Trait("Category", "Integration")]
+[SuppressMessage(
+    "Performance",
+    "CA1515:Consider making public types internal",
+    Justification = "xUnit collection fixture exige tipo de teste público.")]
+public sealed class ConcorrenciaTestHelpersTests
+{
+    private readonly ConfiguracaoEndpointFixture _fixture;
+
+    public ConcorrenciaTestHelpersTests(ConfiguracaoEndpointFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    [Fact(DisplayName =
+        "Uma conexão conhecida bloqueada por coincidência de texto não é confundida com o backend real sob teste")]
+    public async Task AguardarBackendBloqueadoAsync_ComConexaoConhecidaBloqueadaPorTextoCoincidente_NaoDaFalsoPositivo()
+    {
+        MonolitoApiFactory api = _fixture.Factory;
+
+        Guid idAlvo;
+        Guid idDecoy;
+        await using (AsyncServiceScope setupScope = api.Services.CreateAsyncScope())
+        {
+            ConfiguracaoDbContext db = setupScope.ServiceProvider.GetRequiredService<ConfiguracaoDbContext>();
+            CalendarioDiasUteis alvo = CalendarioDiasUteis.Criar(
+                $"pid-alvo-{Guid.NewGuid():N}"[..20],
+                [new DiaNaoUtilCriacao("NACIONAL", null, new DateOnly(2099, 1, 1), "x")]).Value!;
+            CalendarioDiasUteis decoy = CalendarioDiasUteis.Criar(
+                $"pid-decoy-{Guid.NewGuid():N}"[..20],
+                [new DiaNaoUtilCriacao("NACIONAL", null, new DateOnly(2099, 1, 1), "x")]).Value!;
+            db.CalendariosDiasUteis.AddRange(alvo, decoy);
+            await db.SaveChangesAsync();
+            idAlvo = alvo.Id;
+            idDecoy = decoy.Id;
+        }
+
+        // Decoy: uma segunda corrida, TOTALMENTE alheia à corrida sob teste,
+        // sobre uma linha DIFERENTE da mesma tabela — sua query de bloqueio
+        // menciona "calendario_dias_uteis" por coincidência, exatamente o
+        // cenário que o antigo casamento por ILIKE não sabia distinguir.
+        await using AsyncServiceScope scopeDecoyHolder = api.Services.CreateAsyncScope();
+        ConfiguracaoDbContext dbDecoyHolder = scopeDecoyHolder.ServiceProvider.GetRequiredService<ConfiguracaoDbContext>();
+        await using IDbContextTransaction txDecoyHolder = await dbDecoyHolder.Database.BeginTransactionAsync();
+        await dbDecoyHolder.Database.ExecuteSqlInterpolatedAsync(
+            $"UPDATE configuracao.calendario_dias_uteis SET updated_at = now() WHERE id = {idDecoy}");
+        int pidDecoyHolder = await ConcorrenciaTestHelpers.ObterPidDaConexaoAsync(dbDecoyHolder);
+
+        await using AsyncServiceScope scopeDecoyBlocked = api.Services.CreateAsyncScope();
+        ConfiguracaoDbContext dbDecoyBlocked = scopeDecoyBlocked.ServiceProvider.GetRequiredService<ConfiguracaoDbContext>();
+        await using IDbContextTransaction txDecoyBlocked = await dbDecoyBlocked.Database.BeginTransactionAsync();
+
+        // PID capturado ANTES de disparar o comando que vai bloquear — depois
+        // disso a conexão fica ocupada e não aceitaria mais nenhum comando
+        // concorrente (nem SELECT pg_backend_pid()).
+        int pidDecoyBlocked = await ConcorrenciaTestHelpers.ObterPidDaConexaoAsync(dbDecoyBlocked);
+        Task decoyBlockedTask = dbDecoyBlocked.Database.ExecuteSqlInterpolatedAsync(
+            $"UPDATE configuracao.calendario_dias_uteis SET updated_at = now() WHERE id = {idDecoy}");
+
+        await ConcorrenciaTestHelpers.AguardarBackendBloqueadoAsync(
+            api, decoyBlockedTask, [pidDecoyHolder], TimeSpan.FromSeconds(5));
+
+        // --- Fase 1: com o decoy já bloqueado (e ainda não excluído da
+        // checagem), a corrida real (busA) nem começou — nada de genuinamente
+        // novo está bloqueado. Se a identificação ainda fosse por texto, o
+        // decoy sozinho já teria satisfeito a espera; com PID, só timeout.
+        await using AsyncServiceScope scopeAlvoHolder = api.Services.CreateAsyncScope();
+        ConfiguracaoDbContext dbAlvoHolder = scopeAlvoHolder.ServiceProvider.GetRequiredService<ConfiguracaoDbContext>();
+        await using IDbContextTransaction txAlvoHolder = await dbAlvoHolder.Database.BeginTransactionAsync();
+        await dbAlvoHolder.Database.ExecuteSqlInterpolatedAsync(
+            $"UPDATE configuracao.calendario_dias_uteis SET updated_at = now() WHERE id = {idAlvo}");
+        int pidAlvoHolder = await ConcorrenciaTestHelpers.ObterPidDaConexaoAsync(dbAlvoHolder);
+
+        int[] pidsConhecidos = [pidDecoyHolder, pidDecoyBlocked, pidAlvoHolder];
+        Task tarefaQueNuncaBloqueiaDeVerdade = Task.Delay(TimeSpan.FromMinutes(1));
+        Func<Task> aguardarSemBusA = () => ConcorrenciaTestHelpers.AguardarBackendBloqueadoAsync(
+            api, tarefaQueNuncaBloqueiaDeVerdade, pidsConhecidos, TimeSpan.FromMilliseconds(300));
+
+        await aguardarSemBusA.Should().ThrowAsync<FailException>(
+            "o decoy e o holder são conhecidos e excluídos — nenhum backend genuinamente novo está bloqueado ainda");
+
+        // --- Fase 2: agora a corrida real (busA) começa e disputa a MESMA
+        // linha que dbAlvoHolder está segurando — seu PID não está na lista de
+        // conhecidos, então é o único capaz de satisfazer a espera.
+        await using AsyncServiceScope scopeA = api.Services.CreateAsyncScope();
+        IMessageBus busA = scopeA.ServiceProvider.GetRequiredService<IMessageBus>();
+        Task<Result> taskA = busA.InvokeAsync<Result>(new RemoverCalendarioDiasUteisCommand(idAlvo));
+
+        await ConcorrenciaTestHelpers.AguardarBackendBloqueadoAsync(
+            api, taskA, pidsConhecidos, TimeSpan.FromSeconds(5));
+
+        await txAlvoHolder.CommitAsync();
+        await txDecoyHolder.CommitAsync();
+
+        Func<Task> act = async () => await taskA;
+        await act.Should().ThrowAsync<DbUpdateConcurrencyException>(
+            "o xmin lido por busA ficou obsoleto assim que dbAlvoHolder commitou a própria escrita na mesma linha (ADR-0119 — RemoverCalendarioDiasUteisCommandHandler propaga sem catch)");
+
+        await decoyBlockedTask;
+        await txDecoyBlocked.RollbackAsync();
+    }
+}

--- a/tests/Unifesspa.UniPlus.Configuracao.IntegrationTests/Infrastructure/ConcorrenciaTestHelpersTests.cs
+++ b/tests/Unifesspa.UniPlus.Configuracao.IntegrationTests/Infrastructure/ConcorrenciaTestHelpersTests.cs
@@ -20,11 +20,11 @@ using IMessageBus = Wolverine.IMessageBus;
 
 /// <summary>
 /// Prova de correção da issue #1031: <see cref="ConcorrenciaTestHelpers.AguardarBackendBloqueadoAsync"/>
-/// identifica o backend bloqueado por exclusão de PID, não por texto de query —
-/// imune a uma query concorrente sem relação com a corrida sob teste que
-/// mencione a mesma tabela por coincidência, DESDE QUE o chamador enumere essa
-/// conexão entre as conhecidas (o antigo <c>ILIKE '%tabela%'</c> não tinha
-/// como diferenciar as duas).
+/// identifica o backend bloqueado correlacionando via <c>pg_blocking_pids</c> —
+/// imune tanto a texto de query coincidente quanto a qualquer OUTRO backend
+/// bloqueado por um lock não relacionado ao que o chamador está segurando (o
+/// achado P2 do Codex sobre a primeira versão deste teste, que só excluía PIDs
+/// conhecidos sem confirmar QUEM realmente bloqueava o candidato).
 /// </summary>
 [Collection(ConfiguracaoEndpointCollection.Name)]
 [Trait("Category", "Integration")]
@@ -42,8 +42,8 @@ public sealed class ConcorrenciaTestHelpersTests
     }
 
     [Fact(DisplayName =
-        "Uma conexão conhecida bloqueada por coincidência de texto não é confundida com o backend real sob teste")]
-    public async Task AguardarBackendBloqueadoAsync_ComConexaoConhecidaBloqueadaPorTextoCoincidente_NaoDaFalsoPositivo()
+        "Um backend bloqueado por um lock alheio (mesma tabela, holder diferente) não é confundido com o backend real sob teste")]
+    public async Task AguardarBackendBloqueadoAsync_ComBackendBloqueadoPorHolderAlheio_NaoDaFalsoPositivo()
     {
         MonolitoApiFactory api = _fixture.Factory;
 
@@ -65,9 +65,10 @@ public sealed class ConcorrenciaTestHelpersTests
         }
 
         // Decoy: uma segunda corrida, TOTALMENTE alheia à corrida sob teste,
-        // sobre uma linha DIFERENTE da mesma tabela — sua query de bloqueio
-        // menciona "calendario_dias_uteis" por coincidência, exatamente o
-        // cenário que o antigo casamento por ILIKE não sabia distinguir.
+        // sobre uma linha DIFERENTE da mesma tabela — um backend genuinamente
+        // bloqueado (wait_event_type='Lock'), com query mencionando
+        // "calendario_dias_uteis" por coincidência, mas bloqueado por um
+        // holder que NÃO é o que a corrida real vai usar.
         await using AsyncServiceScope scopeDecoyHolder = api.Services.CreateAsyncScope();
         ConfiguracaoDbContext dbDecoyHolder = scopeDecoyHolder.ServiceProvider.GetRequiredService<ConfiguracaoDbContext>();
         await using IDbContextTransaction txDecoyHolder = await dbDecoyHolder.Database.BeginTransactionAsync();
@@ -78,21 +79,18 @@ public sealed class ConcorrenciaTestHelpersTests
         await using AsyncServiceScope scopeDecoyBlocked = api.Services.CreateAsyncScope();
         ConfiguracaoDbContext dbDecoyBlocked = scopeDecoyBlocked.ServiceProvider.GetRequiredService<ConfiguracaoDbContext>();
         await using IDbContextTransaction txDecoyBlocked = await dbDecoyBlocked.Database.BeginTransactionAsync();
-
-        // PID capturado ANTES de disparar o comando que vai bloquear — depois
-        // disso a conexão fica ocupada e não aceitaria mais nenhum comando
-        // concorrente (nem SELECT pg_backend_pid()).
-        int pidDecoyBlocked = await ConcorrenciaTestHelpers.ObterPidDaConexaoAsync(dbDecoyBlocked);
         Task decoyBlockedTask = dbDecoyBlocked.Database.ExecuteSqlInterpolatedAsync(
             $"UPDATE configuracao.calendario_dias_uteis SET updated_at = now() WHERE id = {idDecoy}");
 
+        // Prova de que o decoy está genuinamente bloqueado — pelo holder DELE,
+        // não pelo que a corrida real vai usar.
         await ConcorrenciaTestHelpers.AguardarBackendBloqueadoAsync(
             api, decoyBlockedTask, [pidDecoyHolder], TimeSpan.FromSeconds(5));
 
-        // --- Fase 1: com o decoy já bloqueado (e ainda não excluído da
-        // checagem), a corrida real (busA) nem começou — nada de genuinamente
-        // novo está bloqueado. Se a identificação ainda fosse por texto, o
-        // decoy sozinho já teria satisfeito a espera; com PID, só timeout.
+        // --- Fase 1: com o decoy já bloqueado, a corrida real (busA) nem
+        // começou. Pedir a espera correlacionada ao holder de A (que só vai
+        // existir de verdade na Fase 2) não deve ser satisfeita pelo decoy —
+        // ele está bloqueado por pidDecoyHolder, não por pidAlvoHolder.
         await using AsyncServiceScope scopeAlvoHolder = api.Services.CreateAsyncScope();
         ConfiguracaoDbContext dbAlvoHolder = scopeAlvoHolder.ServiceProvider.GetRequiredService<ConfiguracaoDbContext>();
         await using IDbContextTransaction txAlvoHolder = await dbAlvoHolder.Database.BeginTransactionAsync();
@@ -100,23 +98,22 @@ public sealed class ConcorrenciaTestHelpersTests
             $"UPDATE configuracao.calendario_dias_uteis SET updated_at = now() WHERE id = {idAlvo}");
         int pidAlvoHolder = await ConcorrenciaTestHelpers.ObterPidDaConexaoAsync(dbAlvoHolder);
 
-        int[] pidsConhecidos = [pidDecoyHolder, pidDecoyBlocked, pidAlvoHolder];
         Task tarefaQueNuncaBloqueiaDeVerdade = Task.Delay(TimeSpan.FromMinutes(1));
         Func<Task> aguardarSemBusA = () => ConcorrenciaTestHelpers.AguardarBackendBloqueadoAsync(
-            api, tarefaQueNuncaBloqueiaDeVerdade, pidsConhecidos, TimeSpan.FromMilliseconds(300));
+            api, tarefaQueNuncaBloqueiaDeVerdade, [pidAlvoHolder], TimeSpan.FromMilliseconds(300));
 
         await aguardarSemBusA.Should().ThrowAsync<FailException>(
-            "o decoy e o holder são conhecidos e excluídos — nenhum backend genuinamente novo está bloqueado ainda");
+            "o decoy está bloqueado por outro holder — pg_blocking_pids não o correlaciona com pidAlvoHolder");
 
         // --- Fase 2: agora a corrida real (busA) começa e disputa a MESMA
-        // linha que dbAlvoHolder está segurando — seu PID não está na lista de
-        // conhecidos, então é o único capaz de satisfazer a espera.
+        // linha que dbAlvoHolder está segurando — pg_blocking_pids vai
+        // confirmar que o bloqueador de busA é especificamente pidAlvoHolder.
         await using AsyncServiceScope scopeA = api.Services.CreateAsyncScope();
         IMessageBus busA = scopeA.ServiceProvider.GetRequiredService<IMessageBus>();
         Task<Result> taskA = busA.InvokeAsync<Result>(new RemoverCalendarioDiasUteisCommand(idAlvo));
 
         await ConcorrenciaTestHelpers.AguardarBackendBloqueadoAsync(
-            api, taskA, pidsConhecidos, TimeSpan.FromSeconds(5));
+            api, taskA, [pidAlvoHolder], TimeSpan.FromSeconds(5));
 
         await txAlvoHolder.CommitAsync();
         await txDecoyHolder.CommitAsync();

--- a/tests/Unifesspa.UniPlus.Configuracao.IntegrationTests/Infrastructure/ConcurrencyTestHelpersTests.cs
+++ b/tests/Unifesspa.UniPlus.Configuracao.IntegrationTests/Infrastructure/ConcurrencyTestHelpersTests.cs
@@ -32,11 +32,11 @@ using IMessageBus = Wolverine.IMessageBus;
     "Performance",
     "CA1515:Consider making public types internal",
     Justification = "xUnit collection fixture exige tipo de teste público.")]
-public sealed class ConcorrenciaTestHelpersTests
+public sealed class ConcurrencyTestHelpersTests
 {
     private readonly ConfiguracaoEndpointFixture _fixture;
 
-    public ConcorrenciaTestHelpersTests(ConfiguracaoEndpointFixture fixture)
+    public ConcurrencyTestHelpersTests(ConfiguracaoEndpointFixture fixture)
     {
         _fixture = fixture;
     }
@@ -47,21 +47,21 @@ public sealed class ConcorrenciaTestHelpersTests
     {
         MonolitoApiFactory api = _fixture.Factory;
 
-        Guid idAlvo;
-        Guid idDecoy;
+        Guid targetId;
+        Guid decoyId;
         await using (AsyncServiceScope setupScope = api.Services.CreateAsyncScope())
         {
             ConfiguracaoDbContext db = setupScope.ServiceProvider.GetRequiredService<ConfiguracaoDbContext>();
-            CalendarioDiasUteis alvo = CalendarioDiasUteis.Criar(
-                $"pid-alvo-{Guid.NewGuid():N}"[..20],
+            CalendarioDiasUteis target = CalendarioDiasUteis.Criar(
+                $"pid-target-{Guid.NewGuid():N}"[..20],
                 [new DiaNaoUtilCriacao("NACIONAL", null, new DateOnly(2099, 1, 1), "x")]).Value!;
             CalendarioDiasUteis decoy = CalendarioDiasUteis.Criar(
                 $"pid-decoy-{Guid.NewGuid():N}"[..20],
                 [new DiaNaoUtilCriacao("NACIONAL", null, new DateOnly(2099, 1, 1), "x")]).Value!;
-            db.CalendariosDiasUteis.AddRange(alvo, decoy);
+            db.CalendariosDiasUteis.AddRange(target, decoy);
             await db.SaveChangesAsync();
-            idAlvo = alvo.Id;
-            idDecoy = decoy.Id;
+            targetId = target.Id;
+            decoyId = decoy.Id;
         }
 
         // Decoy: uma segunda corrida, TOTALMENTE alheia à corrida sob teste,
@@ -73,14 +73,14 @@ public sealed class ConcorrenciaTestHelpersTests
         ConfiguracaoDbContext dbDecoyHolder = scopeDecoyHolder.ServiceProvider.GetRequiredService<ConfiguracaoDbContext>();
         await using IDbContextTransaction txDecoyHolder = await dbDecoyHolder.Database.BeginTransactionAsync();
         await dbDecoyHolder.Database.ExecuteSqlInterpolatedAsync(
-            $"UPDATE configuracao.calendario_dias_uteis SET updated_at = now() WHERE id = {idDecoy}");
-        int pidDecoyHolder = await ConcorrenciaTestHelpers.GetConnectionPidAsync(dbDecoyHolder);
+            $"UPDATE configuracao.calendario_dias_uteis SET updated_at = now() WHERE id = {decoyId}");
+        int pdecoyIdHolder = await ConcorrenciaTestHelpers.GetConnectionPidAsync(dbDecoyHolder);
 
         await using AsyncServiceScope scopeDecoyBlocked = api.Services.CreateAsyncScope();
         ConfiguracaoDbContext dbDecoyBlocked = scopeDecoyBlocked.ServiceProvider.GetRequiredService<ConfiguracaoDbContext>();
         await using IDbContextTransaction txDecoyBlocked = await dbDecoyBlocked.Database.BeginTransactionAsync();
         Task decoyBlockedTask = dbDecoyBlocked.Database.ExecuteSqlInterpolatedAsync(
-            $"UPDATE configuracao.calendario_dias_uteis SET updated_at = now() WHERE id = {idDecoy}");
+            $"UPDATE configuracao.calendario_dias_uteis SET updated_at = now() WHERE id = {decoyId}");
 
         // Se qualquer asserção abaixo — incluindo a própria confirmação de que
         // o decoy está bloqueado — falhar antes de liberar txDecoyHolder,
@@ -102,43 +102,43 @@ public sealed class ConcorrenciaTestHelpersTests
             // Prova de que o decoy está genuinamente bloqueado — pelo holder
             // DELE, não pelo que a corrida real vai usar.
             await ConcorrenciaTestHelpers.WaitForBlockedBackendAsync(
-                api, decoyBlockedTask, [pidDecoyHolder], TimeSpan.FromSeconds(5));
+                api, decoyBlockedTask, [pdecoyIdHolder], TimeSpan.FromSeconds(5));
 
             // --- Fase 1: com o decoy já bloqueado, a corrida real (busA) nem
             // começou. Pedir a espera correlacionada ao holder de A (que só vai
             // existir de verdade na Fase 2) não deve ser satisfeita pelo decoy —
-            // ele está bloqueado por pidDecoyHolder, não por pidAlvoHolder.
-            await using AsyncServiceScope scopeAlvoHolder = api.Services.CreateAsyncScope();
-            ConfiguracaoDbContext dbAlvoHolder = scopeAlvoHolder.ServiceProvider.GetRequiredService<ConfiguracaoDbContext>();
-            await using IDbContextTransaction txAlvoHolder = await dbAlvoHolder.Database.BeginTransactionAsync();
-            await dbAlvoHolder.Database.ExecuteSqlInterpolatedAsync(
-                $"UPDATE configuracao.calendario_dias_uteis SET updated_at = now() WHERE id = {idAlvo}");
-            int pidAlvoHolder = await ConcorrenciaTestHelpers.GetConnectionPidAsync(dbAlvoHolder);
+            // ele está bloqueado por pdecoyIdHolder, não por targetHolderPid.
+            await using AsyncServiceScope scopeTargetHolder = api.Services.CreateAsyncScope();
+            ConfiguracaoDbContext dbTargetHolder = scopeTargetHolder.ServiceProvider.GetRequiredService<ConfiguracaoDbContext>();
+            await using IDbContextTransaction txTargetHolder = await dbTargetHolder.Database.BeginTransactionAsync();
+            await dbTargetHolder.Database.ExecuteSqlInterpolatedAsync(
+                $"UPDATE configuracao.calendario_dias_uteis SET updated_at = now() WHERE id = {targetId}");
+            int targetHolderPid = await ConcorrenciaTestHelpers.GetConnectionPidAsync(dbTargetHolder);
 
             Task taskThatNeverActuallyBlocks = Task.Delay(TimeSpan.FromMinutes(1));
             Func<Task> waitWithoutBusA = () => ConcorrenciaTestHelpers.WaitForBlockedBackendAsync(
-                api, taskThatNeverActuallyBlocks, [pidAlvoHolder], TimeSpan.FromMilliseconds(300));
+                api, taskThatNeverActuallyBlocks, [targetHolderPid], TimeSpan.FromMilliseconds(300));
 
             await waitWithoutBusA.Should().ThrowAsync<FailException>(
-                "o decoy está bloqueado por outro holder — pg_blocking_pids não o correlaciona com pidAlvoHolder");
+                "o decoy está bloqueado por outro holder — pg_blocking_pids não o correlaciona com targetHolderPid");
 
             // --- Fase 2: agora a corrida real (busA) começa e disputa a MESMA
-            // linha que dbAlvoHolder está segurando — pg_blocking_pids vai
-            // confirmar que o bloqueador de busA é especificamente pidAlvoHolder.
+            // linha que dbTargetHolder está segurando — pg_blocking_pids vai
+            // confirmar que o bloqueador de busA é especificamente targetHolderPid.
             await using AsyncServiceScope scopeA = api.Services.CreateAsyncScope();
             IMessageBus busA = scopeA.ServiceProvider.GetRequiredService<IMessageBus>();
-            Task<Result> taskA = busA.InvokeAsync<Result>(new RemoverCalendarioDiasUteisCommand(idAlvo));
+            Task<Result> taskA = busA.InvokeAsync<Result>(new RemoverCalendarioDiasUteisCommand(targetId));
 
             await ConcorrenciaTestHelpers.WaitForBlockedBackendAsync(
-                api, taskA, [pidAlvoHolder], TimeSpan.FromSeconds(5));
+                api, taskA, [targetHolderPid], TimeSpan.FromSeconds(5));
 
-            await txAlvoHolder.CommitAsync();
+            await txTargetHolder.CommitAsync();
             await txDecoyHolder.CommitAsync();
             decoyHolderCommitted = true;
 
             Func<Task> act = async () => await taskA;
             await act.Should().ThrowAsync<DbUpdateConcurrencyException>(
-                "o xmin lido por busA ficou obsoleto assim que dbAlvoHolder commitou a própria escrita na mesma linha (ADR-0119 — RemoverCalendarioDiasUteisCommandHandler propaga sem catch)");
+                "o xmin lido por busA ficou obsoleto assim que dbTargetHolder commitou a própria escrita na mesma linha (ADR-0119 — RemoverCalendarioDiasUteisCommandHandler propaga sem catch)");
 
             await decoyBlockedTask;
             await txDecoyBlocked.RollbackAsync();

--- a/tests/Unifesspa.UniPlus.Configuracao.IntegrationTests/TermosConsentimento/TermoConsentimentoConcorrenciaTests.cs
+++ b/tests/Unifesspa.UniPlus.Configuracao.IntegrationTests/TermosConsentimento/TermoConsentimentoConcorrenciaTests.cs
@@ -73,16 +73,18 @@ public sealed class TermoConsentimentoConcorrenciaTests
         // aqui até txB liberar.
         await dbB.Database.ExecuteSqlInterpolatedAsync(
             $"UPDATE configuracao.termo_consentimento SET updated_at = now() WHERE id = {id}");
+        int pidDbB = await ConcorrenciaTestHelpers.ObterPidDaConexaoAsync(dbB);
 
         await using AsyncServiceScope scopeA = api.Services.CreateAsyncScope();
         IMessageBus busA = scopeA.ServiceProvider.GetRequiredService<IMessageBus>();
         Task<Result> taskA = busA.InvokeAsync<Result>(new RemoverTermoConsentimentoCommand(id));
 
         // Prova direta (não uma aposta de tempo) de que busA já leu o xmin
-        // antigo e está bloqueado tentando escrever: poll em pg_locks até
-        // aparecer um lock NÃO concedido na tabela — só existe se alguém além
-        // de txB está esperando a linha.
-        await ConcorrenciaTestHelpers.AguardarLockPendenteAsync(api, "termo_consentimento", taskA);
+        // antigo e está bloqueado tentando escrever: poll em pg_stat_activity
+        // até aparecer um backend em wait_event_type='Lock' que não é nem a
+        // conexão de poll nem dbB (issue #1031 — identificação por PID, não
+        // por texto de query).
+        await ConcorrenciaTestHelpers.AguardarBackendBloqueadoAsync(api, taskA, [pidDbB]);
 
         await txB.CommitAsync();
 

--- a/tests/Unifesspa.UniPlus.Configuracao.IntegrationTests/TermosConsentimento/TermoConsentimentoConcorrenciaTests.cs
+++ b/tests/Unifesspa.UniPlus.Configuracao.IntegrationTests/TermosConsentimento/TermoConsentimentoConcorrenciaTests.cs
@@ -73,7 +73,7 @@ public sealed class TermoConsentimentoConcorrenciaTests
         // aqui até txB liberar.
         await dbB.Database.ExecuteSqlInterpolatedAsync(
             $"UPDATE configuracao.termo_consentimento SET updated_at = now() WHERE id = {id}");
-        int pidDbB = await ConcorrenciaTestHelpers.ObterPidDaConexaoAsync(dbB);
+        int pidDbB = await ConcorrenciaTestHelpers.GetConnectionPidAsync(dbB);
 
         await using AsyncServiceScope scopeA = api.Services.CreateAsyncScope();
         IMessageBus busA = scopeA.ServiceProvider.GetRequiredService<IMessageBus>();
@@ -84,7 +84,7 @@ public sealed class TermoConsentimentoConcorrenciaTests
         // até aparecer um backend em wait_event_type='Lock' que não é nem a
         // conexão de poll nem dbB (issue #1031 — identificação por PID, não
         // por texto de query).
-        await ConcorrenciaTestHelpers.AguardarBackendBloqueadoAsync(api, taskA, [pidDbB]);
+        await ConcorrenciaTestHelpers.WaitForBlockedBackendAsync(api, taskA, [pidDbB]);
 
         await txB.CommitAsync();
 


### PR DESCRIPTION
## Contexto

`ConcorrenciaTestHelpers.AguardarLockPendenteAsync` (introduzido na PR #1030, ADR-0119) prova, contra Postgres real, que um handler real está bloqueado esperando um lock antes de liberar a transação que o segura — identificando o backend bloqueado por `ILIKE '%tabela%'` no texto da query. Isso é seguro hoje só porque a collection que chama o helper roda com `DisableParallelization = true` e cada módulo usa seu próprio container Postgres isolado — não por construção do método. Se alguém reintroduzisse paralelismo, ou se o helper fosse reutilizado numa collection com paralelismo, o casamento por texto poderia dar falso positivo casando com uma query concorrente alheia que mencionasse a mesma tabela por coincidência.

## Investigação

Testei empiricamente se dava para capturar o PID exato da conexão que o handler usa (opção "a" da issue): resolvendo `ConfiguracaoDbContext` diretamente do mesmo `scope` de onde `IMessageBus` é resolvido, e comparando com o PID que de fato aparece bloqueado em `pg_stat_activity`. **Os PIDs são diferentes** — o Wolverine abre sua própria conexão interna para processar o `InvokeAsync`, não reaproveita a do scope de onde foi resolvido. Capturar o PID exato do handler não é viável sem tocar Wolverine/código de produção.

## O que muda

- `AguardarBackendBloqueadoAsync` substitui `AguardarLockPendenteAsync`: identifica o backend bloqueado por **exclusão de PID real**, não por texto — só considera prova de corrida um backend cujo PID não está entre os que o chamador enumera como conhecidos (ex.: a transação que segura o lock).
- `ObterPidDaConexaoAsync` captura o PID de uma conexão — só é seguro chamar enquanto ela está ociosa, nunca durante um comando ainda em voo (o protocolo Npgsql não aceita um segundo comando concorrente na mesma conexão; descoberto empiricamente ao construir o teste de regressão, que inicialmente tentava capturar o PID de uma conexão já bloqueada e produzia `ParseComplete while expecting ReadyForQueryMessage`).
- Os dois callers existentes (`CalendarioDiasUteisConcorrenciaTests`, `TermoConsentimentoConcorrenciaTests`) foram atualizados para o novo contrato.
- Teste de regressão novo (`ConcorrenciaTestHelpersTests`) prova que uma conexão CONHECIDA bloqueada por coincidência de texto não é mais confundida com o backend real: com o decoy sozinho bloqueado (e corretamente excluído por PID), a espera dá timeout; só quando o backend genuinamente novo (busA) bloqueia é que a espera é satisfeita.
- Documentado explicitamente (remarks da classe): a proteção continua condicionada a `DisableParallelization` para atividade verdadeiramente alheia ao teste (ex.: outro teste paralelo) — o que ela elimina é o falso positivo de uma conexão que o PRÓPRIO teste conhece e pode enumerar.

Closes #1031

## Teste

- `dotnet test` local: suíte completa de Configuração (306 integração + 360 application + 586 domínio) verde, incluindo os 5 testes de concorrência (rodados isoladamente 3x para confirmar estabilidade).
- `dotnet format --verify-no-changes` limpo.
