### PR TITLE
chore(deps): alinha EF Core Design com o runtime nos startup projects

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -34,7 +34,7 @@
     <PackageVersion Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.10" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.10" />
     <PackageVersion Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.3" />
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.7" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.10" />
     <!-- snake_case automático para tabelas, colunas, índices, FKs (ADR-0054). -->
     <PackageVersion Include="EFCore.NamingConventions" Version="10.0.1" />
 

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.API/packages.lock.json
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.API/packages.lock.json
@@ -834,7 +834,7 @@
       },
       "Microsoft.EntityFrameworkCore.Design": {
         "type": "CentralTransitive",
-        "requested": "[10.0.7, )",
+        "requested": "[10.0.10, )",
         "resolved": "10.0.2",
         "contentHash": "tBwpyZ75SqcRjmZyhLYJVGKyfz1Z1dmsYtvJGZ2QLSI1tOHgMuLPTovunHA1JF9a0EWJs+WB6tVWmqo3DTL/MQ==",
         "dependencies": {

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Infrastructure/packages.lock.json
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Infrastructure/packages.lock.json
@@ -1255,7 +1255,7 @@
       },
       "Microsoft.EntityFrameworkCore.Design": {
         "type": "CentralTransitive",
-        "requested": "[10.0.7, )",
+        "requested": "[10.0.10, )",
         "resolved": "10.0.2",
         "contentHash": "tBwpyZ75SqcRjmZyhLYJVGKyfz1Z1dmsYtvJGZ2QLSI1tOHgMuLPTovunHA1JF9a0EWJs+WB6tVWmqo3DTL/MQ==",
         "dependencies": {

--- a/src/discentes/Unifesspa.UniPlus.Discentes.API/packages.lock.json
+++ b/src/discentes/Unifesspa.UniPlus.Discentes.API/packages.lock.json
@@ -1107,7 +1107,7 @@
       },
       "Microsoft.EntityFrameworkCore.Design": {
         "type": "CentralTransitive",
-        "requested": "[10.0.7, )",
+        "requested": "[10.0.10, )",
         "resolved": "10.0.2",
         "contentHash": "tBwpyZ75SqcRjmZyhLYJVGKyfz1Z1dmsYtvJGZ2QLSI1tOHgMuLPTovunHA1JF9a0EWJs+WB6tVWmqo3DTL/MQ==",
         "dependencies": {

--- a/src/discentes/Unifesspa.UniPlus.Discentes.Infrastructure/packages.lock.json
+++ b/src/discentes/Unifesspa.UniPlus.Discentes.Infrastructure/packages.lock.json
@@ -1118,7 +1118,7 @@
       },
       "Microsoft.EntityFrameworkCore.Design": {
         "type": "CentralTransitive",
-        "requested": "[10.0.7, )",
+        "requested": "[10.0.10, )",
         "resolved": "10.0.2",
         "contentHash": "tBwpyZ75SqcRjmZyhLYJVGKyfz1Z1dmsYtvJGZ2QLSI1tOHgMuLPTovunHA1JF9a0EWJs+WB6tVWmqo3DTL/MQ==",
         "dependencies": {

--- a/src/host/Unifesspa.UniPlus.Host/Unifesspa.UniPlus.Host.csproj
+++ b/src/host/Unifesspa.UniPlus.Host/Unifesspa.UniPlus.Host.csproj
@@ -5,6 +5,15 @@
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" />
     <PackageReference Include="Serilog.AspNetCore" />
     <PackageReference Include="WolverineFx.Postgresql" />
+    <!--
+      Startup project obrigatório do `dotnet ef` (os .Infrastructure dos módulos
+      internos são class libraries sem runtimeconfig). A referência direta faz a
+      versão central valer para o assembly de design-time; sem ela o pacote só
+      chegava como transitiva do WolverineFx.EntityFrameworkCore, presa numa
+      versão anterior à do runtime EF Core. PrivateAssets impede que ele
+      atravesse para runtime e publish.
+    -->
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" PrivateAssets="all" />
   </ItemGroup>
 
   <!--

--- a/src/host/Unifesspa.UniPlus.Host/packages.lock.json
+++ b/src/host/Unifesspa.UniPlus.Host/packages.lock.json
@@ -17,6 +17,23 @@
           "Microsoft.OpenApi": "2.0.0"
         }
       },
+      "Microsoft.EntityFrameworkCore.Design": {
+        "type": "Direct",
+        "requested": "[10.0.10, )",
+        "resolved": "10.0.10",
+        "contentHash": "BsvxiKcy8k4/ijAPitmwKG1mlVsdC2lQtFLP28K2N8PlsGYbqPFOyfJ7p2kWil3gM6xXgQGf8Hz/pJB8ej+Dug==",
+        "dependencies": {
+          "Humanizer.Core": "2.14.1",
+          "Microsoft.Build.Framework": "18.0.2",
+          "Microsoft.CodeAnalysis.CSharp": "5.0.0",
+          "Microsoft.CodeAnalysis.CSharp.Workspaces": "5.0.0",
+          "Microsoft.CodeAnalysis.Workspaces.MSBuild": "5.0.0",
+          "Microsoft.EntityFrameworkCore.Relational": "10.0.10",
+          "Microsoft.Extensions.DependencyModel": "10.0.10",
+          "Mono.TextTemplating": "3.0.0",
+          "Newtonsoft.Json": "13.0.3"
+        }
+      },
       "Serilog.AspNetCore": {
         "type": "Direct",
         "requested": "[10.0.0, )",
@@ -304,8 +321,8 @@
       },
       "Microsoft.Extensions.DependencyModel": {
         "type": "Transitive",
-        "resolved": "10.0.2",
-        "contentHash": "DHXzj/FKmUDmhzw7AHbMXbNNcgO8Cb9PDbYOUDICjFAdIALy2WbC6pm+dFKiAUNtcYMucZu2iMVw1ef/sdcZFw=="
+        "resolved": "10.0.10",
+        "contentHash": "rfZA1RjR021RPqSmIPovfz2aOd79TGqJ9BengbjnzIISOVwjLmuSDnhCMmiY/1c6iYvGolQ1iNGzkav0u11XEA=="
       },
       "Microsoft.IdentityModel.Abstractions": {
         "type": "Transitive",
@@ -1031,23 +1048,6 @@
         "dependencies": {
           "Microsoft.EntityFrameworkCore.Abstractions": "10.0.10",
           "Microsoft.EntityFrameworkCore.Analyzers": "10.0.10"
-        }
-      },
-      "Microsoft.EntityFrameworkCore.Design": {
-        "type": "CentralTransitive",
-        "requested": "[10.0.7, )",
-        "resolved": "10.0.2",
-        "contentHash": "tBwpyZ75SqcRjmZyhLYJVGKyfz1Z1dmsYtvJGZ2QLSI1tOHgMuLPTovunHA1JF9a0EWJs+WB6tVWmqo3DTL/MQ==",
-        "dependencies": {
-          "Humanizer.Core": "2.14.1",
-          "Microsoft.Build.Framework": "18.0.2",
-          "Microsoft.CodeAnalysis.CSharp": "5.0.0",
-          "Microsoft.CodeAnalysis.CSharp.Workspaces": "5.0.0",
-          "Microsoft.CodeAnalysis.Workspaces.MSBuild": "5.0.0",
-          "Microsoft.EntityFrameworkCore.Relational": "10.0.2",
-          "Microsoft.Extensions.DependencyModel": "10.0.2",
-          "Mono.TextTemplating": "3.0.0",
-          "Newtonsoft.Json": "13.0.3"
         }
       },
       "Microsoft.EntityFrameworkCore.Relational": {

--- a/src/ingresso/Unifesspa.UniPlus.Ingresso.API/packages.lock.json
+++ b/src/ingresso/Unifesspa.UniPlus.Ingresso.API/packages.lock.json
@@ -781,7 +781,7 @@
       },
       "Microsoft.EntityFrameworkCore.Design": {
         "type": "CentralTransitive",
-        "requested": "[10.0.7, )",
+        "requested": "[10.0.10, )",
         "resolved": "10.0.2",
         "contentHash": "tBwpyZ75SqcRjmZyhLYJVGKyfz1Z1dmsYtvJGZ2QLSI1tOHgMuLPTovunHA1JF9a0EWJs+WB6tVWmqo3DTL/MQ==",
         "dependencies": {

--- a/src/ingresso/Unifesspa.UniPlus.Ingresso.Infrastructure/packages.lock.json
+++ b/src/ingresso/Unifesspa.UniPlus.Ingresso.Infrastructure/packages.lock.json
@@ -1110,7 +1110,7 @@
       },
       "Microsoft.EntityFrameworkCore.Design": {
         "type": "CentralTransitive",
-        "requested": "[10.0.7, )",
+        "requested": "[10.0.10, )",
         "resolved": "10.0.2",
         "contentHash": "tBwpyZ75SqcRjmZyhLYJVGKyfz1Z1dmsYtvJGZ2QLSI1tOHgMuLPTovunHA1JF9a0EWJs+WB6tVWmqo3DTL/MQ==",
         "dependencies": {

--- a/src/organizacao-institucional/Unifesspa.UniPlus.OrganizacaoInstitucional.API/packages.lock.json
+++ b/src/organizacao-institucional/Unifesspa.UniPlus.OrganizacaoInstitucional.API/packages.lock.json
@@ -812,7 +812,7 @@
       },
       "Microsoft.EntityFrameworkCore.Design": {
         "type": "CentralTransitive",
-        "requested": "[10.0.7, )",
+        "requested": "[10.0.10, )",
         "resolved": "10.0.2",
         "contentHash": "tBwpyZ75SqcRjmZyhLYJVGKyfz1Z1dmsYtvJGZ2QLSI1tOHgMuLPTovunHA1JF9a0EWJs+WB6tVWmqo3DTL/MQ==",
         "dependencies": {

--- a/src/organizacao-institucional/Unifesspa.UniPlus.OrganizacaoInstitucional.Infrastructure/packages.lock.json
+++ b/src/organizacao-institucional/Unifesspa.UniPlus.OrganizacaoInstitucional.Infrastructure/packages.lock.json
@@ -1132,7 +1132,7 @@
       },
       "Microsoft.EntityFrameworkCore.Design": {
         "type": "CentralTransitive",
-        "requested": "[10.0.7, )",
+        "requested": "[10.0.10, )",
         "resolved": "10.0.2",
         "contentHash": "tBwpyZ75SqcRjmZyhLYJVGKyfz1Z1dmsYtvJGZ2QLSI1tOHgMuLPTovunHA1JF9a0EWJs+WB6tVWmqo3DTL/MQ==",
         "dependencies": {

--- a/src/portal/Unifesspa.UniPlus.Portal.API/Unifesspa.UniPlus.Portal.API.csproj
+++ b/src/portal/Unifesspa.UniPlus.Portal.API/Unifesspa.UniPlus.Portal.API.csproj
@@ -4,6 +4,13 @@
     <PackageReference Include="FluentValidation" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" />
     <PackageReference Include="Serilog.AspNetCore" />
+    <!--
+      Startup project do `dotnet ef` para o PortalDbContext, pelo mesmo motivo do
+      host do monólito: a referência direta faz a versão central valer para o
+      assembly de design-time. PrivateAssets impede que ele atravesse para
+      runtime e publish.
+    -->
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/portal/Unifesspa.UniPlus.Portal.API/packages.lock.json
+++ b/src/portal/Unifesspa.UniPlus.Portal.API/packages.lock.json
@@ -17,6 +17,23 @@
           "Microsoft.OpenApi": "2.0.0"
         }
       },
+      "Microsoft.EntityFrameworkCore.Design": {
+        "type": "Direct",
+        "requested": "[10.0.10, )",
+        "resolved": "10.0.10",
+        "contentHash": "BsvxiKcy8k4/ijAPitmwKG1mlVsdC2lQtFLP28K2N8PlsGYbqPFOyfJ7p2kWil3gM6xXgQGf8Hz/pJB8ej+Dug==",
+        "dependencies": {
+          "Humanizer.Core": "2.14.1",
+          "Microsoft.Build.Framework": "18.0.2",
+          "Microsoft.CodeAnalysis.CSharp": "5.0.0",
+          "Microsoft.CodeAnalysis.CSharp.Workspaces": "5.0.0",
+          "Microsoft.CodeAnalysis.Workspaces.MSBuild": "5.0.0",
+          "Microsoft.EntityFrameworkCore.Relational": "10.0.10",
+          "Microsoft.Extensions.DependencyModel": "10.0.10",
+          "Mono.TextTemplating": "3.0.0",
+          "Newtonsoft.Json": "13.0.3"
+        }
+      },
       "Serilog.AspNetCore": {
         "type": "Direct",
         "requested": "[10.0.0, )",
@@ -294,8 +311,8 @@
       },
       "Microsoft.Extensions.DependencyModel": {
         "type": "Transitive",
-        "resolved": "10.0.2",
-        "contentHash": "DHXzj/FKmUDmhzw7AHbMXbNNcgO8Cb9PDbYOUDICjFAdIALy2WbC6pm+dFKiAUNtcYMucZu2iMVw1ef/sdcZFw=="
+        "resolved": "10.0.10",
+        "contentHash": "rfZA1RjR021RPqSmIPovfz2aOd79TGqJ9BengbjnzIISOVwjLmuSDnhCMmiY/1c6iYvGolQ1iNGzkav0u11XEA=="
       },
       "Microsoft.IdentityModel.Abstractions": {
         "type": "Transitive",
@@ -777,23 +794,6 @@
         "dependencies": {
           "Microsoft.EntityFrameworkCore.Abstractions": "10.0.10",
           "Microsoft.EntityFrameworkCore.Analyzers": "10.0.10"
-        }
-      },
-      "Microsoft.EntityFrameworkCore.Design": {
-        "type": "CentralTransitive",
-        "requested": "[10.0.7, )",
-        "resolved": "10.0.2",
-        "contentHash": "tBwpyZ75SqcRjmZyhLYJVGKyfz1Z1dmsYtvJGZ2QLSI1tOHgMuLPTovunHA1JF9a0EWJs+WB6tVWmqo3DTL/MQ==",
-        "dependencies": {
-          "Humanizer.Core": "2.14.1",
-          "Microsoft.Build.Framework": "18.0.2",
-          "Microsoft.CodeAnalysis.CSharp": "5.0.0",
-          "Microsoft.CodeAnalysis.CSharp.Workspaces": "5.0.0",
-          "Microsoft.CodeAnalysis.Workspaces.MSBuild": "5.0.0",
-          "Microsoft.EntityFrameworkCore.Relational": "10.0.2",
-          "Microsoft.Extensions.DependencyModel": "10.0.2",
-          "Mono.TextTemplating": "3.0.0",
-          "Newtonsoft.Json": "13.0.3"
         }
       },
       "Microsoft.EntityFrameworkCore.Relational": {

--- a/src/portal/Unifesspa.UniPlus.Portal.Infrastructure/packages.lock.json
+++ b/src/portal/Unifesspa.UniPlus.Portal.Infrastructure/packages.lock.json
@@ -1110,7 +1110,7 @@
       },
       "Microsoft.EntityFrameworkCore.Design": {
         "type": "CentralTransitive",
-        "requested": "[10.0.7, )",
+        "requested": "[10.0.10, )",
         "resolved": "10.0.2",
         "contentHash": "tBwpyZ75SqcRjmZyhLYJVGKyfz1Z1dmsYtvJGZ2QLSI1tOHgMuLPTovunHA1JF9a0EWJs+WB6tVWmqo3DTL/MQ==",
         "dependencies": {

--- a/src/publicacoes/Unifesspa.UniPlus.Publicacoes.API/packages.lock.json
+++ b/src/publicacoes/Unifesspa.UniPlus.Publicacoes.API/packages.lock.json
@@ -826,7 +826,7 @@
       },
       "Microsoft.EntityFrameworkCore.Design": {
         "type": "CentralTransitive",
-        "requested": "[10.0.7, )",
+        "requested": "[10.0.10, )",
         "resolved": "10.0.2",
         "contentHash": "tBwpyZ75SqcRjmZyhLYJVGKyfz1Z1dmsYtvJGZ2QLSI1tOHgMuLPTovunHA1JF9a0EWJs+WB6tVWmqo3DTL/MQ==",
         "dependencies": {

--- a/src/publicacoes/Unifesspa.UniPlus.Publicacoes.Infrastructure/packages.lock.json
+++ b/src/publicacoes/Unifesspa.UniPlus.Publicacoes.Infrastructure/packages.lock.json
@@ -1152,7 +1152,7 @@
       },
       "Microsoft.EntityFrameworkCore.Design": {
         "type": "CentralTransitive",
-        "requested": "[10.0.7, )",
+        "requested": "[10.0.10, )",
         "resolved": "10.0.2",
         "contentHash": "tBwpyZ75SqcRjmZyhLYJVGKyfz1Z1dmsYtvJGZ2QLSI1tOHgMuLPTovunHA1JF9a0EWJs+WB6tVWmqo3DTL/MQ==",
         "dependencies": {

--- a/src/selecao/Unifesspa.UniPlus.Selecao.API/packages.lock.json
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.API/packages.lock.json
@@ -842,7 +842,7 @@
       },
       "Microsoft.EntityFrameworkCore.Design": {
         "type": "CentralTransitive",
-        "requested": "[10.0.7, )",
+        "requested": "[10.0.10, )",
         "resolved": "10.0.2",
         "contentHash": "tBwpyZ75SqcRjmZyhLYJVGKyfz1Z1dmsYtvJGZ2QLSI1tOHgMuLPTovunHA1JF9a0EWJs+WB6tVWmqo3DTL/MQ==",
         "dependencies": {

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/packages.lock.json
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/packages.lock.json
@@ -1149,7 +1149,7 @@
       },
       "Microsoft.EntityFrameworkCore.Design": {
         "type": "CentralTransitive",
-        "requested": "[10.0.7, )",
+        "requested": "[10.0.10, )",
         "resolved": "10.0.2",
         "contentHash": "tBwpyZ75SqcRjmZyhLYJVGKyfz1Z1dmsYtvJGZ2QLSI1tOHgMuLPTovunHA1JF9a0EWJs+WB6tVWmqo3DTL/MQ==",
         "dependencies": {

--- a/src/shared/Unifesspa.UniPlus.Infrastructure.Core/packages.lock.json
+++ b/src/shared/Unifesspa.UniPlus.Infrastructure.Core/packages.lock.json
@@ -919,7 +919,7 @@
       },
       "Microsoft.EntityFrameworkCore.Design": {
         "type": "CentralTransitive",
-        "requested": "[10.0.7, )",
+        "requested": "[10.0.10, )",
         "resolved": "10.0.2",
         "contentHash": "tBwpyZ75SqcRjmZyhLYJVGKyfz1Z1dmsYtvJGZ2QLSI1tOHgMuLPTovunHA1JF9a0EWJs+WB6tVWmqo3DTL/MQ==",
         "dependencies": {

--- a/tests/Unifesspa.UniPlus.ArchTests/packages.lock.json
+++ b/tests/Unifesspa.UniPlus.ArchTests/packages.lock.json
@@ -1549,7 +1549,7 @@
       },
       "Microsoft.EntityFrameworkCore.Design": {
         "type": "CentralTransitive",
-        "requested": "[10.0.7, )",
+        "requested": "[10.0.10, )",
         "resolved": "10.0.2",
         "contentHash": "tBwpyZ75SqcRjmZyhLYJVGKyfz1Z1dmsYtvJGZ2QLSI1tOHgMuLPTovunHA1JF9a0EWJs+WB6tVWmqo3DTL/MQ==",
         "dependencies": {

--- a/tests/Unifesspa.UniPlus.Configuracao.IntegrationTests/packages.lock.json
+++ b/tests/Unifesspa.UniPlus.Configuracao.IntegrationTests/packages.lock.json
@@ -1632,7 +1632,7 @@
       },
       "Microsoft.EntityFrameworkCore.Design": {
         "type": "CentralTransitive",
-        "requested": "[10.0.7, )",
+        "requested": "[10.0.10, )",
         "resolved": "10.0.2",
         "contentHash": "tBwpyZ75SqcRjmZyhLYJVGKyfz1Z1dmsYtvJGZ2QLSI1tOHgMuLPTovunHA1JF9a0EWJs+WB6tVWmqo3DTL/MQ==",
         "dependencies": {

--- a/tests/Unifesspa.UniPlus.Discentes.IntegrationTests/packages.lock.json
+++ b/tests/Unifesspa.UniPlus.Discentes.IntegrationTests/packages.lock.json
@@ -1302,7 +1302,7 @@
       },
       "Microsoft.EntityFrameworkCore.Design": {
         "type": "CentralTransitive",
-        "requested": "[10.0.7, )",
+        "requested": "[10.0.10, )",
         "resolved": "10.0.2",
         "contentHash": "tBwpyZ75SqcRjmZyhLYJVGKyfz1Z1dmsYtvJGZ2QLSI1tOHgMuLPTovunHA1JF9a0EWJs+WB6tVWmqo3DTL/MQ==",
         "dependencies": {

--- a/tests/Unifesspa.UniPlus.Host.IntegrationTests/packages.lock.json
+++ b/tests/Unifesspa.UniPlus.Host.IntegrationTests/packages.lock.json
@@ -1604,7 +1604,7 @@
       },
       "Microsoft.EntityFrameworkCore.Design": {
         "type": "CentralTransitive",
-        "requested": "[10.0.7, )",
+        "requested": "[10.0.10, )",
         "resolved": "10.0.2",
         "contentHash": "tBwpyZ75SqcRjmZyhLYJVGKyfz1Z1dmsYtvJGZ2QLSI1tOHgMuLPTovunHA1JF9a0EWJs+WB6tVWmqo3DTL/MQ==",
         "dependencies": {

--- a/tests/Unifesspa.UniPlus.Infrastructure.Core.IntegrationTests/packages.lock.json
+++ b/tests/Unifesspa.UniPlus.Infrastructure.Core.IntegrationTests/packages.lock.json
@@ -1592,7 +1592,7 @@
       },
       "Microsoft.EntityFrameworkCore.Design": {
         "type": "CentralTransitive",
-        "requested": "[10.0.7, )",
+        "requested": "[10.0.10, )",
         "resolved": "10.0.2",
         "contentHash": "tBwpyZ75SqcRjmZyhLYJVGKyfz1Z1dmsYtvJGZ2QLSI1tOHgMuLPTovunHA1JF9a0EWJs+WB6tVWmqo3DTL/MQ==",
         "dependencies": {

--- a/tests/Unifesspa.UniPlus.Infrastructure.Core.UnitTests/packages.lock.json
+++ b/tests/Unifesspa.UniPlus.Infrastructure.Core.UnitTests/packages.lock.json
@@ -870,7 +870,7 @@
       },
       "Microsoft.EntityFrameworkCore.Design": {
         "type": "CentralTransitive",
-        "requested": "[10.0.7, )",
+        "requested": "[10.0.10, )",
         "resolved": "10.0.2",
         "contentHash": "tBwpyZ75SqcRjmZyhLYJVGKyfz1Z1dmsYtvJGZ2QLSI1tOHgMuLPTovunHA1JF9a0EWJs+WB6tVWmqo3DTL/MQ==",
         "dependencies": {

--- a/tests/Unifesspa.UniPlus.Ingresso.ArchTests/packages.lock.json
+++ b/tests/Unifesspa.UniPlus.Ingresso.ArchTests/packages.lock.json
@@ -1315,7 +1315,7 @@
       },
       "Microsoft.EntityFrameworkCore.Design": {
         "type": "CentralTransitive",
-        "requested": "[10.0.7, )",
+        "requested": "[10.0.10, )",
         "resolved": "10.0.2",
         "contentHash": "tBwpyZ75SqcRjmZyhLYJVGKyfz1Z1dmsYtvJGZ2QLSI1tOHgMuLPTovunHA1JF9a0EWJs+WB6tVWmqo3DTL/MQ==",
         "dependencies": {

--- a/tests/Unifesspa.UniPlus.Ingresso.IntegrationTests/packages.lock.json
+++ b/tests/Unifesspa.UniPlus.Ingresso.IntegrationTests/packages.lock.json
@@ -1572,7 +1572,7 @@
       },
       "Microsoft.EntityFrameworkCore.Design": {
         "type": "CentralTransitive",
-        "requested": "[10.0.7, )",
+        "requested": "[10.0.10, )",
         "resolved": "10.0.2",
         "contentHash": "tBwpyZ75SqcRjmZyhLYJVGKyfz1Z1dmsYtvJGZ2QLSI1tOHgMuLPTovunHA1JF9a0EWJs+WB6tVWmqo3DTL/MQ==",
         "dependencies": {

--- a/tests/Unifesspa.UniPlus.IntegrationTests.Fixtures/packages.lock.json
+++ b/tests/Unifesspa.UniPlus.IntegrationTests.Fixtures/packages.lock.json
@@ -1264,7 +1264,7 @@
       },
       "Microsoft.EntityFrameworkCore.Design": {
         "type": "CentralTransitive",
-        "requested": "[10.0.7, )",
+        "requested": "[10.0.10, )",
         "resolved": "10.0.2",
         "contentHash": "tBwpyZ75SqcRjmZyhLYJVGKyfz1Z1dmsYtvJGZ2QLSI1tOHgMuLPTovunHA1JF9a0EWJs+WB6tVWmqo3DTL/MQ==",
         "dependencies": {

--- a/tests/Unifesspa.UniPlus.Monolito.TestSupport/packages.lock.json
+++ b/tests/Unifesspa.UniPlus.Monolito.TestSupport/packages.lock.json
@@ -1524,7 +1524,7 @@
       },
       "Microsoft.EntityFrameworkCore.Design": {
         "type": "CentralTransitive",
-        "requested": "[10.0.7, )",
+        "requested": "[10.0.10, )",
         "resolved": "10.0.2",
         "contentHash": "tBwpyZ75SqcRjmZyhLYJVGKyfz1Z1dmsYtvJGZ2QLSI1tOHgMuLPTovunHA1JF9a0EWJs+WB6tVWmqo3DTL/MQ==",
         "dependencies": {

--- a/tests/Unifesspa.UniPlus.OrganizacaoInstitucional.IntegrationTests/packages.lock.json
+++ b/tests/Unifesspa.UniPlus.OrganizacaoInstitucional.IntegrationTests/packages.lock.json
@@ -1632,7 +1632,7 @@
       },
       "Microsoft.EntityFrameworkCore.Design": {
         "type": "CentralTransitive",
-        "requested": "[10.0.7, )",
+        "requested": "[10.0.10, )",
         "resolved": "10.0.2",
         "contentHash": "tBwpyZ75SqcRjmZyhLYJVGKyfz1Z1dmsYtvJGZ2QLSI1tOHgMuLPTovunHA1JF9a0EWJs+WB6tVWmqo3DTL/MQ==",
         "dependencies": {

--- a/tests/Unifesspa.UniPlus.Portal.IntegrationTests/packages.lock.json
+++ b/tests/Unifesspa.UniPlus.Portal.IntegrationTests/packages.lock.json
@@ -1310,7 +1310,7 @@
       },
       "Microsoft.EntityFrameworkCore.Design": {
         "type": "CentralTransitive",
-        "requested": "[10.0.7, )",
+        "requested": "[10.0.10, )",
         "resolved": "10.0.2",
         "contentHash": "tBwpyZ75SqcRjmZyhLYJVGKyfz1Z1dmsYtvJGZ2QLSI1tOHgMuLPTovunHA1JF9a0EWJs+WB6tVWmqo3DTL/MQ==",
         "dependencies": {

--- a/tests/Unifesspa.UniPlus.Publicacoes.IntegrationTests/packages.lock.json
+++ b/tests/Unifesspa.UniPlus.Publicacoes.IntegrationTests/packages.lock.json
@@ -1590,7 +1590,7 @@
       },
       "Microsoft.EntityFrameworkCore.Design": {
         "type": "CentralTransitive",
-        "requested": "[10.0.7, )",
+        "requested": "[10.0.10, )",
         "resolved": "10.0.2",
         "contentHash": "tBwpyZ75SqcRjmZyhLYJVGKyfz1Z1dmsYtvJGZ2QLSI1tOHgMuLPTovunHA1JF9a0EWJs+WB6tVWmqo3DTL/MQ==",
         "dependencies": {

--- a/tests/Unifesspa.UniPlus.Selecao.ArchTests/packages.lock.json
+++ b/tests/Unifesspa.UniPlus.Selecao.ArchTests/packages.lock.json
@@ -1315,7 +1315,7 @@
       },
       "Microsoft.EntityFrameworkCore.Design": {
         "type": "CentralTransitive",
-        "requested": "[10.0.7, )",
+        "requested": "[10.0.10, )",
         "resolved": "10.0.2",
         "contentHash": "tBwpyZ75SqcRjmZyhLYJVGKyfz1Z1dmsYtvJGZ2QLSI1tOHgMuLPTovunHA1JF9a0EWJs+WB6tVWmqo3DTL/MQ==",
         "dependencies": {

--- a/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/packages.lock.json
+++ b/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/packages.lock.json
@@ -1632,7 +1632,7 @@
       },
       "Microsoft.EntityFrameworkCore.Design": {
         "type": "CentralTransitive",
-        "requested": "[10.0.7, )",
+        "requested": "[10.0.10, )",
         "resolved": "10.0.2",
         "contentHash": "tBwpyZ75SqcRjmZyhLYJVGKyfz1Z1dmsYtvJGZ2QLSI1tOHgMuLPTovunHA1JF9a0EWJs+WB6tVWmqo3DTL/MQ==",
         "dependencies": {


### PR DESCRIPTION
## Resumo

- Declara `Microsoft.EntityFrameworkCore.Design` como `PackageReference` direto nos dois startup projects obrigatórios do `dotnet ef` — o host do monólito e a API do Portal — com `PrivateAssets="all"`;
- Sobe a versão central de 10.0.7 para 10.0.10, alinhando com `Microsoft.EntityFrameworkCore` e `.Relational`;
- Regenera os lock files da solution inteira, fazendo `requested` e `resolved` voltarem a concordar onde o pacote é de fato usado.

Closes #1065

## O problema era diferente do que o título da issue sugeria

A issue nasceu de uma leitura simples — "a central package management pede 10.0.7, o runtime está em 10.0.10, é só bumpar". A investigação mostrou que o bump sozinho **não alinharia nada**.

O `.Design` não era `PackageReference` de nenhum `.csproj`. Chegava apenas como transitiva do `WolverineFx.EntityFrameworkCore` (5.40.0), que pede `>= 10.0.2`. Sem `CentralPackageTransitivePinningEnabled`, a entrada `<PackageVersion>` para um pacote puramente transitivo **não governa a resolução** — fica registrada como `requested` no lock e é ignorada na hora de resolver.

O estado antes deste PR, nos 34 lock files que continham o pacote:

| | tipo | requested | resolved |
|---|---|---|---|
| 31 locks | `CentralTransitive` | `[10.0.7, )` | **10.0.2** |
| 3 locks | `Transitive` | — | **10.0.2** |

Ou seja: o que o build consumia era **10.0.2**, três patches atrás do runtime, e o `dotnet ef` — que acabou de ir para 10.0.10 no #1022 — carregava esse assembly de design-time.

Comprovei que bumpar só a versão central é inócuo: rodei `restore --force-evaluate` com a CPM em 10.0.10 e o diff mexeu apenas na linha `requested`; todos os `resolved` continuaram 10.0.2.

## A correção

Declarar o pacote onde ele é de fato usado. `dotnet ef` exige um startup project com `runtimeconfig` — desde a ADR-0097 os `.Infrastructure` dos módulos internos são class libraries puras, então os únicos startup projects são `Unifesspa.UniPlus.Host` e `Unifesspa.UniPlus.Portal.API`. Com `PackageReference` direto, a versão central passa a valer; `PrivateAssets="all"` impede que o assembly de design-time atravesse para runtime e publish.

Depois da mudança:

| | tipo | requested | resolved |
|---|---|---|---|
| 2 locks (Host, Portal.API) | `Direct` | `[10.0.10, )` | **10.0.10** |
| 29 locks | `CentralTransitive` | `[10.0.10, )` | 10.0.2 |
| 3 locks | `Transitive` | — | 10.0.2 |

## O que este PR deliberadamente não faz

Os 29 locks restantes seguem com a transitiva do Wolverine em 10.0.2. Isso é inofensivo — nenhum deles é startup de migration e o assembly de design-time não é carregado ali. Alinhá-los exigiria habilitar `CentralPackageTransitivePinningEnabled`, que pinaria **toda** transitiva com versão central declarada, não só esta. É mudança de alcance bem maior, com risco de deslocar outras resoluções do grafo, e sem ganho para o problema desta issue.

## Mudanças

### Modificados

- `Directory.Packages.props` — `Microsoft.EntityFrameworkCore.Design` de 10.0.7 para 10.0.10;
- `src/host/Unifesspa.UniPlus.Host/Unifesspa.UniPlus.Host.csproj` — `PackageReference` do `.Design` com `PrivateAssets="all"` e comentário explicando o porquê;
- `src/portal/Unifesspa.UniPlus.Portal.API/Unifesspa.UniPlus.Portal.API.csproj` — idem, para o `PortalDbContext`;
- 31 `packages.lock.json` regenerados com `restore --force-evaluate` na solution inteira.

## Testes

Diff semântico dos locks, comparando `resolved` de cada pacote contra a `main`: **dois** pacotes alteram versão, e só nos dois locks dos startup projects — o próprio `.Design` e o `Microsoft.Extensions.DependencyModel` que ele arrasta, ambos `10.0.2 -> 10.0.10`. Nenhum pacote entrou ou saiu do grafo.

Gates locais, todos verdes:

- `restore UniPlus.slnx --locked-mode` sem `NU1004` e sem reescrever lock file;
- `build UniPlus.slnx -c Release` — 0 avisos, 0 erros;
- `format --verify-no-changes --exclude-diagnostics CA1515` limpo;
- `test` com filtro fora de integração — 3.138 aprovados, 0 falhas;
- `dotnet ef dbcontext list` contra os dois startup projects — enumera `SelecaoDbContext` e `PortalDbContext`, que é a verificação que interessa aqui, já que o pacote só atua em design-time.

- [x] Testes unitários passando
- [x] Testes de integração passando (via CI)
- [ ] Testes E2E passando (se aplicável) - N/A

## Checklist

- [x] Build sem erros e sem warnings
- [x] Código segue Clean Architecture e SOLID - N/A (sem código de domínio)
- [x] Sem exposição de PII (CPF, renda, dados sensíveis) - N/A
- [x] Strings user-facing em pt-BR - N/A
- [x] Soft delete utilizado (sem DELETE físico) - N/A
- [x] Documentação atualizada (se aplicável) - comentários nos `.csproj`