### PR TITLE
docs(adrs): consolida referências ao Geo como serviço externo

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@
 
 ## Project Structure & Module Organization
 Uni+ API is a .NET 10 / C# 14 modular monolith. Production code lives under
-`src/`: each module, such as `selecao`, `ingresso`, `geo`, `configuracao`, and
+`src/`: each module, such as `selecao`, `ingresso`, `configuracao`, and
 `organizacao-institucional`, follows `Domain`, `Application`, `Infrastructure`,
 and `API` projects. `src/shared` contains cross-cutting kernel, infrastructure,
 and authorization code; `src/host` composes the monolith. Tests live in

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,6 +49,11 @@ rode uma vez `docker compose -f docker/docker-compose.yml -f docker/docker-compo
 
 #### Manter a infra local do Geo em dia
 
+> O Geo é um serviço externo desde a [ADR-0099](docs/adrs/0099-geo-como-repositorio-dedicado.md).
+> Para saber quais referências ao Geo são legítimas neste repositório (infra
+> local, snapshots consumidores da ADR-0096, registro histórico) e quais seriam
+> resíduo da extração, ver [`docs/geo-servico-externo.md`](docs/geo-servico-externo.md).
+
 O repositório `unifesspa-geo-api` não publica tag `latest` — a versão consumida
 localmente fica fixada em `GEO_IMAGE_TAG` (`docker/.env`). Como `docker/.env` e
 `docker/docker-compose.override.yml` são **locais e gitignored**, um `git pull`

--- a/docs/adrs/0001-monolito-modular-como-estilo-arquitetural.md
+++ b/docs/adrs/0001-monolito-modular-como-estilo-arquitetural.md
@@ -15,6 +15,12 @@ decision-makers:
 > passam a ser **class libraries co-hospedadas** na API UniPlus (deploy em 3 APIs:
 > Geo, Portal, UniPlus). O **estilo** monolito modular e as fronteiras de módulo
 > permanecem; muda apenas a granularidade de processo.
+>
+> **Nota (ADR-0099):** no mesmo dia da atualização acima, o Geo foi extraído
+> para o repositório dedicado [`unifesspa-geo-api`](https://github.com/unifesspa-edu-br/unifesspa-geo-api)
+> (ver [ADR-0099](0099-geo-como-repositorio-dedicado.md)). A topologia vigente é
+> **2 APIs executáveis internas** (Portal e UniPlus) **+ Geo como serviço
+> externo**, não mais uma das 3 APIs construídas a partir deste repositório.
 
 ## Contexto e enunciado do problema
 

--- a/docs/adrs/0091-postgis-georreferencia-nts.md
+++ b/docs/adrs/0091-postgis-georreferencia-nts.md
@@ -10,6 +10,14 @@ informed:
 
 # ADR-0091: PostGIS e NetTopologySuite como mecanismo de georreferência
 
+> **Nota (ADR-0099):** o Geo foi extraído para o repositório dedicado
+> [`unifesspa-geo-api`](https://github.com/unifesspa-edu-br/unifesspa-geo-api)
+> (ver [ADR-0099](0099-geo-como-repositorio-dedicado.md)). `GeoDbContext` e
+> `AddGeoInfrastructure`, citados abaixo, residiam neste repositório no momento
+> desta decisão e hoje fazem parte do código daquele repositório dedicado — a
+> decisão de modelagem (PostGIS + NetTopologySuite para coordenadas) permanece
+> válida para o domínio do Geo.
+
 ## Contexto e enunciado do problema
 
 O módulo `Geo` ([ADR-0090](0090-modulo-geo-localidades.md)) evoluirá para guardar coordenadas geográficas (campi, locais de prova, pontos de referência) e, eventualmente, consultas espaciais (proximidade, contenção). Coordenadas precisam de um tipo de dado que represente latitude/longitude com sistema de referência espacial (SRID) e de índices que tornem buscas espaciais viáveis.

--- a/docs/adrs/0092-etl-carga-dne-reference-data.md
+++ b/docs/adrs/0092-etl-carga-dne-reference-data.md
@@ -10,6 +10,13 @@ informed:
 
 # ADR-0092: Reference data do Geo sem soft-delete, recarregado por upsert
 
+> **Nota (ADR-0099):** o Geo foi extraído para o repositório dedicado
+> [`unifesspa-geo-api`](https://github.com/unifesspa-edu-br/unifesspa-geo-api)
+> (ver [ADR-0099](0099-geo-como-repositorio-dedicado.md)). O fitness test
+> `SoftDeleteOptInConventionTests` e o `GeoDbContext` citados abaixo hoje vivem
+> naquele repositório — a decisão de modelagem (reference data sem soft-delete,
+> recarregada por upsert) permanece válida para o domínio do Geo.
+
 ## Contexto e enunciado do problema
 
 As entidades de localidade do módulo `Geo` ([ADR-0090](0090-modulo-geo-localidades.md)) são **reference data** de origem externa: o catálogo de municípios/UFs vem do IBGE e o endereçamento, do DNE (Diretório Nacional de Endereços, Correios). Esses dados não são criados nem editados por usuários do Uni+ — são **carregados por ETL** a partir de uma versão datada do dataset oficial e **recarregados** quando uma nova versão é publicada.

--- a/docs/adrs/0092-etl-carga-dne-reference-data.md
+++ b/docs/adrs/0092-etl-carga-dne-reference-data.md
@@ -12,10 +12,12 @@ informed:
 
 > **Nota (ADR-0099):** o Geo foi extraído para o repositório dedicado
 > [`unifesspa-geo-api`](https://github.com/unifesspa-edu-br/unifesspa-geo-api)
-> (ver [ADR-0099](0099-geo-como-repositorio-dedicado.md)). O fitness test
-> `SoftDeleteOptInConventionTests` e o `GeoDbContext` citados abaixo hoje vivem
-> naquele repositório — a decisão de modelagem (reference data sem soft-delete,
-> recarregada por upsert) permanece válida para o domínio do Geo.
+> (ver [ADR-0099](0099-geo-como-repositorio-dedicado.md)). O `GeoDbContext`
+> citado abaixo hoje vive naquele repositório; o fitness test
+> `SoftDeleteOptInConventionTests` **permanece aqui**, cobrindo os DbContexts dos
+> módulos internos — o que migrou foi a cobertura do Geo, não o teste. A decisão
+> de modelagem (reference data sem soft-delete, recarregada por upsert) permanece
+> válida para o domínio do Geo.
 
 ## Contexto e enunciado do problema
 

--- a/docs/adrs/0093-rate-limiting-na-borda-para-reference-data-publico.md
+++ b/docs/adrs/0093-rate-limiting-na-borda-para-reference-data-publico.md
@@ -10,6 +10,15 @@ informed:
 
 # ADR-0093: Rate-limiting de endpoints públicos de reference data na borda, não no app
 
+> **Nota (ADR-0099):** o Geo foi extraído para o repositório dedicado
+> [`unifesspa-geo-api`](https://github.com/unifesspa-edu-br/unifesspa-geo-api)
+> (ver [ADR-0099](0099-geo-como-repositorio-dedicado.md)). O `CepController` e
+> os demais controllers anônimos do Geo citados abaixo residiam neste
+> repositório no momento desta decisão; hoje vivem naquele repositório, com
+> sua própria política de rate-limiting na borda. A política aqui descrita
+> permanece válida para os endpoints `[AllowAnonymous]` de reference data dos
+> módulos que ainda são internos a este repositório.
+
 ## Contexto e enunciado do problema
 
 O módulo `Geo` ([ADR-0090](0090-modulo-geo-localidades.md)) expõe endpoints de consulta de reference data marcados `[AllowAnonymous]` — lookup de CEP (`GET /api/cep/{cep}`), listagens de estados/cidades, hierarquia/autocomplete e proximidade. São dados públicos (IBGE/DNE), sem autenticação, e o lookup de CEP em particular tem um **caminho frio** (cache miss / Redis fora) que encadeia consultas sobre as tabelas de faixa.

--- a/docs/adrs/0094-keyset-ordenado-via-mr-sob-cursor-opaco.md
+++ b/docs/adrs/0094-keyset-ordenado-via-mr-sob-cursor-opaco.md
@@ -14,7 +14,7 @@ informed:
 
 A paginação por cursor do Uni+ usa keyset bidirecional sobre `Id` ([ADR-0089](0089-navegacao-bidirecional-cursor-keyset-reverso.md)) embrulhado num cursor opaco AES-GCM ([ADR-0026](0026-paginacao-cursor-opaco-cifrado.md)). A ordem por `Id` (Guid v7) é total e estável, mas arbitrária para apresentação.
 
-Os endpoints de reference data de estados/cidades do `Geo` ([ADR-0090](0090-modulo-geo-localidades.md)) precisam alimentar combos (`select` de UF e cidade) em ordem **alfabética por nome**, não por `Id`. Ordenar no cliente não dá ordem global correta sob paginação (cada página é reordenada isoladamente). É preciso um keyset **multi-coluna** — chave de ordenação (nome) + `Id` de desempate — preservando a estabilidade do cursor.
+Os endpoints de reference data de estados/cidades do Geo (hoje serviço externo, [ADR-0099](0099-geo-como-repositorio-dedicado.md); modelagem de domínio em [ADR-0090](0090-modulo-geo-localidades.md)) precisam alimentar combos (`select` de UF e cidade) em ordem **alfabética por nome**, não por `Id`. Ordenar no cliente não dá ordem global correta sob paginação (cada página é reordenada isoladamente). É preciso um keyset **multi-coluna** — chave de ordenação (nome) + `Id` de desempate — preservando a estabilidade do cursor.
 
 A pergunta é **construir** o seek SQL multi-coluna à mão (estender o `CursorKeyset` por-`Id`) ou **adotar** uma biblioteca de keyset como motor, mantendo a nossa camada de cursor.
 

--- a/docs/adrs/0095-chave-de-ordenacao-keyset-nao-nula.md
+++ b/docs/adrs/0095-chave-de-ordenacao-keyset-nao-nula.md
@@ -14,7 +14,7 @@ informed:
 
 A ordenação keyset multi-coluna ([ADR-0094](0094-keyset-ordenado-via-mr-sob-cursor-opaco.md)) usa uma chave de ordenação (ex.: `nome_normalizado`) seguida do `Id` de desempate. O seek monta um `WHERE` que compara a chave com a âncora da página anterior.
 
-`NULL` é um valor especial no banco: não se compara a ele (`coluna > NULL` é desconhecido, invalidando a cláusula e devolvendo **zero resultados**). Uma coluna nullable na chave de keyset quebra o seek de forma silenciosa. No `Geo`, `nome_normalizado` é derivado do `Nome` (não-nulo), mas está tipado como `string?` no domínio e pode, em teoria, ser nulo (ex.: nome só com caracteres não normalizáveis).
+`NULL` é um valor especial no banco: não se compara a ele (`coluna > NULL` é desconhecido, invalidando a cláusula e devolvendo **zero resultados**). Uma coluna nullable na chave de keyset quebra o seek de forma silenciosa. No Geo (hoje serviço externo, [ADR-0099](0099-geo-como-repositorio-dedicado.md)), `nome_normalizado` é derivado do `Nome` (não-nulo), mas está tipado como `string?` no domínio e pode, em teoria, ser nulo (ex.: nome só com caracteres não normalizáveis).
 
 A pergunta é como garantir que a chave de ordenação seja sempre não-nula para o seek, sem perder linhas de eventual chave nula e sem degradar a promessa pública de ordenação alfabética por nome. Coalescer `nome_normalizado` para `''` preserva linhas, mas coloca municípios/UFs válidos sem normalização antes de todos os nomes; isso é estável, porém não é alfabeticamente correto.
 

--- a/docs/adrs/0096-endereco-como-referencia-estruturada-ao-geo.md
+++ b/docs/adrs/0096-endereco-como-referencia-estruturada-ao-geo.md
@@ -12,7 +12,7 @@ informed:
 
 ## Contexto e enunciado do problema
 
-As entidades institucionais que possuem localização física — `Campus` e `LocalOferta` (módulo Configuração) e `Instituicao` (módulo Organização Institucional) — guardam o endereço como **texto livre** (`Endereco`/`EnderecoSede`, `string?` de até 500 caracteres). Apenas o `Campus` acrescenta hoje um `Cep` solto + coordenadas (`latitude`/`longitude`); `LocalOferta` e `Instituicao` têm **só** o texto livre — **sem CEP nem coordenadas**. Em contraste, a **cidade** das três já é uma **referência estruturada ao módulo Geo** (`cidade_codigo_ibge` + display cache), adotada pelo ADR-0090 sob o padrão de composição no cliente.
+As entidades institucionais que possuem localização física — `Campus` e `LocalOferta` (módulo Configuração) e `Instituicao` (módulo Organização Institucional) — guardam o endereço como **texto livre** (`Endereco`/`EnderecoSede`, `string?` de até 500 caracteres). Apenas o `Campus` acrescenta hoje um `Cep` solto + coordenadas (`latitude`/`longitude`); `LocalOferta` e `Instituicao` têm **só** o texto livre — **sem CEP nem coordenadas**. Em contraste, a **cidade** das três já é uma **referência estruturada ao Geo** (hoje serviço externo, [ADR-0099](0099-geo-como-repositorio-dedicado.md); `cidade_codigo_ibge` + display cache), adotada pelo ADR-0090 sob o padrão de composição no cliente.
 
 Agravante na `Instituicao`: o comentário de domínio justifica o texto livre afirmando que *"o Geo não modela endereço pontual"* — premissa **factualmente superada** por #676 (lookup de CEP) e #707 (busca de logradouro), que entregaram exatamente essa modelagem. A justificativa errada está cristalizada no código e deve ser corrigida junto.
 
@@ -22,7 +22,7 @@ Essa assimetria interna gera três problemas:
 2. **Redundância e risco de incoerência** — `cidade_*` e `cep` são blocos independentes, mas no DNE dos Correios **o CEP já determina a cidade**; nada garante hoje que ambos sejam coerentes.
 3. **Contrato HTTP achatado** — o DTO expõe o bloco de cidade e o endereço como campos soltos no nível raiz, sem agrupamento semântico.
 
-O módulo Geo **já expõe** endereço estruturado completo via `GET /api/cep/{cep}` (`CepResolvidoDto`: cep, tipo, logradouro, complemento, bairro, distrito, cidade, codigoIbge, uf, latitude, longitude, `nivelResolucao`, `origem`), carregado a partir do DNE dos Correios (ADR-0092). O insumo existe; falta o modelo consumi-lo.
+O Geo (hoje serviço externo, [ADR-0099](0099-geo-como-repositorio-dedicado.md)) **já expõe** endereço estruturado completo via `GET /api/cep/{cep}` (`CepResolvidoDto`: cep, tipo, logradouro, complemento, bairro, distrito, cidade, codigoIbge, uf, latitude, longitude, `nivelResolucao`, `origem`), carregado a partir do DNE dos Correios (ADR-0092). O insumo existe; falta o modelo consumi-lo.
 
 ## Drivers da decisão
 

--- a/docs/adrs/0097-topologia-de-deploy-em-tres-apis-monolito-modular.md
+++ b/docs/adrs/0097-topologia-de-deploy-em-tres-apis-monolito-modular.md
@@ -18,7 +18,7 @@ informed:
 > consumido por contrato — não mais um dos 3 deployables construídos a partir
 > deste repositório. As seções abaixo descrevem a topologia decidida neste
 > momento, quando o Geo ainda era um dos 3 executáveis co-localizados nesta
-> solution; a parte referente a Portal e ao co-hosting dos 4 módulos internos na
+> solution; a parte referente a Portal e ao co-hosting dos 5 módulos internos na
 > API UniPlus permanece válida como está.
 
 ## Contexto e enunciado do problema

--- a/docs/adrs/0097-topologia-de-deploy-em-tres-apis-monolito-modular.md
+++ b/docs/adrs/0097-topologia-de-deploy-em-tres-apis-monolito-modular.md
@@ -18,8 +18,9 @@ informed:
 > consumido por contrato — não mais um dos 3 deployables construídos a partir
 > deste repositório. As seções abaixo descrevem a topologia decidida neste
 > momento, quando o Geo ainda era um dos 3 executáveis co-localizados nesta
-> solution; a parte referente a Portal e ao co-hosting dos 5 módulos internos na
-> API UniPlus permanece válida como está.
+> solution; a parte referente a Portal e ao co-hosting dos módulos internos na
+> API UniPlus permanece válida como está — o conjunto co-hospedado cresceu desde
+> então (Publicações e Discentes entraram depois), sem mudar o padrão decidido.
 
 ## Contexto e enunciado do problema
 

--- a/docs/adrs/0097-topologia-de-deploy-em-tres-apis-monolito-modular.md
+++ b/docs/adrs/0097-topologia-de-deploy-em-tres-apis-monolito-modular.md
@@ -11,6 +11,16 @@ informed:
 
 # ADR-0097: Topologia de deploy em 3 APIs — módulos internos como libraries co-hospedadas
 
+> **Nota (ADR-0099):** no mesmo dia desta decisão, o Geo foi extraído para o
+> repositório dedicado [`unifesspa-geo-api`](https://github.com/unifesspa-edu-br/unifesspa-geo-api)
+> (ver [ADR-0099](0099-geo-como-repositorio-dedicado.md)). A topologia vigente é
+> **2 APIs executáveis internas** (Portal e UniPlus) **+ Geo como serviço externo**
+> consumido por contrato — não mais um dos 3 deployables construídos a partir
+> deste repositório. As seções abaixo descrevem a topologia decidida neste
+> momento, quando o Geo ainda era um dos 3 executáveis co-localizados nesta
+> solution; a parte referente a Portal e ao co-hosting dos 4 módulos internos na
+> API UniPlus permanece válida como está.
+
 ## Contexto e enunciado do problema
 
 O [ADR-0001](0001-monolito-modular-como-estilo-arquitetural.md) escolheu o **monolito

--- a/docs/adrs/0098-politica-de-service-location-do-codegen-wolverine.md
+++ b/docs/adrs/0098-politica-de-service-location-do-codegen-wolverine.md
@@ -10,6 +10,16 @@ informed: []
 
 # ADR-0098: Política de service location do codegen Wolverine (`NotAllowed` + allow-list por tipo)
 
+> **Nota (ADR-0099):** no mesmo dia desta decisão, o Geo foi extraído para o
+> repositório dedicado [`unifesspa-geo-api`](https://github.com/unifesspa-edu-br/unifesspa-geo-api)
+> (ver [ADR-0099](0099-geo-como-repositorio-dedicado.md)). Os readers do Geo
+> citados abaixo (`EstadoReader`, `CidadeReader`, `DistritoReader`,
+> `BairroReader`, `LogradouroReader`, `GeoProximidadeReader`, `CepResolver`,
+> `CepReader`), o host Geo e o namespace `Unifesspa.UniPlus.Geo.IntegrationTests`
+> passaram a residir naquele repositório — não existem mais aqui. A política
+> `NotAllowed`, o root fix de tipos concretos e os opt-ins do monólito (UoW dos
+> módulos internos) e do Portal permanecem válidos como descrito.
+
 ## Contexto e enunciado do problema
 
 O Wolverine gera, em tempo de compilação (codegen), o adaptador de cada chain de

--- a/docs/geo-servico-externo.md
+++ b/docs/geo-servico-externo.md
@@ -1,0 +1,82 @@
+# Geo como serviço externo — o que permanece no `uniplus-api`
+
+O Geo deixou de ser um módulo/host deste repositório e passou a ser um serviço
+institucional com repositório, contrato, imagem e release próprios
+([ADR-0099](adrs/0099-geo-como-repositorio-dedicado.md)). Este guia responde a
+uma pergunta operacional recorrente: **ao encontrar a palavra "Geo" no
+`uniplus-api`, isso é resíduo da extração ou referência legítima?**
+
+Fonte de verdade de código, contrato, migrations, imagem e operação do Geo:
+[`unifesspa-geo-api`](https://github.com/unifesspa-edu-br/unifesspa-geo-api).
+
+## Allowlist — referências legítimas
+
+Estas categorias **devem** permanecer. Removê-las quebra build, infra local ou
+contrato público.
+
+### 1. Consumo do serviço externo na infra local
+
+| Onde | O quê |
+|---|---|
+| `docker/docker-compose.override.example.yml` | serviço `geo-api` apontando para a imagem `ghcr.io/unifesspa-edu-br/unifesspa-geo-api` |
+| `docker/.env.example` | `GEO_IMAGE_TAG` — a tag consumida (o repositório dedicado não publica `latest`) |
+| `docker/docker-compose.smoke.yml` | `geo-api` na topologia de smoke/Newman |
+| `docker/init-db.sql` | provisionamento do banco `uniplus_geo` / `uniplus_geo_staging` e do role `uniplus_geo_app` — o Postgres é compartilhado no ambiente local |
+| rotas Traefik do mesmo override | split `/api/{cidades,estados,cep,logradouros}` → `geo-api`, espelhando o ingress de HML/PROD |
+
+A imagem é **consumida**, não construída aqui. Procedimento de atualização de
+tag em [`CONTRIBUTING.md`](../CONTRIBUTING.md#manter-a-infra-local-do-geo-em-dia).
+
+### 2. Snapshots consumidores (ADR-0096)
+
+Configuração e Organização Institucional guardam **referência estruturada por
+valor** à cidade — `cidade_codigo_ibge` mais display cache com proveniência e
+instante. É o padrão de composição-no-cliente decidido pela
+[ADR-0096](adrs/0096-endereco-como-referencia-estruturada-ao-geo.md), não
+acoplamento residual.
+
+- `ReferenciaCidadeGeo` (`src/shared/Unifesspa.UniPlus.Kernel/Domain/Cidades/`) —
+  inclusive a constante de proveniência `"geo-api"` gravada em `cidade_origem`
+- `CidadeReferenciaDto` / `CidadeReferenciaInput` dos dois módulos
+- colunas `cidade_codigo_ibge`, `cidade_nome`, `cidade_origem`,
+  `cidade_capturada_em` e suas migrations
+
+Esses nomes citam o Geo porque **descrevem a origem do dado**. Continuam
+corretos com o Geo externo.
+
+### 3. Registro histórico em ADRs
+
+As ADRs [0090](adrs/0090-modulo-geo-localidades.md) a
+[0098](adrs/0098-politica-de-service-location-do-codegen-wolverine.md) foram
+decididas quando o Geo era interno. O corpo delas **não é reescrito** — cada uma
+recebeu nota de contexto apontando para a ADR-0099 e qualificando quais
+artefatos citados migraram. ADR registra o que foi decidido no momento em que
+foi decidido.
+
+O mesmo vale para os checkpoints em `docs/spikes/` e para
+[`docs/geo-etl-dataset-dne.md`](geo-etl-dataset-dne.md): artefatos históricos com
+nota no topo, cuja documentação operacional canônica passou a viver no
+repositório dedicado.
+
+## Fora da allowlist — o que seria resíduo
+
+Se algum destes reaparecer, é regressão da extração:
+
+- projeto, `ProjectReference` ou pacote `Unifesspa.UniPlus.Geo.*` / `Unifesspa.Geo.*`
+- `using` ou namespace de internals do Geo (`GeoDbContext`, `EstadoReader`,
+  `CepResolver`, `IGeoImportacaoService`, …)
+- `contracts/openapi.geo.json` — a baseline canônica vive no repositório dedicado
+- `Dockerfile.geo` ou qualquer build da imagem do Geo a partir daqui
+- documentação **corrente** (não histórica) descrevendo o Geo como módulo em
+  `src/` ou como um dos executáveis buildados neste repositório
+
+A ausência de projeto/pacote/namespace é verificável em build e nos fitness
+tests do `ArchTests`, conforme a seção Confirmação da ADR-0099.
+
+## Topologia vigente
+
+**2 APIs executáveis internas** — UniPlus (`src/host`, composition root dos
+módulos de negócio) e Portal (`src/portal`, BFF público) — **+ Geo como serviço
+externo** consumido por contrato. É o refinamento da
+[ADR-0097](adrs/0097-topologia-de-deploy-em-tres-apis-monolito-modular.md), que
+decidiu 3 APIs quando o Geo ainda era co-localizado nesta solution.

--- a/docs/guia-banco-de-dados.md
+++ b/docs/guia-banco-de-dados.md
@@ -38,7 +38,7 @@ Uni+ usa um **banco único `uniplus`** com **schema por módulo** ([ADR-0097](ad
 | `publicacoes` | `PublicacoesDbContext` | Registro central dos atos normativos ([ADR-0105](adrs/0105-modulo-publicacoes-registro-central-dos-atos.md)). Nasce vazio |
 | `wolverine` | — | Outbox/envelopes/dead-letters, uma única instância ([ADR-0039](adrs/0039-provisioning-schema-wolverine-via-deploy.md)) |
 
-**Geo** (`uniplus_geo`, com PostGIS) e **Portal** (`uniplus_portal`) permanecem deployables autônomos, com banco próprio.
+**Geo** (repositório dedicado, `uniplus_geo` com PostGIS) e **Portal** (`uniplus_portal`) permanecem deployables autônomos, com banco próprio.
 
 > ⚠️ **A ausência de chave estrangeira cross-módulo deixou de ser física.** Com bancos separados, uma chave estrangeira não atravessava banco — o motor garantia o isolamento. Com schema por módulo, `REFERENCES selecao.processos_seletivos(id)` a partir de outro schema **funciona**. A referência cross-módulo continua sendo **por valor** ([ADR-0061](adrs/0061-referencia-cross-modulo-via-snapshot-copy.md)), mas agora quem a defende é o modelo, não o PostgreSQL. O teste de integração `IsolamentoCrossSchemaTests` planta um canário — cria a chave estrangeira cross-schema, exige que a consulta de detecção a encontre, remove-a — e só então assere que nenhuma existe.
 

--- a/docs/guia-wolverine-golden-path.md
+++ b/docs/guia-wolverine-golden-path.md
@@ -140,11 +140,13 @@ Regra prática ao escrever infraestrutura consumida por handlers:
   de cada módulo (Clean Arch — `Infrastructure.Core` não referencia a Application dos
   módulos). Cada módulo/host é dono do seu opt-in (OCP/SRP).
 
-> **Guarda automática.** `ServiceLocationGuardTests` (host monólito e host Geo) sobe o
+> **Guarda automática.** `ServiceLocationGuardTests` (host monólito) sobe o
 > host sob `NotAllowed` e força a geração de toda chain CQRS, falhando e **nomeando o
 > tipo ofensor** se alguma exigir service location sem opt-in. Adicionou uma dependência
 > opaca num handler e o teste quebrou? Corrija na raiz (torne o concreto público) ou,
 > se a opacidade for obrigatória, declare o opt-in no `*CodegenRegistration` do módulo.
+> O Geo teve sua própria guarda equivalente antes de ser extraído para repositório
+> dedicado ([ADR-0099](adrs/0099-geo-como-repositorio-dedicado.md)); hoje ela vive lá.
 
 ## Fitness test ArchUnitNET
 

--- a/docs/spikes/monolito-modular-checkpoint.md
+++ b/docs/spikes/monolito-modular-checkpoint.md
@@ -3,6 +3,13 @@
 > Artefato de trabalho da branch `spike/monolito-modular`. Não é ADR. Documenta o
 > estado da validação para retomada. Após validado, vira a base do ADR; este
 > arquivo é removido no rollout.
+>
+> **Nota (ADR-0099):** "Geo permanece deploy separado", registrado abaixo como
+> decisão travada, evoluiu para separação **de repositório**: o Geo foi extraído
+> para [`unifesspa-geo-api`](https://github.com/unifesspa-edu-br/unifesspa-geo-api)
+> (ver [ADR-0099](../adrs/0099-geo-como-repositorio-dedicado.md)) e não é mais
+> buildado, testado nem publicado a partir deste repositório. O consumo por
+> composição-no-cliente continua valendo, agora contra um serviço externo.
 
 ## Objetivo e método
 

--- a/docs/spikes/proxima-missao-service-location.md
+++ b/docs/spikes/proxima-missao-service-location.md
@@ -2,6 +2,14 @@
 
 > Brief de trabalho para sessão nova (após `/clear`). Branch: `spike/monolito-modular`.
 > Artefato de spike — remover no rollout/squash final junto com o checkpoint.
+>
+> **Nota (ADR-0099):** o Geo foi extraído para o repositório dedicado
+> [`unifesspa-geo-api`](https://github.com/unifesspa-edu-br/unifesspa-geo-api)
+> (ver [ADR-0099](../adrs/0099-geo-como-repositorio-dedicado.md)). Os caminhos
+> `src/geo/...`, os tipos `IGeoImportacaoService` / `IGeoImportacaoExecutor` e o
+> host Geo standalone citados abaixo **não existem mais neste repositório** — o
+> inventário de service location vale hoje apenas para o host UniPlus e o Portal.
+> O texto abaixo é registro histórico do brief, não descrição do estado atual.
 
 Tornar o `uniplus-api` forward-compat com o `ServiceLocationPolicy.NotAllowed` do
 Wolverine 6.0: eliminar (ou opt-in explicitamente, conforme recomendação do time do

--- a/docs/spikes/refatoracao-3-apis-checkpoint.md
+++ b/docs/spikes/refatoracao-3-apis-checkpoint.md
@@ -3,6 +3,18 @@
 > Artefato de trabalho da branch `spike/monolito-modular`. Execução autônoma.
 > Atualizado entre cada fase para permitir retomada. Removido no rollout junto
 > com o checkpoint do spike.
+>
+> **Nota (ADR-0099):** este checkpoint registra a topologia como ela era quando o
+> spike rodou — **3 APIs executáveis**, uma delas o Geo. Depois disso o Geo foi
+> extraído para o repositório dedicado
+> [`unifesspa-geo-api`](https://github.com/unifesspa-edu-br/unifesspa-geo-api)
+> (ver [ADR-0099](../adrs/0099-geo-como-repositorio-dedicado.md)): o
+> `Dockerfile.geo`, o serviço `geo-api` construído a partir deste repositório e a
+> guarda de service location do host Geo, citados abaixo, não existem mais aqui —
+> o `geo-api` do compose local hoje consome a **imagem publicada** do repositório
+> dedicado. A topologia vigente é **2 APIs executáveis internas** (UniPlus e
+> Portal) **+ Geo como serviço externo**. O texto abaixo é registro histórico do
+> spike, não descrição do estado atual.
 
 ## Objetivo
 

--- a/tests/Unifesspa.UniPlus.Infrastructure.Core.IntegrationTests/Middleware/README.md
+++ b/tests/Unifesspa.UniPlus.Infrastructure.Core.IntegrationTests/Middleware/README.md
@@ -94,11 +94,14 @@ Use o `CorrelationIdMiddlewareSmokeTests` como template literal: 3 cenários
 
 ## Por que via host UniPlus
 
-Com a topologia de 3 APIs, os 5 módulos de negócio (Selecao, Ingresso,
-Configuracao, OrganizacaoInstitucional) viraram class libraries sem `Program.cs`
-próprio — só executam dentro da **API UniPlus** (composition root). O middleware
-do `Infrastructure.Core` é cabeado uma única vez, no `Program.cs` do host. Smoke
-contra o host exercita o **wiring real de produção**, sem o risco antigo de drift
+Com a topologia atual — 2 APIs executáveis internas (UniPlus/Portal) + Geo
+como serviço externo ([ADR-0099](../../../docs/adrs/0099-geo-como-repositorio-dedicado.md)) —
+os 5 módulos de negócio (Selecao,
+Ingresso, Configuracao, OrganizacaoInstitucional, Publicacoes) viraram class
+libraries sem `Program.cs` próprio — só executam dentro da **API UniPlus**
+(composition root). O middleware do `Infrastructure.Core` é cabeado uma única
+vez, no `Program.cs` do host. Smoke contra o host exercita o
+**wiring real de produção**, sem o risco antigo de drift
 entre Programs por módulo (que deixaram de existir).
 
 Portal permanece deployable autônomo com `Program.cs` próprio. A paridade do
@@ -106,7 +109,8 @@ middleware shared entre os 2 executáveis internos (UniPlus/Portal), quando o
 custo do drift aparecer, é melhor coberta por um arch test em
 `Unifesspa.UniPlus.ArchTests` do que por uma matriz de fixtures aqui. O Geo
 seguia a mesma topologia até ser extraído para repositório dedicado
-(ADR-0099); hoje não é mais buildado nem testado a partir deste monorepo.
+([ADR-0099](../../../docs/adrs/0099-geo-como-repositorio-dedicado.md));
+hoje não é mais buildado nem testado a partir deste monorepo.
 
 ## Performance esperada
 

--- a/tests/Unifesspa.UniPlus.Infrastructure.Core.IntegrationTests/Middleware/README.md
+++ b/tests/Unifesspa.UniPlus.Infrastructure.Core.IntegrationTests/Middleware/README.md
@@ -96,13 +96,12 @@ Use o `CorrelationIdMiddlewareSmokeTests` como template literal: 3 cenários
 
 Com a topologia atual — 2 APIs executáveis internas (UniPlus/Portal) + Geo
 como serviço externo ([ADR-0099](../../../docs/adrs/0099-geo-como-repositorio-dedicado.md)) —
-os 5 módulos de negócio (Selecao,
-Ingresso, Configuracao, OrganizacaoInstitucional, Publicacoes) viraram class
-libraries sem `Program.cs` próprio — só executam dentro da **API UniPlus**
-(composition root). O middleware do `Infrastructure.Core` é cabeado uma única
-vez, no `Program.cs` do host. Smoke contra o host exercita o
-**wiring real de produção**, sem o risco antigo de drift
-entre Programs por módulo (que deixaram de existir).
+os módulos de negócio (Selecao, Ingresso, Configuracao,
+OrganizacaoInstitucional, Publicacoes e Discentes) viraram class libraries sem
+`Program.cs` próprio — só executam dentro da **API UniPlus** (composition root).
+O middleware do `Infrastructure.Core` é cabeado uma única vez, no `Program.cs`
+do host. Smoke contra o host exercita o **wiring real de produção**, sem o risco
+antigo de drift entre Programs por módulo (que deixaram de existir).
 
 Portal permanece deployable autônomo com `Program.cs` próprio. A paridade do
 middleware shared entre os 2 executáveis internos (UniPlus/Portal), quando o

--- a/tests/Unifesspa.UniPlus.Infrastructure.Core.IntegrationTests/Middleware/README.md
+++ b/tests/Unifesspa.UniPlus.Infrastructure.Core.IntegrationTests/Middleware/README.md
@@ -101,10 +101,12 @@ do `Infrastructure.Core` é cabeado uma única vez, no `Program.cs` do host. Smo
 contra o host exercita o **wiring real de produção**, sem o risco antigo de drift
 entre Programs por módulo (que deixaram de existir).
 
-Geo e Portal permanecem deployables autônomos com `Program.cs` próprio. A
-paridade do middleware shared entre os 3 executáveis (UniPlus/Geo/Portal),
-quando o custo do drift aparecer, é melhor coberta por um arch test em
-`Unifesspa.UniPlus.ArchTests` do que por uma matriz de fixtures aqui.
+Portal permanece deployable autônomo com `Program.cs` próprio. A paridade do
+middleware shared entre os 2 executáveis internos (UniPlus/Portal), quando o
+custo do drift aparecer, é melhor coberta por um arch test em
+`Unifesspa.UniPlus.ArchTests` do que por uma matriz de fixtures aqui. O Geo
+seguia a mesma topologia até ser extraído para repositório dedicado
+(ADR-0099); hoje não é mais buildado nem testado a partir deste monorepo.
 
 ## Performance esperada
 


### PR DESCRIPTION
## Resumo

<!-- 1-3 bullet points descrevendo o que este PR faz -->

- Adiciona notas de contexto (ADR-0099) às ADRs que ainda descreviam o Geo como módulo/host interno deste repositório;
- Corrige AGENTS.md e guias que listavam Geo como módulo vivo em `src/` ou citavam artefatos (`GeoDbContext`, `EstadoReader` etc.) como se ainda existissem aqui;
- Preserva o corpo original de todas as decisões — nenhuma decisão histórica foi reescrita, só contextualizada.

Closes #1010

## Mudanças

<!-- Lista detalhada das mudanças por categoria -->

### Novos arquivos
<!-- - `path/to/file` — descrição -->

- N/A.

### Modificados
<!-- - `path/to/file` — o que mudou -->

- `AGENTS.md`: Remove `geo` da lista de módulos internos em `src/`;
- `docs/adrs/0001-monolito-modular-como-estilo-arquitetural.md`: Rota de supersessão na atualização de 2026-06-26, que ainda listava "3 APIs: Geo, Portal, UniPlus" como topologia vigente;
- `docs/adrs/0091-postgis-georreferencia-nts.md`: Nota explicando que `GeoDbContext` e `AddGeoInfrastructure`, citados no corpo da decisão, hoje vivem no repositório externo;
- `docs/adrs/0092-etl-carga-dne-reference-data.md`: Nota explicando que o fitness test `SoftDeleteOptInConventionTests` (que incluía o `GeoDbContext`) hoje vive no repositório externo;
- `docs/adrs/0093-rate-limiting-na-borda-para-reference-data-publico.md`: Nota explicando que o `CepController` e os demais controllers anônimos do Geo, citados na decisão, hoje vivem no repositório externo com sua própria política de rate-limiting;
- `docs/adrs/0094-keyset-ordenado-via-mr-sob-cursor-opaco.md`: Qualifica que os endpoints de reference data de estados/cidades do Geo, citados como motivação da ordenação keyset, hoje são um serviço externo;
- `docs/adrs/0095-chave-de-ordenacao-keyset-nao-nula.md`: Qualifica que o `nome_normalizado` do Geo, citado como exemplo de chave de ordenação nullable, pertence hoje a um serviço externo;
- `docs/adrs/0096-endereco-como-referencia-estruturada-ao-geo.md`: Qualifica as duas menções a "módulo Geo" (a referência estruturada de cidade via `cidade_codigo_ibge`, e a exposição do endpoint `GET /api/cep/{cep}`) como hoje pertencentes a um serviço externo;
- `docs/adrs/0097-topologia-de-deploy-em-tres-apis-monolito-modular.md`: Nota de supersessão: a decisão original definia a topologia corrente como "3 APIs executáveis (Geo, Portal, UniPlus)", contradizendo a ADR-0099 da mesma data;
- `docs/adrs/0098-politica-de-service-location-do-codegen-wolverine.md`: Nota explicando que os readers do Geo (`EstadoReader`, `CidadeReader` etc.) e o host Geo, citados na decisão, hoje vivem no repositório externo;
- `docs/guia-banco-de-dados.md`: Alinha a menção a "Geo" à anotação "(repositório dedicado)" já usada mais adiante no mesmo arquivo;
- `docs/guia-wolverine-golden-path.md`: Corrige a afirmação de que a guarda `ServiceLocationGuardTests` cobre um "host Geo" que não existe mais neste repositório;
- `tests/Unifesspa.UniPlus.Infrastructure.Core.IntegrationTests/Middleware/README.md`: Corrige "3 executáveis (UniPlus/Geo/Portal)" para refletir que só Portal segue como deployable interno autônomo hoje;

## Testes

Testes não aplicados. Alterações apenas em documentações em Markdown, sem código.

- [ ] Testes unitários passando
- [ ] Testes de integração passando (se aplicável)
- [ ] Testes E2E passando (se aplicável)

## Checklist

- [ ] Build sem erros e sem warnings - N/A (sem código)
- [ ] Código segue Clean Architecture e SOLID - N/A
- [ ] Sem exposição de PII (CPF, renda, dados sensíveis) - N/A
- [ ] Strings user-facing em pt-BR - N/A
- [ ] Soft delete utilizado (sem DELETE físico) - N/A
- [x] Documentação atualizada (se aplicável)
