### PR TITLE
fix(selecao): reconfere coletabilidade de fatos ao congelar versão

### DIFF
--- a/src/selecao/Unifesspa.UniPlus.Selecao.API/Errors/SelecaoDomainErrorRegistration.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.API/Errors/SelecaoDomainErrorRegistration.cs
@@ -281,6 +281,10 @@ internal sealed class SelecaoDomainErrorRegistration : IDomainErrorRegistration
         // append-only (ADR-0111), então este código não deveria ocorrer em produção, mas
         // precisa de mapeamento nomeado (não um 500 genérico) se ocorrer.
         new("ProcessoSeletivo.FatoCongeladoNaoEncontrado", new DomainErrorMapping(StatusCodes.Status422UnprocessableEntity, "uniplus.selecao.processo_seletivo.fato_congelado_nao_encontrado", "Fato citado em condição de gatilho não encontrado no catálogo de fatos do candidato")),
+        // Reconferência de coletabilidade no congelamento: o catálogo pode reclassificar a
+        // Origem de um fato depois que ele já virou FatoColetado (ex.: a migration que
+        // reclassificou MODALIDADE de DECLARADO para DERIVADO).
+        new("ProcessoSeletivo.FatoColetadoNaoMaisDeclarado", new DomainErrorMapping(StatusCodes.Status422UnprocessableEntity, "uniplus.selecao.processo_seletivo.fato_coletado_nao_mais_declarado", "Fato coletado deixou de ser declarado/vinculado a campo de inscrição no catálogo de fatos do candidato")),
         // Seletor de snapshot vigente (T6 #787, ADR-0075/0076): não há publicação
         // vigente ≤ o instante consultado — 422, nunca retorno silencioso.
         new("Snapshot.VigenteAusente", new DomainErrorMapping(StatusCodes.Status422UnprocessableEntity, "uniplus.selecao.snapshot.vigente_ausente", "Nenhuma publicação vigente para o instante")),

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Application/Commands/ProcessosSeletivos/ConferenciaDeColetabilidadeDeFatos.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Application/Commands/ProcessosSeletivos/ConferenciaDeColetabilidadeDeFatos.cs
@@ -1,0 +1,68 @@
+namespace Unifesspa.UniPlus.Selecao.Application.Commands.ProcessosSeletivos;
+
+using Abstractions;
+
+using Domain.Entities;
+
+using Kernel.Results;
+
+using Unifesspa.UniPlus.Configuracao.Contracts;
+
+/// <summary>
+/// Reconfere, no momento do congelamento, que cada <see cref="FatoColetado"/> do processo ainda
+/// satisfaz <see cref="ColetabilidadeDeFato.EhColetavel"/> contra o catálogo VIVO — o mesmo
+/// predicado que <see cref="DefinirFatosColetadosCommandHandler"/> já aplica ao vincular o fato
+/// (PUT /fatos-coletados), reaplicado aqui porque o catálogo pode reclassificar a
+/// <c>Origem</c> de um fato depois que ele já virou <see cref="FatoColetado"/> — a migration que
+/// reclassificou MODALIDADE de DECLARADO para DERIVADO é o caminho real que o projeto usa para
+/// evoluir o catálogo. Sem esta reconferência, um vínculo morto seria congelado numa versão
+/// append-only e, pela doutrina do agregado, irreparável depois.
+/// </summary>
+/// <remarks>
+/// Espelha <see cref="ResolvedorMetadadosFatosCongelados"/> em estilo: helper estático
+/// compartilhado pelos três handlers que congelam. Usa
+/// <see cref="IFatoCandidatoReader.ListarAsync"/> (o catálogo inteiro, baixo volume) em vez de
+/// uma consulta por código — todo <see cref="FatoColetado"/> do processo precisa ser revisitado,
+/// ao contrário do congelamento de metadado, que só revisita os poucos fatos citados em gatilho
+/// de documento.
+/// </remarks>
+internal static class ConferenciaDeColetabilidadeDeFatos
+{
+    public const string FatoColetadoNaoMaisDeclarado = "ProcessoSeletivo.FatoColetadoNaoMaisDeclarado";
+
+    public static async Task<Result> ConferirAsync(
+        ProcessoSeletivo processo,
+        IFatoCandidatoReader fatoCandidatoReader,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(processo);
+        ArgumentNullException.ThrowIfNull(fatoCandidatoReader);
+
+        if (processo.FatosColetados.Count == 0)
+        {
+            return Result.Success();
+        }
+
+        IReadOnlyList<FatoCandidatoView> catalogo = await fatoCandidatoReader
+            .ListarAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        Dictionary<string, FatoCandidatoView> porCodigo = catalogo
+            .ToDictionary(static f => f.Codigo, StringComparer.Ordinal);
+
+        foreach (FatoColetado fatoColetado in processo.FatosColetados.OrderBy(static f => f.Ordem))
+        {
+            if (!porCodigo.TryGetValue(fatoColetado.FatoCodigo, out FatoCandidatoView? fato)
+                || !ColetabilidadeDeFato.EhColetavel(fato))
+            {
+                return Result.Failure(new DomainError(
+                    FatoColetadoNaoMaisDeclarado,
+                    $"O fato coletado '{fatoColetado.FatoCodigo}' não é mais declarado/vinculado a campo de " +
+                    "inscrição no catálogo de fatos do candidato — o catálogo mudou depois que este fato foi " +
+                    "vinculado ao formulário, e o congelamento não persiste um vínculo que já não é coletável."));
+            }
+        }
+
+        return Result.Success();
+    }
+}

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Application/Commands/ProcessosSeletivos/ConferenciaDeColetabilidadeDeFatos.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Application/Commands/ProcessosSeletivos/ConferenciaDeColetabilidadeDeFatos.cs
@@ -50,17 +50,18 @@ internal static class ConferenciaDeColetabilidadeDeFatos
         Dictionary<string, FatoCandidatoView> porCodigo = catalogo
             .ToDictionary(static f => f.Codigo, StringComparer.Ordinal);
 
-        foreach (FatoColetado fatoColetado in processo.FatosColetados.OrderBy(static f => f.Ordem))
+        FatoColetado? naoColetavel = processo.FatosColetados
+            .OrderBy(static f => f.Ordem)
+            .FirstOrDefault(f => !porCodigo.TryGetValue(f.FatoCodigo, out FatoCandidatoView? fato)
+                || !ColetabilidadeDeFato.EhColetavel(fato));
+
+        if (naoColetavel is not null)
         {
-            if (!porCodigo.TryGetValue(fatoColetado.FatoCodigo, out FatoCandidatoView? fato)
-                || !ColetabilidadeDeFato.EhColetavel(fato))
-            {
-                return Result.Failure(new DomainError(
-                    FatoColetadoNaoMaisDeclarado,
-                    $"O fato coletado '{fatoColetado.FatoCodigo}' não é mais declarado/vinculado a campo de " +
-                    "inscrição no catálogo de fatos do candidato — o catálogo mudou depois que este fato foi " +
-                    "vinculado ao formulário, e o congelamento não persiste um vínculo que já não é coletável."));
-            }
+            return Result.Failure(new DomainError(
+                FatoColetadoNaoMaisDeclarado,
+                $"O fato coletado '{naoColetavel.FatoCodigo}' não é mais declarado/vinculado a campo de " +
+                "inscrição no catálogo de fatos do candidato — o catálogo mudou depois que este fato foi " +
+                "vinculado ao formulário, e o congelamento não persiste um vínculo que já não é coletável."));
         }
 
         return Result.Success();

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Application/Commands/ProcessosSeletivos/FecharRetificacaoCommandHandler.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Application/Commands/ProcessosSeletivos/FecharRetificacaoCommandHandler.cs
@@ -206,6 +206,18 @@ public static class FecharRetificacaoCommandHandler
             return (Result.Failure(pendenciaPreCanonicalizacao), []);
         }
 
+        // O catálogo pode reclassificar a Origem de um fato depois que ele já virou
+        // FatoColetado (ex.: a migration que reclassificou MODALIDADE de DECLARADO para
+        // DERIVADO) — a configuração EDITADA pela sessão pode conter um vínculo (novo ou
+        // preexistente) que deixou de ser coletável.
+        Result coletabilidadeDosFatos = await ConferenciaDeColetabilidadeDeFatos
+            .ConferirAsync(processo, fatoCandidatoReader, cancellationToken)
+            .ConfigureAwait(false);
+        if (coletabilidadeDosFatos.IsFailure)
+        {
+            return (Result.Failure(coletabilidadeDosFatos.Error!), []);
+        }
+
         // Story #919 (RN08): mesmo congelamento de metadado de fato que a publicação de
         // abertura já faz — a configuração EDITADA pela sessão pode conter gatilho de
         // documento vivo (novo ou alterado), e congelar sem este bloco deixaria o metadado

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Application/Commands/ProcessosSeletivos/PublicarProcessoSeletivoCommandHandler.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Application/Commands/ProcessosSeletivos/PublicarProcessoSeletivoCommandHandler.cs
@@ -158,6 +158,18 @@ public static class PublicarProcessoSeletivoCommandHandler
             return (Result.Failure(pendenciaPreCanonicalizacao), []);
         }
 
+        // O catálogo pode reclassificar a Origem de um fato depois que ele já virou
+        // FatoColetado (ex.: a migration que reclassificou MODALIDADE de DECLARADO para
+        // DERIVADO) — sem esta reconferência, um vínculo morto seria congelado numa versão
+        // append-only e, pela doutrina do agregado, irreparável depois.
+        Result coletabilidadeDosFatos = await ConferenciaDeColetabilidadeDeFatos
+            .ConferirAsync(processo, fatoCandidatoReader, cancellationToken)
+            .ConfigureAwait(false);
+        if (coletabilidadeDosFatos.IsFailure)
+        {
+            return (Result.Failure(coletabilidadeDosFatos.Error!), []);
+        }
+
         // Story #919 (RN08): congela o metadado de cada fato citado em alguma condição de
         // gatilho, ao lado da condição bruta {fato, operador, valor} já congelada desde a
         // 1.2 — I/O resolvido só quando existe ao menos uma condição (mesmo princípio de

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Application/Commands/ProcessosSeletivos/RetificarProcessoSeletivoCommandHandler.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Application/Commands/ProcessosSeletivos/RetificarProcessoSeletivoCommandHandler.cs
@@ -192,6 +192,18 @@ public static class RetificarProcessoSeletivoCommandHandler
             return (Result.Failure(pendenciaPreCanonicalizacao), []);
         }
 
+        // O catálogo pode reclassificar a Origem de um fato depois que ele já virou
+        // FatoColetado (ex.: a migration que reclassificou MODALIDADE de DECLARADO para
+        // DERIVADO) — uma retificação também pode congelar um vínculo que deixou de ser
+        // coletável desde a publicação de abertura.
+        Result coletabilidadeDosFatos = await ConferenciaDeColetabilidadeDeFatos
+            .ConferirAsync(processo, fatoCandidatoReader, cancellationToken)
+            .ConfigureAwait(false);
+        if (coletabilidadeDosFatos.IsFailure)
+        {
+            return (Result.Failure(coletabilidadeDosFatos.Error!), []);
+        }
+
         // Story #919 (RN08): mesmo congelamento de metadado de fato que a publicação de
         // abertura já faz — uma retificação também pode conter gatilho de documento vivo, e
         // congelar sem este bloco deixaria o metadado incompleto (vazio) para esta versão.

--- a/tests/Unifesspa.UniPlus.Selecao.Application.UnitTests/Commands/AbrirRetificacaoCommandHandlerTests.cs
+++ b/tests/Unifesspa.UniPlus.Selecao.Application.UnitTests/Commands/AbrirRetificacaoCommandHandlerTests.cs
@@ -24,7 +24,7 @@ using Unifesspa.UniPlus.Selecao.Domain.ValueObjects;
 /// </summary>
 public sealed class AbrirRetificacaoCommandHandlerTests
 {
-    private static readonly string HashFixo = string.Concat(Enumerable.Repeat("ab01234567", 7))[..64];
+    private static readonly string HashFixo = ProcessoSeletivoConformeBuilder.HashFixo;
     private static readonly byte[] Bytes = Encoding.UTF8.GetBytes(new JsonObject { ["status"] = "ok" }.ToJsonString());
     private static readonly DateTimeOffset Agora = new(2026, 1, 1, 12, 0, 0, TimeSpan.Zero);
 
@@ -178,76 +178,8 @@ public sealed class AbrirRetificacaoCommandHandlerTests
     private static DadosEdital NovosDados() => DadosEdital.Criar(
         "001/2026", new DateOnly(2026, 1, 1), new DateOnly(2026, 1, 31), Guid.CreateVersion7()).Value!;
 
-    private static ProcessoSeletivo NovoProcessoConforme()
-    {
-        ProcessoSeletivo processo = ProcessoSeletivo.Criar("PS 2026 — SiSU", TipoProcesso.SiSU, OrigemCandidatos.InscricaoPropria, Guid.NewGuid(), Unifesspa.UniPlus.Selecao.Domain.ValueObjects.UnidadeAdministradoraSnapshot.Criar("CEPS", "ceps", "Centro de Processos Seletivos", "ADMINISTRATIVA").Value!);
-
-        processo.DefinirEtapas(
-            [EtapaProcesso.Criar("Prova Objetiva", CaraterEtapa.Classificatoria, peso: 1m, ordem: 1)],
-            PrecondicaoIfMatch.Ausente).IsSuccess.Should().BeTrue();
-
-        processo.DefinirOfertaAtendimento(
-            OfertaAtendimentoEspecializado.Criar([], [], []).Value!, PrecondicaoIfMatch.Ausente)
-            .IsSuccess.Should().BeTrue();
-
-        ModalidadeSelecionada modalidade = ModalidadeSelecionada.Criar(
-            modalidadeOrigemId: Guid.CreateVersion7(),
-            codigo: "AC",
-            descricao: null,
-            naturezaLegal: NaturezaLegalModalidade.Ampla,
-            composicaoVagas: ComposicaoVagasModalidade.ResidualDoVo,
-            composicaoOrigemCodigo: null,
-            regraRemanejamento: RegraRemanejamentoModalidade.Nenhuma,
-            remanejamentoDestino: null,
-            remanejamentoPar: null,
-            remanejamentoFallback: null,
-            criteriosCumulativos: [],
-            acaoQuandoIndeferido: null,
-            baseLegal: "Res. Unifesspa 532/2021",
-            quantidadeDeclarada: 40).Value!;
-
-        processo.DefinirDistribuicaoVagas(
-            [ConfiguracaoDistribuicaoVagas.Criar(
-                ofertaCursoOrigemId: Guid.CreateVersion7(),
-                voBase: 40,
-                pr: 1m,
-                regraDistribuicao: ReferenciaRegra.Criar(RegraDistribuicaoVagasCodigo.Institucional, "v1", HashFixo).Value!,
-                regraAjuste: null,
-                referenciaDemografica: null,
-                modalidades: [modalidade]).Value!],
-            PrecondicaoIfMatch.Ausente).IsSuccess.Should().BeTrue();
-
-        processo.DefinirClassificacao(
-            ConfiguracaoClassificacao.Criar(
-                regraCalculo: ReferenciaRegra.Criar(RegraCalculoCodigo.ClassificacaoImportada, "v1", HashFixo).Value!,
-                regraArredondamento: null,
-                casasArredondamento: null,
-                regraOrdemAlocacao: ReferenciaRegra.Criar(RegraOrdemAlocacaoCodigo.AlocacaoOpcoesRn04, "v1", HashFixo).Value!,
-                nOpcoesAlocacao: 1,
-                regrasEliminacao: [], baseadoEmEnem: false).Value!,
-            PrecondicaoIfMatch.Ausente).IsSuccess.Should().BeTrue();
-
-        FaseCronograma faseConforme = FaseCronograma.Criar(
-            ordem: 1,
-            faseCanonicaOrigemId: Guid.CreateVersion7(),
-            codigo: "RESULTADO_FINAL",
-            donoInstitucional: "CEPS",
-            origemData: OrigemDataFase.Propria,
-            agrupaEtapas: true,
-            permiteComplementacao: false,
-            produzResultado: true,
-            resultadoDefinitivo: true,
-            coletaInscricao: true,
-            inicio: new DateTimeOffset(2026, 1, 1, 0, 0, 0, TimeSpan.Zero),
-            fim: new DateTimeOffset(2026, 1, 31, 0, 0, 0, TimeSpan.Zero),
-            atoProduzidoCodigo: "RESULTADO_FINAL",
-            atoProduzidoEfeitoIrreversivel: false,
-            bancasRequeridas: [],
-            regraRecurso: null).Value!;
-        processo.DefinirCronogramaFases([faseConforme], [], PrecondicaoIfMatch.Ausente).IsSuccess.Should().BeTrue();
-
-        return processo;
-    }
+    private static ProcessoSeletivo NovoProcessoConforme() =>
+        ProcessoSeletivoConformeBuilder.Criar("PS 2026 — SiSU");
 
     private sealed class RelogioFixo(DateTimeOffset instante) : TimeProvider
     {

--- a/tests/Unifesspa.UniPlus.Selecao.Application.UnitTests/Commands/ColetabilidadeDeFatosGateTests.cs
+++ b/tests/Unifesspa.UniPlus.Selecao.Application.UnitTests/Commands/ColetabilidadeDeFatosGateTests.cs
@@ -1,0 +1,356 @@
+namespace Unifesspa.UniPlus.Selecao.Application.UnitTests.Commands;
+
+using AwesomeAssertions;
+
+using NSubstitute;
+
+using Unifesspa.UniPlus.Application.Abstractions.Authentication;
+using Unifesspa.UniPlus.Configuracao.Contracts;
+using Unifesspa.UniPlus.Kernel.Results;
+using Unifesspa.UniPlus.Publicacoes.Contracts;
+using Unifesspa.UniPlus.Selecao.Application.Abstractions;
+using Unifesspa.UniPlus.Selecao.Application.Commands.ProcessosSeletivos;
+using Unifesspa.UniPlus.Selecao.Domain.Entities;
+using Unifesspa.UniPlus.Selecao.Domain.Enums;
+using Unifesspa.UniPlus.Selecao.Domain.Interfaces;
+using Unifesspa.UniPlus.Selecao.Domain.ValueObjects;
+
+/// <summary>
+/// O catálogo de fatos do candidato pode reclassificar a <c>Origem</c> de um fato depois que
+/// ele já virou <see cref="FatoColetado"/> — a migration que reclassificou MODALIDADE de
+/// DECLARADO para DERIVADO é o caso real. Prova, nos <b>três</b> handlers que congelam
+/// (ao lado de <see cref="ConformidadeLegalGateTests"/>), que um <c>FatoColetado</c> cujo fato
+/// deixou de ser coletável recusa ANTES da canonicalização, e que um fato ainda coletável não
+/// bloqueia a publicação.
+/// </summary>
+public sealed class ColetabilidadeDeFatosGateTests
+{
+    private static readonly string HashFixo = string.Concat(Enumerable.Repeat("ab01234567", 7))[..64];
+    private static readonly DateTimeOffset Agora = new(2026, 1, 1, 12, 0, 0, TimeSpan.Zero);
+
+    private static FatoCandidatoView FatoModalidadeReclassificadaComoDerivada() => new(
+        Id: Guid.CreateVersion7(),
+        Codigo: "MODALIDADE",
+        Nome: "Modalidade de concorrência",
+        Descricao: null,
+        Dominio: "CATEGORICO",
+        Origem: "DERIVADO",
+        Cardinalidade: "MULTIVALORADO",
+        ValoresDominio: null,
+        PontoResolucao: "INSCRICAO",
+        Binding: "REGRA_DERIVACAO:MODALIDADE",
+        ValoresDominioDeclarados: null);
+
+    private static FatoCandidatoView FatoCorRacaAindaDeclarado() => new(
+        Id: Guid.CreateVersion7(),
+        Codigo: "COR_RACA",
+        Nome: "Cor ou raça",
+        Descricao: null,
+        Dominio: "CATEGORICO",
+        Origem: "DECLARADO",
+        Cardinalidade: "ESCALAR",
+        ValoresDominio: ["BRANCA", "PRETA", "PARDA", "AMARELA", "INDIGENA"],
+        PontoResolucao: "INSCRICAO",
+        Binding: "CAMPO_INSCRICAO:COR_RACA",
+        ValoresDominioDeclarados: null);
+
+    private static FatoColetado FatoColetadoModalidade() =>
+        FatoColetado.Criar("MODALIDADE", 0, "Modalidade", TipoRenderizacao.SelecaoUnica, obrigatorio: true, null).Value!;
+
+    private static FatoColetado FatoColetadoCorRaca() =>
+        FatoColetado.Criar("COR_RACA", 0, "Cor ou raça", TipoRenderizacao.SelecaoUnica, obrigatorio: true, null).Value!;
+
+    [Fact(DisplayName = "Publicar_ComFatoColetadoNaoMaisDeclarado_RecusaSemCanonicalizar — o gate precede a canonicalização")]
+    public async Task Publicar_ComFatoColetadoNaoMaisDeclarado_RecusaSemCanonicalizar()
+    {
+        ProcessoSeletivo processo = NovoProcessoConforme();
+        processo.DefinirFatosColetados([FatoColetadoModalidade()], PrecondicaoIfMatch.Ausente)
+            .IsSuccess.Should().BeTrue();
+
+        IFatoCandidatoReader fatoCandidatoReader = ReaderCom(FatoModalidadeReclassificadaComoDerivada());
+        ISnapshotPublicacaoCanonicalizer canonicalizer = CanonicalizerSubstituto();
+
+        (Result resposta, IEnumerable<object> eventos) = await PublicarProcessoSeletivoCommandHandler.Handle(
+            new PublicarProcessoSeletivoCommand(
+                processo.Id, "001/2026", new DateOnly(2026, 1, 1), new DateOnly(2026, 1, 31),
+                DocumentoEditalId: Guid.CreateVersion7(), Ato: NovoAto()),
+            RepositorioDoProcesso(processo),
+            RepositorioDeDocumento(processo.Id),
+            canonicalizer,
+            Substitute.For<ISelecaoUnitOfWork>(),
+            UsuarioAutenticado(),
+            TipoDeAtoReader(),
+            Substitute.For<IVagaDeLinhagemReader>(),
+            Substitute.For<IObrigatoriedadeLegalRepository>(),
+            fatoCandidatoReader,
+            new RelogioFixo(Agora),
+            CancellationToken.None);
+
+        resposta.IsFailure.Should().BeTrue();
+        resposta.Error!.Code.Should().Be("ProcessoSeletivo.FatoColetadoNaoMaisDeclarado");
+        _ = canonicalizer.DidNotReceive().Canonicalizar(Arg.Any<EntradaCanonicalizacao>());
+        eventos.Should().BeEmpty();
+        processo.Status.Should().Be(StatusProcesso.Rascunho, "a publicação recusada não transita o processo");
+    }
+
+    [Fact(DisplayName = "Retificar_ComFatoColetadoNaoMaisDeclarado_RecusaSemCanonicalizar — mesmo gate na retificação")]
+    public async Task Retificar_ComFatoColetadoNaoMaisDeclarado_RecusaSemCanonicalizar()
+    {
+        (ProcessoSeletivo processo, VersaoConfiguracao versaoAtual) = ProcessoPublicadoComFatoColetado();
+
+        IFatoCandidatoReader fatoCandidatoReader = ReaderCom(FatoModalidadeReclassificadaComoDerivada());
+        ISnapshotPublicacaoCanonicalizer canonicalizer = CanonicalizerSubstituto();
+
+        IProcessoSeletivoRepository repositorio = RepositorioDoProcesso(processo);
+        repositorio.ObterVersaoAtualAsync(processo.Id, Arg.Any<CancellationToken>()).Returns(versaoAtual);
+
+        (Result resposta, IEnumerable<object> eventos) = await RetificarProcessoSeletivoCommandHandler.Handle(
+            new RetificarProcessoSeletivoCommand(
+                processo.Id, "Correção do prazo", "001/2026-R1",
+                new DateOnly(2026, 1, 1), new DateOnly(2026, 1, 31),
+                DocumentoEditalId: Guid.CreateVersion7(), Ato: NovoAto()),
+            repositorio,
+            RepositorioDeDocumento(processo.Id),
+            canonicalizer,
+            Substitute.For<ISelecaoUnitOfWork>(),
+            UsuarioAutenticado(),
+            TipoDeAtoReader(),
+            Substitute.For<IVagaDeLinhagemReader>(),
+            Substitute.For<IObrigatoriedadeLegalRepository>(),
+            fatoCandidatoReader,
+            new RelogioFixo(Agora),
+            CancellationToken.None);
+
+        resposta.IsFailure.Should().BeTrue();
+        resposta.Error!.Code.Should().Be("ProcessoSeletivo.FatoColetadoNaoMaisDeclarado");
+        _ = canonicalizer.DidNotReceive().Canonicalizar(Arg.Any<EntradaCanonicalizacao>());
+        eventos.Should().BeEmpty();
+    }
+
+    [Fact(DisplayName = "FecharRetificacao_ComFatoColetadoNaoMaisDeclarado_RecusaESessaoPermaneceAberta — recusa não destrói a sessão editorial")]
+    public async Task FecharRetificacao_ComFatoColetadoNaoMaisDeclarado_RecusaESessaoPermaneceAberta()
+    {
+        (ProcessoSeletivo processo, VersaoConfiguracao versaoAtual) = ProcessoPublicadoComFatoColetado();
+
+        Result<RascunhoRetificacao> rascunho = processo.AbrirRetificacao(
+            "Correção do prazo", versaoAtual, "user-sub-1", Agora);
+        rascunho.IsSuccess.Should().BeTrue(rascunho.Error?.Message);
+        processo.DequeueDomainEvents();
+
+        IFatoCandidatoReader fatoCandidatoReader = ReaderCom(FatoModalidadeReclassificadaComoDerivada());
+        ISnapshotPublicacaoCanonicalizer canonicalizer = CanonicalizerSubstituto();
+
+        IProcessoSeletivoRepository repositorio = RepositorioDoProcesso(processo);
+        repositorio.ObterVersaoAtualAsync(processo.Id, Arg.Any<CancellationToken>()).Returns(versaoAtual);
+
+        (Result resposta, IEnumerable<object> eventos) = await FecharRetificacaoCommandHandler.Handle(
+            new FecharRetificacaoCommand(
+                processo.Id, "001/2026-R1", new DateOnly(2026, 1, 1), new DateOnly(2026, 1, 31),
+                DocumentoEditalId: Guid.CreateVersion7(), Ato: NovoAto(), Precondicao: PrecondicaoIfMatch.Curinga),
+            repositorio,
+            RepositorioDeDocumento(processo.Id),
+            canonicalizer,
+            Substitute.For<ISelecaoUnitOfWork>(),
+            UsuarioAutenticado(),
+            TipoDeAtoReader(),
+            Substitute.For<IVagaDeLinhagemReader>(),
+            Substitute.For<IObrigatoriedadeLegalRepository>(),
+            fatoCandidatoReader,
+            new RelogioFixo(Agora),
+            CancellationToken.None);
+
+        resposta.IsFailure.Should().BeTrue();
+        resposta.Error!.Code.Should().Be("ProcessoSeletivo.FatoColetadoNaoMaisDeclarado");
+        _ = canonicalizer.DidNotReceive().Canonicalizar(Arg.Any<EntradaCanonicalizacao>());
+        eventos.Should().BeEmpty();
+        processo.Rascunho.Should().NotBeNull(
+            "uma recusa de coletabilidade não destrói a sessão editorial — o administrador corrige e tenta de novo");
+    }
+
+    [Fact(DisplayName = "Publicar_ComFatoColetadoAindaDeclarado_Aprova — um fato ainda coletável não bloqueia a publicação")]
+    public async Task Publicar_ComFatoColetadoAindaDeclarado_Aprova()
+    {
+        ProcessoSeletivo processo = NovoProcessoConforme();
+        processo.DefinirFatosColetados([FatoColetadoCorRaca()], PrecondicaoIfMatch.Ausente)
+            .IsSuccess.Should().BeTrue();
+
+        IFatoCandidatoReader fatoCandidatoReader = ReaderCom(FatoCorRacaAindaDeclarado());
+        ISnapshotPublicacaoCanonicalizer canonicalizer = CanonicalizerSubstituto();
+
+        (Result resposta, IEnumerable<object> _) = await PublicarProcessoSeletivoCommandHandler.Handle(
+            new PublicarProcessoSeletivoCommand(
+                processo.Id, "001/2026", new DateOnly(2026, 1, 1), new DateOnly(2026, 1, 31),
+                DocumentoEditalId: Guid.CreateVersion7(), Ato: NovoAto()),
+            RepositorioDoProcesso(processo),
+            RepositorioDeDocumento(processo.Id),
+            canonicalizer,
+            Substitute.For<ISelecaoUnitOfWork>(),
+            UsuarioAutenticado(),
+            TipoDeAtoReader(),
+            Substitute.For<IVagaDeLinhagemReader>(),
+            Substitute.For<IObrigatoriedadeLegalRepository>(),
+            fatoCandidatoReader,
+            new RelogioFixo(Agora),
+            CancellationToken.None);
+
+        resposta.IsSuccess.Should().BeTrue(resposta.Error?.Message);
+        _ = canonicalizer.Received(1).Canonicalizar(Arg.Any<EntradaCanonicalizacao>());
+    }
+
+    // ══════════════════════════════════════════════════════════════════════════════
+
+    private static IFatoCandidatoReader ReaderCom(params FatoCandidatoView[] catalogo)
+    {
+        IFatoCandidatoReader reader = Substitute.For<IFatoCandidatoReader>();
+        reader.ListarAsync(Arg.Any<CancellationToken>()).Returns((IReadOnlyList<FatoCandidatoView>)catalogo);
+        return reader;
+    }
+
+    private static ISnapshotPublicacaoCanonicalizer CanonicalizerSubstituto()
+    {
+        ISnapshotPublicacaoCanonicalizer canonicalizer = Substitute.For<ISnapshotPublicacaoCanonicalizer>();
+        canonicalizer.Canonicalizar(Arg.Any<EntradaCanonicalizacao>())
+            .Returns(new SnapshotCanonico("{}"u8.ToArray(), "1.1", "canonical-json/sha256@v1"));
+        return canonicalizer;
+    }
+
+    private static IProcessoSeletivoRepository RepositorioDoProcesso(ProcessoSeletivo processo)
+    {
+        IProcessoSeletivoRepository repositorio = Substitute.For<IProcessoSeletivoRepository>();
+        repositorio.ObterParaMutacaoAsync(processo.Id, Arg.Any<CancellationToken>()).Returns(processo);
+        return repositorio;
+    }
+
+    private static IDocumentoEditalRepository RepositorioDeDocumento(Guid processoSeletivoId)
+    {
+        DocumentoEdital documento = DocumentoEdital.IniciarPendente(
+            processoSeletivoId, TimeProvider.System, TimeSpan.FromMinutes(15));
+        documento.Confirmar(1024, HashFixo, TimeProvider.System).IsSuccess.Should().BeTrue();
+
+        IDocumentoEditalRepository repositorio = Substitute.For<IDocumentoEditalRepository>();
+        repositorio.ObterPorIdAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>()).Returns(documento);
+        return repositorio;
+    }
+
+    private static ITipoAtoPublicadoReader TipoDeAtoReader()
+    {
+        ITipoAtoPublicadoReader reader = Substitute.For<ITipoAtoPublicadoReader>();
+        reader.ObterVigenteAsync("EDITAL_ABERTURA", Arg.Any<DateOnly>(), Arg.Any<CancellationToken>())
+            .Returns(new TipoAtoPublicadoView(
+                Codigo: "EDITAL_ABERTURA",
+                Nome: "Edital de abertura",
+                CongelaConfiguracao: true,
+                UnicoPorObjeto: false,
+                EfeitoIrreversivel: false));
+        return reader;
+    }
+
+    private static IUserContext UsuarioAutenticado()
+    {
+        IUserContext contexto = Substitute.For<IUserContext>();
+        contexto.UserId.Returns("user-sub-1");
+        return contexto;
+    }
+
+    private static DadosDoAto NovoAto() => new(
+        Orgao: "CEPS",
+        Serie: "EDITAL",
+        Ano: 2026,
+        DataPublicacao: new DateOnly(2026, 1, 1),
+        Assinante: "Diretor do CEPS",
+        TipoAtoCodigo: "EDITAL_ABERTURA");
+
+    /// <summary>Processo publicado com um FatoColetado (MODALIDADE) — para os cenários de Retificar/FecharRetificacao.</summary>
+    private static (ProcessoSeletivo Processo, VersaoConfiguracao VersaoAtual) ProcessoPublicadoComFatoColetado()
+    {
+        ProcessoSeletivo processo = NovoProcessoConforme();
+        processo.DefinirFatosColetados([FatoColetadoModalidade()], PrecondicaoIfMatch.Ausente)
+            .IsSuccess.Should().BeTrue();
+
+        DadosEdital dados = DadosEdital.Criar(
+            "001/2026", new DateOnly(2026, 1, 1), new DateOnly(2026, 1, 31), Guid.CreateVersion7()).Value!;
+
+        VersaoConfiguracao versao = processo.Publicar(
+            dados, "{}"u8.ToArray(), "1.1", "canonical-json/sha256@v1", HashFixo, "user-sub-1",
+            new RelogioFixo(Agora)).Value!;
+        processo.DequeueDomainEvents();
+
+        return (processo, versao);
+    }
+
+    private static ProcessoSeletivo NovoProcessoConforme()
+    {
+        ProcessoSeletivo processo = ProcessoSeletivo.Criar("PS Gate Coletabilidade", TipoProcesso.SiSU, OrigemCandidatos.InscricaoPropria, Guid.NewGuid(), Unifesspa.UniPlus.Selecao.Domain.ValueObjects.UnidadeAdministradoraSnapshot.Criar("CEPS", "ceps", "Centro de Processos Seletivos", "ADMINISTRATIVA").Value!);
+
+        processo.DefinirEtapas(
+            [EtapaProcesso.Criar("Prova Objetiva", CaraterEtapa.Classificatoria, peso: 1m, ordem: 1)],
+            PrecondicaoIfMatch.Ausente).IsSuccess.Should().BeTrue();
+
+        processo.DefinirOfertaAtendimento(
+            OfertaAtendimentoEspecializado.Criar([], [], []).Value!, PrecondicaoIfMatch.Ausente)
+            .IsSuccess.Should().BeTrue();
+
+        ModalidadeSelecionada modalidade = ModalidadeSelecionada.Criar(
+            modalidadeOrigemId: Guid.CreateVersion7(),
+            codigo: "AC",
+            descricao: null,
+            naturezaLegal: NaturezaLegalModalidade.Ampla,
+            composicaoVagas: ComposicaoVagasModalidade.ResidualDoVo,
+            composicaoOrigemCodigo: null,
+            regraRemanejamento: RegraRemanejamentoModalidade.Nenhuma,
+            remanejamentoDestino: null,
+            remanejamentoPar: null,
+            remanejamentoFallback: null,
+            criteriosCumulativos: [],
+            acaoQuandoIndeferido: null,
+            baseLegal: "Res. Unifesspa 532/2021",
+            quantidadeDeclarada: 40).Value!;
+
+        processo.DefinirDistribuicaoVagas(
+            [ConfiguracaoDistribuicaoVagas.Criar(
+                ofertaCursoOrigemId: Guid.CreateVersion7(),
+                voBase: 40,
+                pr: 1m,
+                regraDistribuicao: ReferenciaRegra.Criar(RegraDistribuicaoVagasCodigo.Institucional, "v1", HashFixo).Value!,
+                regraAjuste: null,
+                referenciaDemografica: null,
+                modalidades: [modalidade]).Value!],
+            PrecondicaoIfMatch.Ausente).IsSuccess.Should().BeTrue();
+
+        processo.DefinirClassificacao(
+            ConfiguracaoClassificacao.Criar(
+                regraCalculo: ReferenciaRegra.Criar(RegraCalculoCodigo.ClassificacaoImportada, "v1", HashFixo).Value!,
+                regraArredondamento: null,
+                casasArredondamento: null,
+                regraOrdemAlocacao: ReferenciaRegra.Criar(RegraOrdemAlocacaoCodigo.AlocacaoOpcoesRn04, "v1", HashFixo).Value!,
+                nOpcoesAlocacao: 1,
+                regrasEliminacao: [], baseadoEmEnem: false).Value!,
+            PrecondicaoIfMatch.Ausente).IsSuccess.Should().BeTrue();
+
+        FaseCronograma faseConforme = FaseCronograma.Criar(
+            ordem: 1,
+            faseCanonicaOrigemId: Guid.CreateVersion7(),
+            codigo: "RESULTADO_FINAL",
+            donoInstitucional: "CEPS",
+            origemData: OrigemDataFase.Propria,
+            agrupaEtapas: true,
+            permiteComplementacao: false,
+            produzResultado: true,
+            resultadoDefinitivo: true,
+            coletaInscricao: true,
+            inicio: new DateTimeOffset(2026, 1, 1, 0, 0, 0, TimeSpan.Zero),
+            fim: new DateTimeOffset(2026, 1, 31, 0, 0, 0, TimeSpan.Zero),
+            atoProduzidoCodigo: "RESULTADO_FINAL",
+            atoProduzidoEfeitoIrreversivel: false,
+            bancasRequeridas: [],
+            regraRecurso: null).Value!;
+        processo.DefinirCronogramaFases([faseConforme], [], PrecondicaoIfMatch.Ausente).IsSuccess.Should().BeTrue();
+
+        return processo;
+    }
+
+    private sealed class RelogioFixo(DateTimeOffset instante) : TimeProvider
+    {
+        public override DateTimeOffset GetUtcNow() => instante;
+    }
+}

--- a/tests/Unifesspa.UniPlus.Selecao.Application.UnitTests/Commands/ColetabilidadeDeFatosGateTests.cs
+++ b/tests/Unifesspa.UniPlus.Selecao.Application.UnitTests/Commands/ColetabilidadeDeFatosGateTests.cs
@@ -25,7 +25,7 @@ using Unifesspa.UniPlus.Selecao.Domain.ValueObjects;
 /// </summary>
 public sealed class ColetabilidadeDeFatosGateTests
 {
-    private static readonly string HashFixo = string.Concat(Enumerable.Repeat("ab01234567", 7))[..64];
+    private static readonly string HashFixo = ProcessoSeletivoConformeBuilder.HashFixo;
     private static readonly DateTimeOffset Agora = new(2026, 1, 1, 12, 0, 0, TimeSpan.Zero);
 
     private static FatoCandidatoView FatoModalidadeReclassificadaComoDerivada() => new(
@@ -278,76 +278,8 @@ public sealed class ColetabilidadeDeFatosGateTests
         return (processo, versao);
     }
 
-    private static ProcessoSeletivo NovoProcessoConforme()
-    {
-        ProcessoSeletivo processo = ProcessoSeletivo.Criar("PS Gate Coletabilidade", TipoProcesso.SiSU, OrigemCandidatos.InscricaoPropria, Guid.NewGuid(), Unifesspa.UniPlus.Selecao.Domain.ValueObjects.UnidadeAdministradoraSnapshot.Criar("CEPS", "ceps", "Centro de Processos Seletivos", "ADMINISTRATIVA").Value!);
-
-        processo.DefinirEtapas(
-            [EtapaProcesso.Criar("Prova Objetiva", CaraterEtapa.Classificatoria, peso: 1m, ordem: 1)],
-            PrecondicaoIfMatch.Ausente).IsSuccess.Should().BeTrue();
-
-        processo.DefinirOfertaAtendimento(
-            OfertaAtendimentoEspecializado.Criar([], [], []).Value!, PrecondicaoIfMatch.Ausente)
-            .IsSuccess.Should().BeTrue();
-
-        ModalidadeSelecionada modalidade = ModalidadeSelecionada.Criar(
-            modalidadeOrigemId: Guid.CreateVersion7(),
-            codigo: "AC",
-            descricao: null,
-            naturezaLegal: NaturezaLegalModalidade.Ampla,
-            composicaoVagas: ComposicaoVagasModalidade.ResidualDoVo,
-            composicaoOrigemCodigo: null,
-            regraRemanejamento: RegraRemanejamentoModalidade.Nenhuma,
-            remanejamentoDestino: null,
-            remanejamentoPar: null,
-            remanejamentoFallback: null,
-            criteriosCumulativos: [],
-            acaoQuandoIndeferido: null,
-            baseLegal: "Res. Unifesspa 532/2021",
-            quantidadeDeclarada: 40).Value!;
-
-        processo.DefinirDistribuicaoVagas(
-            [ConfiguracaoDistribuicaoVagas.Criar(
-                ofertaCursoOrigemId: Guid.CreateVersion7(),
-                voBase: 40,
-                pr: 1m,
-                regraDistribuicao: ReferenciaRegra.Criar(RegraDistribuicaoVagasCodigo.Institucional, "v1", HashFixo).Value!,
-                regraAjuste: null,
-                referenciaDemografica: null,
-                modalidades: [modalidade]).Value!],
-            PrecondicaoIfMatch.Ausente).IsSuccess.Should().BeTrue();
-
-        processo.DefinirClassificacao(
-            ConfiguracaoClassificacao.Criar(
-                regraCalculo: ReferenciaRegra.Criar(RegraCalculoCodigo.ClassificacaoImportada, "v1", HashFixo).Value!,
-                regraArredondamento: null,
-                casasArredondamento: null,
-                regraOrdemAlocacao: ReferenciaRegra.Criar(RegraOrdemAlocacaoCodigo.AlocacaoOpcoesRn04, "v1", HashFixo).Value!,
-                nOpcoesAlocacao: 1,
-                regrasEliminacao: [], baseadoEmEnem: false).Value!,
-            PrecondicaoIfMatch.Ausente).IsSuccess.Should().BeTrue();
-
-        FaseCronograma faseConforme = FaseCronograma.Criar(
-            ordem: 1,
-            faseCanonicaOrigemId: Guid.CreateVersion7(),
-            codigo: "RESULTADO_FINAL",
-            donoInstitucional: "CEPS",
-            origemData: OrigemDataFase.Propria,
-            agrupaEtapas: true,
-            permiteComplementacao: false,
-            produzResultado: true,
-            resultadoDefinitivo: true,
-            coletaInscricao: true,
-            inicio: new DateTimeOffset(2026, 1, 1, 0, 0, 0, TimeSpan.Zero),
-            fim: new DateTimeOffset(2026, 1, 31, 0, 0, 0, TimeSpan.Zero),
-            atoProduzidoCodigo: "RESULTADO_FINAL",
-            atoProduzidoEfeitoIrreversivel: false,
-            bancasRequeridas: [],
-            regraRecurso: null).Value!;
-        processo.DefinirCronogramaFases([faseConforme], [], PrecondicaoIfMatch.Ausente).IsSuccess.Should().BeTrue();
-
-        return processo;
-    }
+    private static ProcessoSeletivo NovoProcessoConforme() =>
+        ProcessoSeletivoConformeBuilder.Criar("PS Gate Coletabilidade");
 
     private sealed class RelogioFixo(DateTimeOffset instante) : TimeProvider
     {

--- a/tests/Unifesspa.UniPlus.Selecao.Application.UnitTests/Commands/ConformidadeLegalGateTests.cs
+++ b/tests/Unifesspa.UniPlus.Selecao.Application.UnitTests/Commands/ConformidadeLegalGateTests.cs
@@ -24,7 +24,7 @@ using Unifesspa.UniPlus.Selecao.Domain.ValueObjects;
 /// </summary>
 public sealed class ConformidadeLegalGateTests
 {
-    private static readonly string HashFixo = string.Concat(Enumerable.Repeat("ab01234567", 7))[..64];
+    private static readonly string HashFixo = ProcessoSeletivoConformeBuilder.HashFixo;
     private static readonly DateTimeOffset Agora = new(2026, 1, 1, 12, 0, 0, TimeSpan.Zero);
 
     private static ObrigatoriedadeLegal NovaRegra(string regraCodigo, PredicadoObrigatoriedade predicado) =>
@@ -265,76 +265,8 @@ public sealed class ConformidadeLegalGateTests
         return (processo, versao);
     }
 
-    private static ProcessoSeletivo NovoProcessoConforme()
-    {
-        ProcessoSeletivo processo = ProcessoSeletivo.Criar("PS 2026 — SiSU", TipoProcesso.SiSU, OrigemCandidatos.InscricaoPropria, Guid.NewGuid(), Unifesspa.UniPlus.Selecao.Domain.ValueObjects.UnidadeAdministradoraSnapshot.Criar("CEPS", "ceps", "Centro de Processos Seletivos", "ADMINISTRATIVA").Value!);
-
-        processo.DefinirEtapas(
-            [EtapaProcesso.Criar("Prova Objetiva", CaraterEtapa.Classificatoria, peso: 1m, ordem: 1)],
-            PrecondicaoIfMatch.Ausente).IsSuccess.Should().BeTrue();
-
-        processo.DefinirOfertaAtendimento(
-            OfertaAtendimentoEspecializado.Criar([], [], []).Value!, PrecondicaoIfMatch.Ausente)
-            .IsSuccess.Should().BeTrue();
-
-        ModalidadeSelecionada modalidade = ModalidadeSelecionada.Criar(
-            modalidadeOrigemId: Guid.CreateVersion7(),
-            codigo: "AC",
-            descricao: null,
-            naturezaLegal: NaturezaLegalModalidade.Ampla,
-            composicaoVagas: ComposicaoVagasModalidade.ResidualDoVo,
-            composicaoOrigemCodigo: null,
-            regraRemanejamento: RegraRemanejamentoModalidade.Nenhuma,
-            remanejamentoDestino: null,
-            remanejamentoPar: null,
-            remanejamentoFallback: null,
-            criteriosCumulativos: [],
-            acaoQuandoIndeferido: null,
-            baseLegal: "Res. Unifesspa 532/2021",
-            quantidadeDeclarada: 40).Value!;
-
-        processo.DefinirDistribuicaoVagas(
-            [ConfiguracaoDistribuicaoVagas.Criar(
-                ofertaCursoOrigemId: Guid.CreateVersion7(),
-                voBase: 40,
-                pr: 1m,
-                regraDistribuicao: ReferenciaRegra.Criar(RegraDistribuicaoVagasCodigo.Institucional, "v1", HashFixo).Value!,
-                regraAjuste: null,
-                referenciaDemografica: null,
-                modalidades: [modalidade]).Value!],
-            PrecondicaoIfMatch.Ausente).IsSuccess.Should().BeTrue();
-
-        processo.DefinirClassificacao(
-            ConfiguracaoClassificacao.Criar(
-                regraCalculo: ReferenciaRegra.Criar(RegraCalculoCodigo.ClassificacaoImportada, "v1", HashFixo).Value!,
-                regraArredondamento: null,
-                casasArredondamento: null,
-                regraOrdemAlocacao: ReferenciaRegra.Criar(RegraOrdemAlocacaoCodigo.AlocacaoOpcoesRn04, "v1", HashFixo).Value!,
-                nOpcoesAlocacao: 1,
-                regrasEliminacao: [], baseadoEmEnem: false).Value!,
-            PrecondicaoIfMatch.Ausente).IsSuccess.Should().BeTrue();
-
-        FaseCronograma faseConforme = FaseCronograma.Criar(
-            ordem: 1,
-            faseCanonicaOrigemId: Guid.CreateVersion7(),
-            codigo: "RESULTADO_FINAL",
-            donoInstitucional: "CEPS",
-            origemData: OrigemDataFase.Propria,
-            agrupaEtapas: true,
-            permiteComplementacao: false,
-            produzResultado: true,
-            resultadoDefinitivo: true,
-            coletaInscricao: true,
-            inicio: new DateTimeOffset(2026, 1, 1, 0, 0, 0, TimeSpan.Zero),
-            fim: new DateTimeOffset(2026, 1, 31, 0, 0, 0, TimeSpan.Zero),
-            atoProduzidoCodigo: "RESULTADO_FINAL",
-            atoProduzidoEfeitoIrreversivel: false,
-            bancasRequeridas: [],
-            regraRecurso: null).Value!;
-        processo.DefinirCronogramaFases([faseConforme], [], PrecondicaoIfMatch.Ausente).IsSuccess.Should().BeTrue();
-
-        return processo;
-    }
+    private static ProcessoSeletivo NovoProcessoConforme() =>
+        ProcessoSeletivoConformeBuilder.Criar("PS 2026 — SiSU");
 
     private sealed class RelogioFixo(DateTimeOffset instante) : TimeProvider
     {

--- a/tests/Unifesspa.UniPlus.Selecao.Application.UnitTests/Commands/ProcessoSeletivoConformeBuilder.cs
+++ b/tests/Unifesspa.UniPlus.Selecao.Application.UnitTests/Commands/ProcessoSeletivoConformeBuilder.cs
@@ -1,0 +1,95 @@
+namespace Unifesspa.UniPlus.Selecao.Application.UnitTests.Commands;
+
+using AwesomeAssertions;
+
+using Unifesspa.UniPlus.Selecao.Domain.Entities;
+using Unifesspa.UniPlus.Selecao.Domain.Enums;
+using Unifesspa.UniPlus.Selecao.Domain.ValueObjects;
+
+/// <summary>
+/// Processo mínimo conforme às cinco dimensões estruturais de
+/// <c>ProcessoSeletivo.ItensEstruturaisDeConformidade</c> (etapas, oferta de atendimento,
+/// distribuição de vagas, classificação, cronograma de fases) — compartilhado pelos testes dos
+/// handlers que congelam (Publicar/Retificar/FecharRetificacao), que precisam de um processo
+/// que passe pelo gate estrutural antes de exercitar o gate específico de cada teste.
+/// </summary>
+internal static class ProcessoSeletivoConformeBuilder
+{
+    public static readonly string HashFixo = string.Concat(Enumerable.Repeat("ab01234567", 7))[..64];
+
+    public static ProcessoSeletivo Criar(string nome, out Guid faseId)
+    {
+        ProcessoSeletivo processo = ProcessoSeletivo.Criar(
+            nome, TipoProcesso.SiSU, OrigemCandidatos.InscricaoPropria, Guid.NewGuid(),
+            UnidadeAdministradoraSnapshot.Criar("CEPS", "ceps", "Centro de Processos Seletivos", "ADMINISTRATIVA").Value!);
+
+        processo.DefinirEtapas(
+            [EtapaProcesso.Criar("Prova Objetiva", CaraterEtapa.Classificatoria, peso: 1m, ordem: 1)],
+            PrecondicaoIfMatch.Ausente).IsSuccess.Should().BeTrue();
+
+        processo.DefinirOfertaAtendimento(
+            OfertaAtendimentoEspecializado.Criar([], [], []).Value!, PrecondicaoIfMatch.Ausente)
+            .IsSuccess.Should().BeTrue();
+
+        ModalidadeSelecionada modalidade = ModalidadeSelecionada.Criar(
+            modalidadeOrigemId: Guid.CreateVersion7(),
+            codigo: "AC",
+            descricao: null,
+            naturezaLegal: NaturezaLegalModalidade.Ampla,
+            composicaoVagas: ComposicaoVagasModalidade.ResidualDoVo,
+            composicaoOrigemCodigo: null,
+            regraRemanejamento: RegraRemanejamentoModalidade.Nenhuma,
+            remanejamentoDestino: null,
+            remanejamentoPar: null,
+            remanejamentoFallback: null,
+            criteriosCumulativos: [],
+            acaoQuandoIndeferido: null,
+            baseLegal: "Res. Unifesspa 532/2021",
+            quantidadeDeclarada: 40).Value!;
+
+        processo.DefinirDistribuicaoVagas(
+            [ConfiguracaoDistribuicaoVagas.Criar(
+                ofertaCursoOrigemId: Guid.CreateVersion7(),
+                voBase: 40,
+                pr: 1m,
+                regraDistribuicao: ReferenciaRegra.Criar(RegraDistribuicaoVagasCodigo.Institucional, "v1", HashFixo).Value!,
+                regraAjuste: null,
+                referenciaDemografica: null,
+                modalidades: [modalidade]).Value!],
+            PrecondicaoIfMatch.Ausente).IsSuccess.Should().BeTrue();
+
+        processo.DefinirClassificacao(
+            ConfiguracaoClassificacao.Criar(
+                regraCalculo: ReferenciaRegra.Criar(RegraCalculoCodigo.ClassificacaoImportada, "v1", HashFixo).Value!,
+                regraArredondamento: null,
+                casasArredondamento: null,
+                regraOrdemAlocacao: ReferenciaRegra.Criar(RegraOrdemAlocacaoCodigo.AlocacaoOpcoesRn04, "v1", HashFixo).Value!,
+                nOpcoesAlocacao: 1,
+                regrasEliminacao: [], baseadoEmEnem: false).Value!,
+            PrecondicaoIfMatch.Ausente).IsSuccess.Should().BeTrue();
+
+        FaseCronograma fase = FaseCronograma.Criar(
+            ordem: 1,
+            faseCanonicaOrigemId: Guid.CreateVersion7(),
+            codigo: "RESULTADO_FINAL",
+            donoInstitucional: "CEPS",
+            origemData: OrigemDataFase.Propria,
+            agrupaEtapas: true,
+            permiteComplementacao: false,
+            produzResultado: true,
+            resultadoDefinitivo: true,
+            coletaInscricao: true,
+            inicio: new DateTimeOffset(2026, 1, 1, 0, 0, 0, TimeSpan.Zero),
+            fim: new DateTimeOffset(2026, 1, 31, 0, 0, 0, TimeSpan.Zero),
+            atoProduzidoCodigo: "RESULTADO_FINAL",
+            atoProduzidoEfeitoIrreversivel: false,
+            bancasRequeridas: [],
+            regraRecurso: null).Value!;
+        processo.DefinirCronogramaFases([fase], [], PrecondicaoIfMatch.Ausente).IsSuccess.Should().BeTrue();
+        faseId = fase.Id;
+
+        return processo;
+    }
+
+    public static ProcessoSeletivo Criar(string nome) => Criar(nome, out _);
+}

--- a/tests/Unifesspa.UniPlus.Selecao.Application.UnitTests/Commands/PublicarProcessoSeletivoCommandHandlerTests.cs
+++ b/tests/Unifesspa.UniPlus.Selecao.Application.UnitTests/Commands/PublicarProcessoSeletivoCommandHandlerTests.cs
@@ -28,73 +28,8 @@ public sealed class PublicarProcessoSeletivoCommandHandlerTests
 {
     private static readonly string HashFixo = string.Concat(Enumerable.Repeat("ab01234567", 7))[..64];
 
-    private static ProcessoSeletivo NovoProcessoConforme(out Guid faseId)
-    {
-        ProcessoSeletivo processo = ProcessoSeletivo.Criar("PS Metadado de Fato", TipoProcesso.SiSU, OrigemCandidatos.InscricaoPropria, Guid.NewGuid(), Unifesspa.UniPlus.Selecao.Domain.ValueObjects.UnidadeAdministradoraSnapshot.Criar("CEPS", "ceps", "Centro de Processos Seletivos", "ADMINISTRATIVA").Value!);
-
-        processo.DefinirEtapas(
-            [EtapaProcesso.Criar("Prova Objetiva", CaraterEtapa.Classificatoria, peso: 1m, ordem: 1)],
-            PrecondicaoIfMatch.Ausente).IsSuccess.Should().BeTrue();
-
-        processo.DefinirOfertaAtendimento(
-            OfertaAtendimentoEspecializado.Criar([], [], []).Value!, PrecondicaoIfMatch.Ausente)
-            .IsSuccess.Should().BeTrue();
-
-        ModalidadeSelecionada modalidade = ModalidadeSelecionada.Criar(
-            modalidadeOrigemId: Guid.CreateVersion7(),
-            codigo: "AC",
-            descricao: null,
-            naturezaLegal: NaturezaLegalModalidade.Ampla,
-            composicaoVagas: ComposicaoVagasModalidade.ResidualDoVo,
-            composicaoOrigemCodigo: null,
-            regraRemanejamento: RegraRemanejamentoModalidade.Nenhuma,
-            remanejamentoDestino: null,
-            remanejamentoPar: null,
-            remanejamentoFallback: null,
-            criteriosCumulativos: [],
-            acaoQuandoIndeferido: null,
-            baseLegal: "Res. Unifesspa 532/2021",
-            quantidadeDeclarada: 40).Value!;
-        ConfiguracaoDistribuicaoVagas distribuicao = ConfiguracaoDistribuicaoVagas.Criar(
-            ofertaCursoOrigemId: Guid.CreateVersion7(),
-            voBase: 40,
-            pr: 1m,
-            regraDistribuicao: ReferenciaRegra.Criar(RegraDistribuicaoVagasCodigo.Institucional, "v1", HashFixo).Value!,
-            regraAjuste: null,
-            referenciaDemografica: null,
-            modalidades: [modalidade]).Value!;
-        processo.DefinirDistribuicaoVagas([distribuicao], PrecondicaoIfMatch.Ausente).IsSuccess.Should().BeTrue();
-
-        processo.DefinirClassificacao(ConfiguracaoClassificacao.Criar(
-            regraCalculo: ReferenciaRegra.Criar(RegraCalculoCodigo.ClassificacaoImportada, "v1", HashFixo).Value!,
-            regraArredondamento: null,
-            casasArredondamento: null,
-            regraOrdemAlocacao: ReferenciaRegra.Criar(RegraOrdemAlocacaoCodigo.AlocacaoOpcoesRn04, "v1", HashFixo).Value!,
-            nOpcoesAlocacao: 1,
-            regrasEliminacao: [], baseadoEmEnem: false).Value!, PrecondicaoIfMatch.Ausente).IsSuccess.Should().BeTrue();
-
-        FaseCronograma fase = FaseCronograma.Criar(
-            ordem: 1,
-            faseCanonicaOrigemId: Guid.CreateVersion7(),
-            codigo: "RESULTADO_FINAL",
-            donoInstitucional: "CEPS",
-            origemData: OrigemDataFase.Propria,
-            agrupaEtapas: true,
-            permiteComplementacao: false,
-            produzResultado: true,
-            resultadoDefinitivo: true,
-            coletaInscricao: true,
-            inicio: new DateTimeOffset(2026, 1, 1, 0, 0, 0, TimeSpan.Zero),
-            fim: new DateTimeOffset(2026, 1, 31, 0, 0, 0, TimeSpan.Zero),
-            atoProduzidoCodigo: "RESULTADO_FINAL",
-            atoProduzidoEfeitoIrreversivel: false,
-            bancasRequeridas: [],
-            regraRecurso: null).Value!;
-        processo.DefinirCronogramaFases([fase], [], PrecondicaoIfMatch.Ausente).IsSuccess.Should().BeTrue();
-        faseId = fase.Id;
-
-        return processo;
-    }
+    private static ProcessoSeletivo NovoProcessoConforme(out Guid faseId) =>
+        ProcessoSeletivoConformeBuilder.Criar("PS Metadado de Fato", out faseId);
 
     private static DocumentoExigido ExigenciaComGatilhoPorFato(Guid faseId, string fato) =>
         DocumentoExigido.Criar(

--- a/tests/Unifesspa.UniPlus.Selecao.Application.UnitTests/Commands/PublicarProcessoSeletivoGateTests.cs
+++ b/tests/Unifesspa.UniPlus.Selecao.Application.UnitTests/Commands/PublicarProcessoSeletivoGateTests.cs
@@ -146,75 +146,14 @@ public sealed class PublicarProcessoSeletivoGateTests
     /// <summary>Processo conforme (etapas, oferta, distribuição, classificação, cronograma) — o mínimo para passar pelos dois primeiros gates do handler.</summary>
     private static ProcessoSeletivo NovoProcessoConformeComGatilhoPorFaixaEtariaSemReferencia(out Guid faseId)
     {
-        ProcessoSeletivo processo = ProcessoSeletivo.Criar("PS Gate D5", TipoProcesso.SiSU, OrigemCandidatos.InscricaoPropria, Guid.NewGuid(), Unifesspa.UniPlus.Selecao.Domain.ValueObjects.UnidadeAdministradoraSnapshot.Criar("CEPS", "ceps", "Centro de Processos Seletivos", "ADMINISTRATIVA").Value!);
-
-        processo.DefinirEtapas([
-            EtapaProcesso.Criar("Prova Objetiva", CaraterEtapa.Classificatoria, peso: 1m, ordem: 1),
-        ], PrecondicaoIfMatch.Ausente).IsSuccess.Should().BeTrue();
-
-        processo.DefinirOfertaAtendimento(
-            OfertaAtendimentoEspecializado.Criar([], [], []).Value!, PrecondicaoIfMatch.Ausente).IsSuccess.Should().BeTrue();
-
-        string hashFixo = string.Concat(Enumerable.Repeat("ab01234567", 7))[..64];
-        ModalidadeSelecionada modalidade = ModalidadeSelecionada.Criar(
-            modalidadeOrigemId: Guid.CreateVersion7(),
-            codigo: "AC",
-            descricao: null,
-            naturezaLegal: NaturezaLegalModalidade.Ampla,
-            composicaoVagas: ComposicaoVagasModalidade.ResidualDoVo,
-            composicaoOrigemCodigo: null,
-            regraRemanejamento: RegraRemanejamentoModalidade.Nenhuma,
-            remanejamentoDestino: null,
-            remanejamentoPar: null,
-            remanejamentoFallback: null,
-            criteriosCumulativos: [],
-            acaoQuandoIndeferido: null,
-            baseLegal: "Res. Unifesspa 532/2021",
-            quantidadeDeclarada: 40).Value!;
-        ConfiguracaoDistribuicaoVagas distribuicao = ConfiguracaoDistribuicaoVagas.Criar(
-            ofertaCursoOrigemId: Guid.CreateVersion7(),
-            voBase: 40,
-            pr: 1m,
-            regraDistribuicao: ReferenciaRegra.Criar(RegraDistribuicaoVagasCodigo.Institucional, "v1", hashFixo).Value!,
-            regraAjuste: null,
-            referenciaDemografica: null,
-            modalidades: [modalidade]).Value!;
-        processo.DefinirDistribuicaoVagas([distribuicao], PrecondicaoIfMatch.Ausente).IsSuccess.Should().BeTrue();
-
-        processo.DefinirClassificacao(ConfiguracaoClassificacao.Criar(
-            regraCalculo: ReferenciaRegra.Criar(RegraCalculoCodigo.ClassificacaoImportada, "v1", hashFixo).Value!,
-            regraArredondamento: null,
-            casasArredondamento: null,
-            regraOrdemAlocacao: ReferenciaRegra.Criar(RegraOrdemAlocacaoCodigo.AlocacaoOpcoesRn04, "v1", hashFixo).Value!,
-            nOpcoesAlocacao: 1,
-            regrasEliminacao: [], baseadoEmEnem: false).Value!, PrecondicaoIfMatch.Ausente).IsSuccess.Should().BeTrue();
-
-        FaseCronograma fase = FaseCronograma.Criar(
-            ordem: 1,
-            faseCanonicaOrigemId: Guid.CreateVersion7(),
-            codigo: "RESULTADO_FINAL",
-            donoInstitucional: "CEPS",
-            origemData: OrigemDataFase.Propria,
-            agrupaEtapas: true,
-            permiteComplementacao: false,
-            produzResultado: true,
-            resultadoDefinitivo: true,
-            coletaInscricao: true,
-            inicio: new DateTimeOffset(2026, 1, 1, 0, 0, 0, TimeSpan.Zero),
-            fim: new DateTimeOffset(2026, 1, 31, 0, 0, 0, TimeSpan.Zero),
-            atoProduzidoCodigo: "RESULTADO_FINAL",
-            atoProduzidoEfeitoIrreversivel: false,
-            bancasRequeridas: [],
-            regraRecurso: null).Value!;
-        processo.DefinirCronogramaFases([fase], [], PrecondicaoIfMatch.Ausente).IsSuccess.Should().BeTrue();
-        faseId = fase.Id;
+        ProcessoSeletivo processo = ProcessoSeletivoConformeBuilder.Criar("PS Gate D5", out faseId);
 
         CondicaoGatilho condicao = CondicaoGatilho.Criar(
             0, "FAIXA_ETARIA", Operador.MaiorIgual, JsonSerializer.SerializeToElement(18)).Value!;
         DocumentoExigidoBaseLegal baseLegal = DocumentoExigidoBaseLegal.Criar(
             "Lei 12.711/2012, art. 3º", TipoAbrangencia.InternaEdital, StatusBaseLegal.Resolvido, null).Value!;
         DocumentoExigido exigencia = DocumentoExigido.Criar(
-            fase.Id,
+            faseId,
             tipoDocumentoOrigemId: Guid.CreateVersion7(),
             tipoDocumentoCodigo: "DECLARACAO_MAIORIDADE",
             tipoDocumentoNome: "Declaração de maioridade",


### PR DESCRIPTION
## Contexto

`ColetabilidadeDeFato.EhColetavel` (`DefinirFatosColetadosCommandHandler.cs`) exige `Origem=DECLARADO` + binding `CAMPO_INSCRICAO:{campo}` para um fato virar `FatoColetado`. Esse predicado só era aplicado no PUT `/fatos-coletados`. Nenhum dos três handlers que congelam uma `VersaoConfiguracao` append-only (Publicar, Retificar, FecharRetificacao) reconferia o vínculo contra o catálogo vivo antes de congelar.

O catálogo de fatos do candidato pode reclassificar a `Origem` de um fato via migration/seed em produção — não é hipotético: a migration que reclassificou `MODALIDADE` de `DECLARADO`/`CAMPO_INSCRICAO:MODALIDADE` para `DERIVADO`/`REGRA_DERIVACAO:MODALIDADE` é o caso real. Um `FatoColetado` vinculado antes dessa mudança, se publicado depois, congelava um vínculo morto numa versão que a doutrina do agregado já trata como irreparável.

Não há caminho HTTP para mudar `Origem`/`Binding` de um fato do candidato — confirmado pelo ArchTest `FatoCandidatoCatalogoTests.Controller_SomenteLeitura`. É risco operacional de evolução de catálogo, não vulnerabilidade explorável por usuário, mas é o caminho que o projeto de fato usa para evoluir o vocabulário.

## Correção

Novo helper `ConferenciaDeColetabilidadeDeFatos`, no mesmo estilo e posição de `ResolvedorMetadadosFatosCongelados` (compartilhado pelos três handlers que congelam, chamado antes da canonicalização). Reaproveita o mesmo predicado `ColetabilidadeDeFato.EhColetavel` que o PUT já usa — sem duplicar a regra. Usa `IFatoCandidatoReader.ListarAsync()` (catálogo inteiro, baixo volume) porque todo `FatoColetado` do processo precisa ser revisitado, diferente do congelamento de metadado, que só revisita os fatos citados em gatilho de documento.

Novo erro nomeado 422 `ProcessoSeletivo.FatoColetadoNaoMaisDeclarado`.

## Testes

Novo arquivo `ColetabilidadeDeFatosGateTests.cs`, espelhando `ConformidadeLegalGateTests.cs` (mesmo padrão: gate cross-handler testado nos três handlers com NSubstitute, sem Testcontainers — mesma lógica pura de Application do helper irmão, que também não tem teste de integração dedicado):

- Recusa em `Publicar`, `Retificar` e `FecharRetificacao` quando um `FatoColetado` cita um fato que deixou de ser `DECLARADO`/`CAMPO_INSCRICAO` (cenário real da reclassificação de MODALIDADE), sem canonicalizar.
- `FecharRetificacao` preserva a sessão editorial aberta na recusa (mesmo padrão do gate de conformidade legal).
- Aprovação quando o fato ainda é coletável.

Local: 296 testes de `Application.UnitTests` + 94 `ArchTests` + 19 testes relevantes de `IntegrationTests` (publicação, retificação, PUT de fatos coletados) — todos verdes, zero regressão. `dotnet format` limpo em toda a solução.

## Não regressão

Nenhum teste hoje popula `FatosColetados` nos handlers de congelamento nem em `ConformidadeLegalGateTests.cs` — o retorno antecipado do novo gate quando `FatosColetados` está vazio preserva todos os testes existentes sem tocar nenhum mock.

Closes #1054