### PR TITLE
test(selecao): cobre as coleções que a prova de permutação não exercitava

### DIFF
--- a/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/ProcessosSeletivos/CorpusEnvelope.cs
+++ b/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/ProcessosSeletivos/CorpusEnvelope.cs
@@ -71,6 +71,18 @@ internal static class CorpusEnvelope
         ReferenciaRegra.Criar(codigo, "v1", new string(semente, 64)).Value!;
 
     /// <summary>
+    /// Permuta a ORDEM DE ENTRADA de uma coleção não ordenada, sem mudar o conteúdo (Story
+    /// #928, §7.5): o mesmo conjunto de itens, apresentado ao agregado em ordem física
+    /// inversa, tem de produzir bytes canônicos idênticos — a projeção ordena tudo por
+    /// chave determinística antes de serializar. Compartilhado por toda coleção do corpus
+    /// que declara <c>permutar</c>: etapas, distribuição de vagas, critérios de desempate,
+    /// cronograma de fases, fatos coletados, regras de derivação, destinos da cascata
+    /// (dentro de uma mesma origem) e a árvore de satisfação (raízes e filhos).
+    /// </summary>
+    private static IReadOnlyList<T> Ordem<T>(IReadOnlyList<T> itens, bool inverter) =>
+        inverter ? [.. ((IEnumerable<T>)itens).Reverse()] : itens;
+
+    /// <summary>
     /// O agregado mais rico que o modelo permite: três etapas (uma de cada caráter),
     /// atendimento povoado, bônus com teto, <b>as quatro</b> variantes de desempate,
     /// classificação local com <b>três</b> regras de eliminação — duas delas do
@@ -83,14 +95,17 @@ internal static class CorpusEnvelope
     /// e o segundo <c>DESEMPATE-MAIOR-NOTA-ETAPA</c> em silêncio. Um corpus com “uma de
     /// cada variante” não pegaria isso.
     /// </remarks>
-    internal static ProcessoSeletivo ProcessoRico(int variante = 0, bool permutar = false)
+    /// <param name="variante">Ver <see cref="EtapaId"/> — só distingue processos no mesmo Postgres entre testes de persistência.</param>
+    /// <param name="permutar">Inverte a ordem de ENTRADA das coleções não ordenadas — nunca o conteúdo.</param>
+    /// <param name="comArvoreSatisfacao">
+    /// Opt-in: acrescenta a árvore de satisfação de documentos exigidos (<see cref="ArvoreSatisfacaoRica"/>).
+    /// Fica fora por padrão porque as golden fixtures (<c>envelope-0.0.5-rico.json</c>) e os testes de
+    /// round-trip congelam a forma de HOJE do corpus rico — sem árvore, <c>documentosExigidos.exigencias</c>
+    /// e <c>arvoreSatisfacao</c> vazios. Populá-la incondicionalmente mudaria os bytes desse envelope de
+    /// referência para todo consumidor de <see cref="ProcessoRico"/>, não só quem testa a permutação.
+    /// </param>
+    internal static ProcessoSeletivo ProcessoRico(int variante = 0, bool permutar = false, bool comArvoreSatisfacao = false)
     {
-        // Permuta a ORDEM DE ENTRADA das coleções não ordenadas (Story #928, §7.5): o mesmo conteúdo
-        // apresentado ao agregado em ordem inversa tem de produzir bytes canônicos idênticos, porque a
-        // projeção ordena tudo por chave determinística. Só a ordem de entrada muda — nunca o conteúdo.
-        static IReadOnlyList<T> Ordem<T>(IReadOnlyList<T> itens, bool inverter) =>
-            inverter ? [.. ((IEnumerable<T>)itens).Reverse()] : itens;
-
         Guid objetiva = EtapaId(1, variante);
         Guid redacao = EtapaId(2, variante);
         Guid entrevista = EtapaId(3, variante);
@@ -100,11 +115,11 @@ internal static class CorpusEnvelope
             "PS Rico 2026", TipoProcesso.SiSU, OrigemCandidatos.InscricaoPropria, UnidadeAdministradora,
             Unifesspa.UniPlus.Selecao.Domain.ValueObjects.UnidadeAdministradoraSnapshot.Criar("CEPS", "ceps", "Centro de Processos Seletivos", "ADMINISTRATIVA").Value!);
 
-        processo.DefinirEtapas([
+        processo.DefinirEtapas(Ordem([
             EtapaProcesso.Reidratar(objetiva, "Prova Objetiva", CaraterEtapa.Ambas, peso: 3.5000m, notaMinima: 40.0000m, ordem: 1),
             EtapaProcesso.Reidratar(redacao, "Redação", CaraterEtapa.Classificatoria, peso: 2.2500m, notaMinima: null, ordem: 2),
             EtapaProcesso.Reidratar(entrevista, "Entrevista", CaraterEtapa.Eliminatoria, peso: null, notaMinima: 60.0000m, ordem: 3),
-        ], PrecondicaoIfMatch.Ausente).IsSuccess.Should().BeTrue();
+        ], permutar), PrecondicaoIfMatch.Ausente).IsSuccess.Should().BeTrue();
 
         processo.DefinirOfertaAtendimento(OfertaAtendimentoEspecializado.Criar(
             condicoes: [
@@ -131,14 +146,14 @@ internal static class CorpusEnvelope
 
         // As QUATRO variantes de args — e DUAS do mesmo código (MAIOR-NOTA-ETAPA em
         // ordens distintas), que um decoder indexado por código colapsaria em uma.
-        processo.DefinirCriteriosDesempate([
+        processo.DefinirCriteriosDesempate(Ordem([
             CriterioDesempate.Criar(1, Regra(CriterioDesempateCodigo.Idoso, 'c'), new ArgsDesempateIdoso(60)).Value!,
             CriterioDesempate.Criar(2, Regra(CriterioDesempateCodigo.MaiorNotaEtapa, 'd'), new ArgsDesempateMaiorNotaEtapa(objetiva)).Value!,
             CriterioDesempate.Criar(3, Regra(CriterioDesempateCodigo.MaiorNotaEtapa, 'd'), new ArgsDesempateMaiorNotaEtapa(redacao)).Value!,
             CriterioDesempate.Criar(4, Regra(CriterioDesempateCodigo.PredicadoFato, 'e'), new ArgsDesempatePredicadoFato(
                 CondicaoDnf.Criar("escola_publica", Operador.Igual, JsonSerializer.SerializeToElement(true)).Value!)).Value!,
             CriterioDesempate.Criar(5, Regra(CriterioDesempateCodigo.MaiorIdade, 'f'), new ArgsDesempateMaiorIdade()).Value!,
-        ], PrecondicaoIfMatch.Ausente).IsSuccess.Should().BeTrue();
+        ], permutar), PrecondicaoIfMatch.Ausente).IsSuccess.Should().BeTrue();
 
         processo.DefinirClassificacao(ConfiguracaoClassificacao.Criar(
             regraCalculo: Regra(RegraCalculoCodigo.FormulaMediaPonderada, 'a'),
@@ -155,7 +170,8 @@ internal static class CorpusEnvelope
             ],
             baseadoEmEnem: true).Value!, PrecondicaoIfMatch.Ausente).IsSuccess.Should().BeTrue();
 
-        processo.DefinirCronogramaFases([FaseInscricao(variante), FaseResultadoPreliminarComRecurso(variante)], [], PrecondicaoIfMatch.Ausente)
+        processo.DefinirCronogramaFases(
+            Ordem([FaseInscricao(variante), FaseResultadoPreliminarComRecurso(variante)], permutar), [], PrecondicaoIfMatch.Ausente)
             .IsSuccess.Should().BeTrue();
 
         // Coleta de fatos + derivação de MODALIDADE (Story #928, §7.4): COR_RACA é coletado sem
@@ -201,28 +217,129 @@ internal static class CorpusEnvelope
         // DistribuicaoLei12711 já são SegueCascata (INV-12) — sem uma cascata que as cubra,
         // Publicar() recusa com ProcessoSeletivo.CascataOrigemAusente (PendenciaDaCascata).
         // A matriz legal completa (8×7, fallback AC) é o que mantém este corpus PUBLICÁVEL.
-        processo.DefinirCascataRemanejamento(CascataLegalCompleta(), PrecondicaoIfMatch.Ausente).IsSuccess.Should().BeTrue();
+        processo.DefinirCascataRemanejamento(CascataLegalCompleta(permutar), PrecondicaoIfMatch.Ausente).IsSuccess.Should().BeTrue();
+
+        // Árvore de satisfação de documentos exigidos (Story #920) — opt-in (ver o parâmetro
+        // comArvoreSatisfacao acima): incluí-la incondicionalmente mudaria o envelope de
+        // referência que as golden fixtures e os testes de round-trip congelam.
+        if (comArvoreSatisfacao)
+        {
+            processo.DefinirDocumentosExigidos(ArvoreSatisfacaoRica(variante, permutar), PrecondicaoIfMatch.Ausente)
+                .IsSuccess.Should().BeTrue();
+        }
 
         return processo;
     }
 
-    /// <summary>A matriz legal completa (8×7), fallback AC — mesma forma semeada em REMANEJ-CASCATA-LEI-12711 v1.</summary>
-    private static ConfiguracaoCascataRemanejamento CascataLegalCompleta()
+    /// <summary>
+    /// A matriz legal completa (8×7), fallback AC — mesma forma semeada em
+    /// REMANEJ-CASCATA-LEI-12711 v1. <paramref name="permutar"/> inverte a ordem de ENTRADA dos
+    /// destinos DENTRO de cada origem — nunca a ordem das origens em si: cada origem aparece uma
+    /// única vez na cascata, então permutar a sequência de origens não exercitaria a ordenação de
+    /// <c>cascataRemanejamento…destinos</c> — só a dos destinos de uma MESMA origem prova isso.
+    /// </summary>
+    private static ConfiguracaoCascataRemanejamento CascataLegalCompleta(bool permutar = false)
     {
         IReadOnlyList<string> origens = ModalidadesFederaisLei12711.Codigos;
         List<DestinoRemanejamento> destinos = [];
         foreach (string origem in origens)
         {
             string[] destinosDaOrigem = [.. origens.Where(o => o != origem)];
+            List<DestinoRemanejamento> destinosDestaOrigem = [];
             for (int i = 0; i < destinosDaOrigem.Length; i++)
             {
-                destinos.Add(DestinoRemanejamento.Criar(origem, i + 1, destinosDaOrigem[i]).Value!);
+                destinosDestaOrigem.Add(DestinoRemanejamento.Criar(origem, i + 1, destinosDaOrigem[i]).Value!);
             }
+
+            destinos.AddRange(Ordem(destinosDestaOrigem, permutar));
         }
 
         return ConfiguracaoCascataRemanejamento.Criar(
             Regra(RegraRemanejamentoCodigo.Cascata, '1'), ModalidadesFederaisLei12711.Ac, destinos).Value!;
     }
+
+    /// <summary>
+    /// A árvore de satisfação exercitada pela prova de permutação (Story #928, §7.5, issue
+    /// #1087): DUAS raízes — uma folha solteira (<c>HISTORICO_ESCOLAR</c>, exigência "solteira",
+    /// sem grupo) e um grupo <c>OU</c> com DOIS filhos (comprovação de renda por declaração de
+    /// imposto de renda OU extrato bancário). Duas raízes de um filho cada deixariam a coleção
+    /// <c>filhos</c> trivial — qualquer ordenação produziria o mesmo resultado, e a permutação
+    /// não provaria nada sobre a ordenação de <c>arvoreSatisfacao[].filhos</c>.
+    /// </summary>
+    /// <remarks>
+    /// Ids <b>fixos</b>, via <c>Reidratar</c> — mesma razão de <see cref="EtapaId"/>: tanto
+    /// <c>DocumentoExigido.Id</c> quanto <c>NoExigencia.Id</c> entram no envelope
+    /// (<c>exigenciaId</c>/<c>id</c>). <c>Criar</c> sorteia um Guid v7 novo a cada chamada — duas
+    /// montagens desta árvore (uma para o processo direto, outra para o permutado) produziriam
+    /// ids distintos e os bytes nunca bateriam, mesmo sem nenhuma diferença de ORDEM.
+    /// </remarks>
+    private static IReadOnlyList<NoExigencia> ArvoreSatisfacaoRica(int variante, bool permutar)
+    {
+        Guid faseInscricaoId = FaseInscricao(variante).Id;
+
+        DocumentoExigido historicoEscolar = DocumentoExigidoRico(
+            DocumentoExigidoIdFixo(1, variante), faseInscricaoId, TipoDocumentoOrigemIdFixo(1), "HISTORICO_ESCOLAR",
+            "Histórico escolar do ensino médio", "ACADEMICO", obrigatorio: true);
+        DocumentoExigido declaracaoImpostoRenda = DocumentoExigidoRico(
+            DocumentoExigidoIdFixo(2, variante), faseInscricaoId, TipoDocumentoOrigemIdFixo(2), "DECLARACAO_IMPOSTO_RENDA",
+            "Declaração de Imposto de Renda", "RENDA", obrigatorio: false);
+        DocumentoExigido extratoBancario = DocumentoExigidoRico(
+            DocumentoExigidoIdFixo(3, variante), faseInscricaoId, TipoDocumentoOrigemIdFixo(3), "EXTRATO_BANCARIO",
+            "Extrato bancário dos últimos três meses", "RENDA", obrigatorio: false);
+
+        NoExigencia raizSolteira = NoExigencia.Reidratar(
+            NoExigenciaIdFixo(1, variante), TipoNo.Folha, ordem: 0,
+            documentoExigidoId: historicoEscolar.Id, documentoExigido: historicoEscolar,
+            quantidadeMinima: NoExigencia.QuantidadeMinimaPadrao, consequencia: null, chaveDistincao: null,
+            dataReferencia: null, ocorrenciasEsperadas: null, repetePorEntidade: null, basesLegais: [], filhos: []);
+        NoExigencia filhoDeclaracao = NoExigencia.Reidratar(
+            NoExigenciaIdFixo(2, variante), TipoNo.Folha, ordem: 0,
+            documentoExigidoId: declaracaoImpostoRenda.Id, documentoExigido: declaracaoImpostoRenda,
+            quantidadeMinima: NoExigencia.QuantidadeMinimaPadrao, consequencia: null, chaveDistincao: null,
+            dataReferencia: null, ocorrenciasEsperadas: null, repetePorEntidade: null, basesLegais: [], filhos: []);
+        NoExigencia filhoExtrato = NoExigencia.Reidratar(
+            NoExigenciaIdFixo(3, variante), TipoNo.Folha, ordem: 1,
+            documentoExigidoId: extratoBancario.Id, documentoExigido: extratoBancario,
+            quantidadeMinima: NoExigencia.QuantidadeMinimaPadrao, consequencia: null, chaveDistincao: null,
+            dataReferencia: null, ocorrenciasEsperadas: null, repetePorEntidade: null, basesLegais: [], filhos: []);
+        NoExigencia grupoRenda = NoExigencia.Reidratar(
+            NoExigenciaIdFixo(4, variante), TipoNo.GrupoOu, ordem: 1,
+            documentoExigidoId: null, documentoExigido: null,
+            quantidadeMinima: 1, consequencia: null, chaveDistincao: null, dataReferencia: null,
+            ocorrenciasEsperadas: null, repetePorEntidade: null, basesLegais: [],
+            filhos: Ordem([filhoDeclaracao, filhoExtrato], permutar));
+
+        return Ordem([raizSolteira, grupoRenda], permutar);
+    }
+
+    private static Guid TipoDocumentoOrigemIdFixo(int indice) =>
+        new($"77771111-0000-4000-8000-00000000000{indice:x}");
+
+    private static Guid DocumentoExigidoIdFixo(int ordem, int variante) =>
+        new($"7777200{variante:x}-0000-4000-8000-00000000000{ordem:x}");
+
+    private static Guid NoExigenciaIdFixo(int ordem, int variante) =>
+        new($"7777300{variante:x}-0000-4000-8000-00000000000{ordem:x}");
+
+    private static DocumentoExigido DocumentoExigidoRico(
+        Guid id, Guid exigidoNaFaseId, Guid tipoDocumentoOrigemId, string tipoDocumentoCodigo,
+        string tipoDocumentoNome, string tipoDocumentoCategoria, bool obrigatorio) =>
+        DocumentoExigido.Reidratar(
+            id,
+            exigidoNaFaseId,
+            tipoDocumentoOrigemId: tipoDocumentoOrigemId,
+            tipoDocumentoCodigo: tipoDocumentoCodigo,
+            tipoDocumentoNome: tipoDocumentoNome,
+            tipoDocumentoCategoria: tipoDocumentoCategoria,
+            aplicabilidade: Aplicabilidade.Geral,
+            obrigatorio: obrigatorio,
+            consequenciaIndeferimento: null,
+            grupoSatisfacaoId: null,
+            condicoes: [],
+            basesLegais: [],
+            idadeMaximaEmissao: null,
+            formatosPermitidos: FormatosPermitidos.Criar(qualquer: true, entradas: null).Value!,
+            tamanhoMaximoBytes: null);
 
     /// <summary>Fase 1: coleta inscrição, sem ato produzido — a origem é InscricaoPropria.</summary>
     private static FaseCronograma FaseInscricao(int variante = 0) => FaseCronograma.Reidratar(

--- a/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/ProcessosSeletivos/CorpusEnvelope.cs
+++ b/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/ProcessosSeletivos/CorpusEnvelope.cs
@@ -122,18 +122,18 @@ internal static class CorpusEnvelope
         ], permutar), PrecondicaoIfMatch.Ausente).IsSuccess.Should().BeTrue();
 
         processo.DefinirOfertaAtendimento(OfertaAtendimentoEspecializado.Criar(
-            condicoes: [
+            condicoes: Ordem<OfertaCondicao>([
                 OfertaCondicao.Criar(new Guid("eeee0000-0000-4000-8000-000000000001"), OfertaAtendimentoEspecializado.CodigoCondicaoPcd, "Pessoa com deficiência"),
                 OfertaCondicao.Criar(new Guid("eeee0000-0000-4000-8000-000000000002"), "LACTANTE", "Lactante"),
-            ],
-            recursos: [
+            ], permutar),
+            recursos: Ordem<OfertaRecurso>([
                 OfertaRecurso.Criar(new Guid("ffff0000-0000-4000-8000-000000000001"), "Ledor"),
                 OfertaRecurso.Criar(new Guid("ffff0000-0000-4000-8000-000000000002"), "Prova ampliada"),
-            ],
-            tiposDeficiencia: [
+            ], permutar),
+            tiposDeficiencia: Ordem<OfertaTipoDeficiencia>([
                 OfertaTipoDeficiencia.Criar(new Guid("1111aaaa-0000-4000-8000-000000000001"), "Deficiência visual"),
                 OfertaTipoDeficiencia.Criar(new Guid("1111aaaa-0000-4000-8000-000000000002"), "Deficiência auditiva"),
-            ]).Value!, PrecondicaoIfMatch.Ausente).IsSuccess.Should().BeTrue();
+            ], permutar)).Value!, PrecondicaoIfMatch.Ausente).IsSuccess.Should().BeTrue();
 
         processo.DefinirDistribuicaoVagas(Ordem([DistribuicaoLei12711(), DistribuicaoInstitucional()], permutar), PrecondicaoIfMatch.Ausente).IsSuccess.Should().BeTrue();
 
@@ -171,7 +171,7 @@ internal static class CorpusEnvelope
             baseadoEmEnem: true).Value!, PrecondicaoIfMatch.Ausente).IsSuccess.Should().BeTrue();
 
         processo.DefinirCronogramaFases(
-            Ordem([FaseInscricao(variante), FaseResultadoPreliminarComRecurso(variante)], permutar), [], PrecondicaoIfMatch.Ausente)
+            Ordem([FaseInscricao(variante), FaseResultadoPreliminarComRecurso(variante, permutar)], permutar), [], PrecondicaoIfMatch.Ausente)
             .IsSuccess.Should().BeTrue();
 
         // Coleta de fatos + derivação de MODALIDADE (Story #928, §7.4): COR_RACA é coletado sem
@@ -367,7 +367,9 @@ internal static class CorpusEnvelope
     /// 1ª instância com valor (5 dias corridos), a 2ª <b>nula</b> (não bloqueia — o caso
     /// normal do Ingresso via judicial). É o ramo mais rico do bloco <c>cronogramaFases</c>.
     /// </summary>
-    private static FaseCronograma FaseResultadoPreliminarComRecurso(int variante = 0) => FaseCronograma.Reidratar(
+    /// <param name="variante">Ver <see cref="EtapaId"/> — só distingue processos no mesmo Postgres entre testes de persistência.</param>
+    /// <param name="permutar">Inverte a ordem de ENTRADA das bancas requeridas desta fase — nunca o conteúdo.</param>
+    private static FaseCronograma FaseResultadoPreliminarComRecurso(int variante = 0, bool permutar = false) => FaseCronograma.Reidratar(
         id: new Guid($"6666aaaa-000{variante:x}-4000-8000-000000000002"),
         ordem: 2,
         faseCanonicaOrigemId: new Guid("4444dddd-0000-4000-8000-000000000002"),
@@ -383,10 +385,10 @@ internal static class CorpusEnvelope
         fim: new DateTimeOffset(2026, 3, 25, 18, 0, 0, TimeSpan.Zero),
         atoProduzidoCodigo: "RESULTADO_PRELIMINAR",
         atoProduzidoEfeitoIrreversivel: true,
-        bancasRequeridas: [
+        bancasRequeridas: Ordem<BancaRequerida>([
             BancaRequerida.Criar(new Guid("5555eeee-0000-4000-8000-000000000001"), "BANCA_ANALISE_DOCUMENTAL"),
             BancaRequerida.Criar(new Guid("5555eeee-0000-4000-8000-000000000002"), "BANCA_HETEROIDENTIFICACAO"),
-        ],
+        ], permutar),
         regraRecurso: RegraRecursoFase.Criar(
             Regra(RegraPrazoRecursoCodigo.AncoradoEmAto, '9'),
             new ArgsRegraPrazoRecurso(

--- a/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/ProcessosSeletivos/EnvelopeCanonicoPermutacaoTests.cs
+++ b/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/ProcessosSeletivos/EnvelopeCanonicoPermutacaoTests.cs
@@ -4,34 +4,63 @@ using AwesomeAssertions;
 
 using Unifesspa.UniPlus.Selecao.Application.Abstractions;
 using Unifesspa.UniPlus.Selecao.Domain.Entities;
+using Unifesspa.UniPlus.Selecao.Domain.Enums;
 using Unifesspa.UniPlus.Selecao.Infrastructure.Canonicalization;
 
 using Xunit;
 
 /// <summary>
-/// <b>Invariância à permutação</b> (Story #928, §7.5): o envelope canônico depende só do
-/// <b>conteúdo</b> da configuração, nunca da ordem em que as coleções não ordenadas chegam ao
-/// agregado. Permutar a ordem de entrada de fatos coletados, regras de derivação, condições de um
-/// predicado e ofertas de curso — sem mudar nenhum valor — SHALL produzir os mesmos bytes canônicos
-/// e o mesmo hash.
+/// <b>Invariância à permutação</b> (Story #928, §7.5; issue #1087): o envelope canônico depende só
+/// do <b>conteúdo</b> da configuração, nunca da ordem em que as coleções não ordenadas chegam ao
+/// agregado. Permutar a ordem de entrada de etapas, distribuição de vagas e ofertas, critérios de
+/// desempate, cronograma de fases, fatos coletados, regras de derivação (a lista externa e as
+/// condições/regras aninhadas), destinos da cascata de remanejamento (dentro de uma mesma origem) e
+/// a árvore de satisfação (as raízes e os filhos de um grupo) — sem mudar nenhum valor — SHALL
+/// produzir os mesmos bytes canônicos e o mesmo hash.
 /// </summary>
 /// <remarks>
+/// <para>
 /// A projeção ordena cada coleção por uma chave determinística (a <c>Ordem</c> onde é semântica, a
 /// identidade de negócio onde existe, a chave de conteúdo onde não há chave natural), então duas
 /// entradas equivalentes convergem para os mesmos bytes. O determinismo do grafo conjunto e da
 /// identidade canônica é provado no grão do value object (<c>GrafoDependenciaConjuntaTests</c>,
 /// <c>IdCanonicoTests</c>); aqui a prova é sobre os <b>bytes do envelope inteiro</b>.
+/// </para>
+/// <para>
+/// FORA desta prova, por decisão: as coleções que o encoder já ordena pela CHAVE DE CONTEÚDO do
+/// próprio item (ADR-0109 D9) em vez de um campo <c>Ordem</c> declarado — <c>ofertaAtendimento</c>
+/// (condições/recursos/tipos de deficiência), <c>modalidades[].criteriosCumulativos</c>,
+/// <c>classificacao.regrasEliminacao</c>, <c>cronogramaFases.fases[].bancasRequeridas</c> e
+/// <c>documentosExigidos.exigencias</c>. A ordem de CRIAÇÃO dessa família não pode vazar para o
+/// envelope de qualquer forma (dois Guid v7 em ordem inversa também mudariam a ordem de ENTRADA), e
+/// já tem prova própria — <c>EnvelopeCanonicoGoldenTests.Envelope_IndependeDaOrdemDeCriacao</c> —
+/// no vetor de regressão que cabe a uma chave que É o próprio conteúdo, não uma posição declarada.
+/// <c>valoresSelecionaveis[]</c> tem prova própria, em
+/// <see cref="PermutacaoDeValoresSelecionaveis_ProduzMesmosBytes"/>.
+/// </para>
 /// </remarks>
 public sealed class EnvelopeCanonicoPermutacaoTests
 {
     [Fact(DisplayName = "Permutar a ordem de entrada das coleções produz bytes canônicos e hash idênticos")]
     public void Permutacao_ProduzMesmosBytesEHash()
     {
-        ProcessoSeletivo direto = CorpusEnvelope.ProcessoRico();
-        ProcessoSeletivo permutado = CorpusEnvelope.ProcessoRico(permutar: true);
+        ProcessoSeletivo direto = CorpusEnvelope.ProcessoRico(comArvoreSatisfacao: true);
+        ProcessoSeletivo permutado = CorpusEnvelope.ProcessoRico(permutar: true, comArvoreSatisfacao: true);
 
-        // Pré-condição: a permutação inverteu DE FATO a ordem de entrada — sem isto o teste seria
-        // vacuamente verdadeiro (comparar um envelope com ele mesmo).
+        // Pré-condição POR COLEÇÃO: sem provar que a permutação alterou DE FATO a ordem de entrada
+        // DAQUELA coleção especificamente, uma coleção que o `permutar` não conseguisse inverter
+        // (por exemplo, porque o agregado a reordena na entrada) passaria por vacuidade — a
+        // comparação de bytes ao final compararia um envelope com ele mesmo, sob outro nome, e a
+        // ausência de cobertura ficaria invisível (issue #1087).
+        direto.Etapas.Select(static e => e.Nome)
+            .Should().NotEqual(permutado.Etapas.Select(static e => e.Nome),
+                "pré-condição: a permutação tem de inverter a ordem de entrada das etapas");
+        direto.CriteriosDesempate.Select(static c => c.Ordem)
+            .Should().NotEqual(permutado.CriteriosDesempate.Select(static c => c.Ordem),
+                "pré-condição: a permutação tem de inverter a ordem de entrada dos critérios de desempate");
+        direto.CronogramaFases.Select(static f => f.Codigo)
+            .Should().NotEqual(permutado.CronogramaFases.Select(static f => f.Codigo),
+                "pré-condição: a permutação tem de inverter a ordem de entrada das fases do cronograma");
         direto.FatosColetados.Select(static f => f.FatoCodigo)
             .Should().NotEqual(permutado.FatosColetados.Select(static f => f.FatoCodigo),
                 "pré-condição: a permutação tem de inverter a ordem de entrada dos fatos coletados");
@@ -39,12 +68,34 @@ public sealed class EnvelopeCanonicoPermutacaoTests
             .Should().NotEqual(permutado.RegrasDerivacao.Select(static c => c.CodigoFato),
                 "pré-condição: a permutação tem de inverter a ordem de entrada da lista de configurações de derivação");
 
+        // A origem fixada é a primeira das 8 federais — permutar embaralha os DESTINOS dentro dela;
+        // inverter a sequência de ORIGENS não provaria nada (cada origem aparece uma única vez na
+        // cascata, então a ordem entre origens nunca alimenta SerializarCascataRemanejamento).
+        string origemCascataDeTeste = ModalidadesFederaisLei12711.Codigos[0];
+        direto.Cascata!.Destinos.Where(d => d.ModalidadeOrigemCodigo == origemCascataDeTeste)
+            .Select(static d => d.ModalidadeDestinoCodigo)
+            .Should().NotEqual(
+                permutado.Cascata!.Destinos.Where(d => d.ModalidadeOrigemCodigo == origemCascataDeTeste)
+                    .Select(static d => d.ModalidadeDestinoCodigo),
+                $"pré-condição: a permutação tem de inverter a ordem de entrada dos destinos da cascata dentro da origem '{origemCascataDeTeste}'");
+
+        direto.RaizesDeExigencia.Select(static r => r.Tipo)
+            .Should().NotEqual(permutado.RaizesDeExigencia.Select(static r => r.Tipo),
+                "pré-condição: a permutação tem de inverter a ordem de entrada das raízes da árvore de satisfação");
+
+        NoExigencia grupoDireto = direto.RaizesDeExigencia.Single(static r => r.Filhos.Count > 0);
+        NoExigencia grupoPermutado = permutado.RaizesDeExigencia.Single(static r => r.Filhos.Count > 0);
+        grupoDireto.Filhos.Select(static f => f.DocumentoExigido!.TipoDocumentoCodigo)
+            .Should().NotEqual(grupoPermutado.Filhos.Select(static f => f.DocumentoExigido!.TipoDocumentoCodigo),
+                "pré-condição: a permutação tem de inverter a ordem de entrada dos filhos do grupo da árvore de satisfação");
+
         SnapshotCanonico bytesDireto = CorpusEnvelope.Codec.Codificar(CorpusEnvelope.Entrada(direto));
         SnapshotCanonico bytesPermutado = CorpusEnvelope.Codec.Codificar(CorpusEnvelope.Entrada(permutado));
 
         bytesPermutado.Bytes.Should().Equal(bytesDireto.Bytes,
-            "o envelope depende só do conteúdo — permutar a ordem de entrada de fatos, regras, condições e " +
-            "ofertas não muda um único byte");
+            "o envelope depende só do conteúdo — permutar a ordem de entrada de etapas, distribuição/ofertas, " +
+            "critérios de desempate, cronograma de fases, fatos coletados, regras de derivação, destinos da " +
+            "cascata e a árvore de satisfação não muda um único byte");
         PerfilCanonicoV1.Instancia.HashHex(bytesPermutado.Bytes)
             .Should().Be(PerfilCanonicoV1.Instancia.HashHex(bytesDireto.Bytes),
                 "bytes idênticos ⟹ hash idêntico");

--- a/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/ProcessosSeletivos/EnvelopeCanonicoPermutacaoTests.cs
+++ b/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/ProcessosSeletivos/EnvelopeCanonicoPermutacaoTests.cs
@@ -12,11 +12,13 @@ using Xunit;
 /// <summary>
 /// <b>Invariância à permutação</b> (Story #928, §7.5; issue #1087): o envelope canônico depende só
 /// do <b>conteúdo</b> da configuração, nunca da ordem em que as coleções não ordenadas chegam ao
-/// agregado. Permutar a ordem de entrada de etapas, distribuição de vagas e ofertas, critérios de
-/// desempate, cronograma de fases, fatos coletados, regras de derivação (a lista externa e as
-/// condições/regras aninhadas), destinos da cascata de remanejamento (dentro de uma mesma origem) e
-/// a árvore de satisfação (as raízes e os filhos de um grupo) — sem mudar nenhum valor — SHALL
-/// produzir os mesmos bytes canônicos e o mesmo hash.
+/// agregado. Permutar a ordem de entrada de etapas, da oferta de atendimento (condições, recursos e
+/// tipos de deficiência), distribuição de vagas e ofertas, critérios de desempate, cronograma de
+/// fases (inclusive as bancas requeridas de uma fase), fatos coletados, regras de derivação (a
+/// lista externa, as regras internas de uma configuração e as condições aninhadas de uma regra),
+/// destinos da cascata de remanejamento (dentro de uma mesma origem) e a árvore de satisfação (as
+/// raízes e os filhos de um grupo) — sem mudar nenhum valor — SHALL produzir os mesmos bytes
+/// canônicos e o mesmo hash.
 /// </summary>
 /// <remarks>
 /// <para>
@@ -27,14 +29,34 @@ using Xunit;
 /// <c>IdCanonicoTests</c>); aqui a prova é sobre os <b>bytes do envelope inteiro</b>.
 /// </para>
 /// <para>
-/// FORA desta prova, por decisão: as coleções que o encoder já ordena pela CHAVE DE CONTEÚDO do
-/// próprio item (ADR-0109 D9) em vez de um campo <c>Ordem</c> declarado — <c>ofertaAtendimento</c>
-/// (condições/recursos/tipos de deficiência), <c>modalidades[].criteriosCumulativos</c>,
-/// <c>classificacao.regrasEliminacao</c>, <c>cronogramaFases.fases[].bancasRequeridas</c> e
-/// <c>documentosExigidos.exigencias</c>. A ordem de CRIAÇÃO dessa família não pode vazar para o
-/// envelope de qualquer forma (dois Guid v7 em ordem inversa também mudariam a ordem de ENTRADA), e
-/// já tem prova própria — <c>EnvelopeCanonicoGoldenTests.Envelope_IndependeDaOrdemDeCriacao</c> —
-/// no vetor de regressão que cabe a uma chave que É o próprio conteúdo, não uma posição declarada.
+/// <c>ofertaAtendimento</c> (condições/recursos/tipos de deficiência) e
+/// <c>cronogramaFases.fases[].bancasRequeridas</c> ordenam pela IDENTIDADE DE ORIGEM do item
+/// (<c>CondicaoOrigemId</c>/<c>RecursoOrigemId</c>/<c>TipoDeficienciaOrigemId</c>/<c>TipoBancaOrigemId</c>)
+/// — a segunda camada da política de ordenação, não a chave de conteúdo (ADR-0109 D9, a terceira e
+/// última camada, reservada a coleções sem identidade de negócio nenhuma). As duas entram nesta
+/// prova (a pré-condição correspondente confere que a permutação de fato inverte a ordem de
+/// entrada de cada uma).
+/// </para>
+/// <para>
+/// FORA desta prova, por decisão: <c>modalidades[].criteriosCumulativos</c> e
+/// <c>classificacao.regrasEliminacao</c> — as duas coleções que não têm identidade de negócio nem
+/// de origem entre os elementos, e por isso o encoder ordena pela CHAVE DE CONTEÚDO do próprio
+/// item (ADR-0109 D9). <c>classificacao.regrasEliminacao</c> tem prova própria —
+/// <c>EnvelopeCanonicoGoldenTests.Envelope_IndependeDaOrdemDeCriacao</c> varia a ordem de CRIAÇÃO
+/// de duas regras de eliminação (e, com ela, a ordem dos Guid v7) e prova que o envelope resultante
+/// não muda. <c>modalidades[].criteriosCumulativos</c> tem prova própria em
+/// <c>OrdenacaoDeConjuntosCanonicosTests.CriteriosCumulativos_OrdenaPelaChaveDeConteudoEmBytesUtf8</c>,
+/// que compara os bytes de duas entradas com o mesmo conteúdo em ordens de entrada diferentes.
+/// </para>
+/// <para>
+/// <c>documentosExigidos.exigencias</c> também fica FORA, por um motivo distinto dos dois acima: a
+/// chave PRIMÁRIA de ordenação é de negócio parcial — fase mais tipo de documento, ver
+/// <c>SnapshotPublicacaoCanonicalizer.SerializarExigencias</c> — não a identidade de origem nem a
+/// chave de conteúdo; a chave de conteúdo só desempata o caso raro de duas exigências idênticas na
+/// mesma fase e no mesmo tipo. Como a chave primária independe de qualquer identidade técnica da
+/// linha, a ordem de entrada não tem como vazar para o envelope — não há permutação a provar aqui.
+/// </para>
+/// <para>
 /// <c>valoresSelecionaveis[]</c> tem prova própria, em
 /// <see cref="PermutacaoDeValoresSelecionaveis_ProduzMesmosBytes"/>.
 /// </para>
@@ -55,18 +77,67 @@ public sealed class EnvelopeCanonicoPermutacaoTests
         direto.Etapas.Select(static e => e.Nome)
             .Should().NotEqual(permutado.Etapas.Select(static e => e.Nome),
                 "pré-condição: a permutação tem de inverter a ordem de entrada das etapas");
+
+        // A oferta de atendimento não tem chave `Ordem` — o encoder ordena as três listas pela
+        // IDENTIDADE DE ORIGEM do item (CondicaoOrigemId/RecursoOrigemId/TipoDeficienciaOrigemId),
+        // não pela chave de conteúdo. Sem esta pré-condição, remover o OrderBy de
+        // SerializarAtendimento no encoder deixaria a comparação de bytes ao final vazia para as
+        // três listas (issue #1087).
+        direto.OfertaAtendimento!.Condicoes.Select(static c => c.CondicaoOrigemId)
+            .Should().NotEqual(permutado.OfertaAtendimento!.Condicoes.Select(static c => c.CondicaoOrigemId),
+                "pré-condição: a permutação tem de inverter a ordem de entrada das condições da oferta de atendimento");
+        direto.OfertaAtendimento!.Recursos.Select(static r => r.RecursoOrigemId)
+            .Should().NotEqual(permutado.OfertaAtendimento!.Recursos.Select(static r => r.RecursoOrigemId),
+                "pré-condição: a permutação tem de inverter a ordem de entrada dos recursos da oferta de atendimento");
+        direto.OfertaAtendimento!.TiposDeficiencia.Select(static t => t.TipoDeficienciaOrigemId)
+            .Should().NotEqual(permutado.OfertaAtendimento!.TiposDeficiencia.Select(static t => t.TipoDeficienciaOrigemId),
+                "pré-condição: a permutação tem de inverter a ordem de entrada dos tipos de deficiência da oferta de atendimento");
+
+        direto.DistribuicaoVagas.Select(static d => d.OfertaCursoOrigemId)
+            .Should().NotEqual(permutado.DistribuicaoVagas.Select(static d => d.OfertaCursoOrigemId),
+                "pré-condição: a permutação tem de inverter a ordem de entrada da distribuição de vagas por oferta");
+
         direto.CriteriosDesempate.Select(static c => c.Ordem)
             .Should().NotEqual(permutado.CriteriosDesempate.Select(static c => c.Ordem),
                 "pré-condição: a permutação tem de inverter a ordem de entrada dos critérios de desempate");
         direto.CronogramaFases.Select(static f => f.Codigo)
             .Should().NotEqual(permutado.CronogramaFases.Select(static f => f.Codigo),
                 "pré-condição: a permutação tem de inverter a ordem de entrada das fases do cronograma");
+
+        // As bancas requeridas não têm chave `Ordem` — o encoder ordena pela IDENTIDADE DE ORIGEM
+        // (TipoBancaOrigemId), não pela chave de conteúdo. A fase RESULTADO_PRELIMINAR é a única
+        // do corpus com mais de uma banca — sem esta pré-condição, remover o OrderBy de
+        // SerializarBancasRequeridas deixaria a comparação de bytes ao final vazia para esta lista.
+        FaseCronograma faseComBancasDireto = direto.CronogramaFases.Single(static f => f.Codigo == "RESULTADO_PRELIMINAR");
+        FaseCronograma faseComBancasPermutado = permutado.CronogramaFases.Single(static f => f.Codigo == "RESULTADO_PRELIMINAR");
+        faseComBancasDireto.BancasRequeridas.Select(static b => b.TipoBancaOrigemId)
+            .Should().NotEqual(faseComBancasPermutado.BancasRequeridas.Select(static b => b.TipoBancaOrigemId),
+                "pré-condição: a permutação tem de inverter a ordem de entrada das bancas requeridas da fase RESULTADO_PRELIMINAR");
+
         direto.FatosColetados.Select(static f => f.FatoCodigo)
             .Should().NotEqual(permutado.FatosColetados.Select(static f => f.FatoCodigo),
                 "pré-condição: a permutação tem de inverter a ordem de entrada dos fatos coletados");
         direto.RegrasDerivacao.Select(static c => c.CodigoFato)
             .Should().NotEqual(permutado.RegrasDerivacao.Select(static c => c.CodigoFato),
                 "pré-condição: a permutação tem de inverter a ordem de entrada da lista de configurações de derivação");
+
+        // A lista EXTERNA de configurações de derivação já está coberta acima — mas o `permutar`
+        // também inverte, DENTRO da configuração de MODALIDADE, a lista de regras (AC/LB_PPI) e,
+        // dentro da regra LB_PPI, a lista de condições aninhadas (COR_RACA/RENDA). Nenhuma das duas
+        // tinha pré-condição própria: um agregado que normalizasse a ordem de QUALQUER uma na
+        // entrada (por exemplo, reordenando por `Ordem`/`Clausula` num factory futuro) passaria
+        // pela comparação de bytes ao final por vacuidade, sem que a lacuna aparecesse (issue #1087).
+        ConfiguracaoDerivacaoFato derivacaoModalidadeDireto = direto.RegrasDerivacao.Single(static c => c.CodigoFato == "MODALIDADE");
+        ConfiguracaoDerivacaoFato derivacaoModalidadePermutado = permutado.RegrasDerivacao.Single(static c => c.CodigoFato == "MODALIDADE");
+        derivacaoModalidadeDireto.Regras.Select(static r => r.Contribui)
+            .Should().NotEqual(derivacaoModalidadePermutado.Regras.Select(static r => r.Contribui),
+                "pré-condição: a permutação tem de inverter a ordem de entrada das regras dentro da configuração de derivação de MODALIDADE");
+
+        RegraDerivacaoConfigurada regraComCondicoesDireto = derivacaoModalidadeDireto.Regras.Single(static r => r.Contribui == "LB_PPI");
+        RegraDerivacaoConfigurada regraComCondicoesPermutado = derivacaoModalidadePermutado.Regras.Single(static r => r.Contribui == "LB_PPI");
+        regraComCondicoesDireto.Condicoes.Select(static c => c.Fato)
+            .Should().NotEqual(regraComCondicoesPermutado.Condicoes.Select(static c => c.Fato),
+                "pré-condição: a permutação tem de inverter a ordem de entrada das condições aninhadas da regra que contribui LB_PPI");
 
         // A origem fixada é a primeira das 8 federais — permutar embaralha os DESTINOS dentro dela;
         // inverter a sequência de ORIGENS não provaria nada (cada origem aparece uma única vez na
@@ -93,9 +164,11 @@ public sealed class EnvelopeCanonicoPermutacaoTests
         SnapshotCanonico bytesPermutado = CorpusEnvelope.Codec.Codificar(CorpusEnvelope.Entrada(permutado));
 
         bytesPermutado.Bytes.Should().Equal(bytesDireto.Bytes,
-            "o envelope depende só do conteúdo — permutar a ordem de entrada de etapas, distribuição/ofertas, " +
-            "critérios de desempate, cronograma de fases, fatos coletados, regras de derivação, destinos da " +
-            "cascata e a árvore de satisfação não muda um único byte");
+            "o envelope depende só do conteúdo — permutar a ordem de entrada de etapas, oferta de atendimento, " +
+            "distribuição/ofertas, critérios de desempate, cronograma de fases (inclusive as bancas requeridas " +
+            "de uma fase), fatos coletados, regras de derivação (a lista externa, as regras internas de uma " +
+            "configuração e as condições aninhadas de uma regra), destinos da cascata e a árvore de satisfação " +
+            "não muda um único byte");
         PerfilCanonicoV1.Instancia.HashHex(bytesPermutado.Bytes)
             .Should().Be(PerfilCanonicoV1.Instancia.HashHex(bytesDireto.Bytes),
                 "bytes idênticos ⟹ hash idêntico");


### PR DESCRIPTION
Corrige um defeito de cobertura **já presente na `main`**: a prova de invariância do envelope à ordem física declarava cobrir as coleções filhas do processo e exercitava menos da metade delas.

Closes #1087

## O que estava errado

`ObterComConfiguracaoAsync` não aplica `ORDER BY` aos `Include`, então a ordem física em que o Postgres devolve uma coleção pode variar entre leituras da mesma linha. Como a ordem de um array entra no hash, o canonicalizador ordena cada coleção por uma chave determinística — e a prova de permutação existe para garantir que isso vale para o envelope inteiro.

Só que o corpus invertia a ordem de entrada de apenas quatro coleções. **Etapas, critérios de desempate, cronograma de fases e destinos da cascata nunca eram permutados**, e a árvore de satisfação sequer era populada: o bloco saía vazio.

## Por que isso é mais do que cobertura faltando

Remover hoje a ordenação de qualquer uma dessas coleções **não quebra nada**. A prova de permutação passa, porque não inverte a entrada delas. A golden fixture também passa, porque foi gerada a partir da mesma ordem física.

A divergência só apareceria quando o plano de execução do banco mudasse — e aí como hash diferente para a mesma configuração de um certame publicado, que é precisamente o que este gate existe para impedir.

O agravante é o nome do teste: ele **declara** cobrir o envelope, então uma mudança que passe por ele parece provada.

## O que mudou

O corpus passa a inverter as quatro coleções faltantes e a montar a árvore com **duas raízes, uma delas com dois filhos**. Duas raízes de um filho cada deixariam a coleção de irmãos trivial — qualquer ordenação produz o mesmo resultado, e a linha passaria sem exercitar nada.

Nos destinos da cascata, a inversão acontece **dentro de uma mesma modalidade de origem**. Inverter a sequência de origens não provaria nada: cada origem aparece uma única vez, então a ordem entre elas nunca alimenta a serialização.

Cada coleção ganhou **asserção de pré-condição própria**. Sem ela, uma coleção que a permutação não conseguisse inverter — porque o agregado a reordena na entrada, por exemplo — passaria por vacuidade: a comparação final confrontaria um envelope com ele mesmo sob outro nome, e a ausência de cobertura ficaria invisível. É o mesmo modo de falha que este PR corrige.

A árvore entra por **parâmetro opcional, desligado por padrão**. Populá-la em todo processo do corpus acrescentaria blocos ao envelope de referência e mudaria as fixtures — o que transformaria uma correção de cobertura em mudança de forma, sem que o título dissesse isso.

A documentação do teste passa a declarar **o que fica de fora e por quê**: as coleções que o codificador ordena pela chave de conteúdo do próprio item, e não por posição declarada, já têm prova própria de independência da ordem de criação.

## Prova de que a cobertura é real

Removendo a ordenação de cada coleção, **uma de cada vez**, e rodando o teste:

| Coleção | Resultado com a ordenação removida |
|---|---|
| `etapas` | **falha** — diverge no byte 9786 |
| `criteriosDesempate` | **falha** — byte 4336 |
| `cronogramaFases.fases` | **falha** — byte 5313 |
| `cascataRemanejamento…destinos` | **falha** — byte 2182 |
| `arvoreSatisfacao` raízes | **falha** — byte 117 |
| `arvoreSatisfacao` filhos | **falha** — byte 555 |

Nenhuma coleção passa por vacuidade. O canonicalizador foi restaurado byte a byte após cada mutante.

## Escopo

Só dois arquivos de teste. **Nenhuma golden fixture mudou** e o canonicalizador não foi tocado — o `git diff` sobre `src/` é vazio. Suíte completa verde: 26 projetos, 4.584 testes, build com 0 avisos, `format` limpo.

## Nota sobre uma armadilha encontrada

A primeira versão da árvore usava as factories de criação, que geram identidade nova a cada chamada. As duas montagens do corpus recebiam ids diferentes, e o teste falhava por ruído de identidade — no byte 129, dentro do campo de id, antes de qualquer conteúdo sensível à ordem. Corrigido com reidratação e ids fixos, no mesmo padrão já usado pelas etapas do corpus. Vale registro porque é um defeito que inspeção não pega: só aparece executando.
