### PR TITLE
docs(adr): emenda o regime de codec do envelope

### DIFF
--- a/docs/adrs/0109-envelope-canonico-v2-do-congelamento.md
+++ b/docs/adrs/0109-envelope-canonico-v2-do-congelamento.md
@@ -178,3 +178,41 @@ engano, destruiria o testemunho produtor→consumidor que o array existe para pr
 
 Contagem de blocos/chaves do envelope: fatia de #1083. Política de fixture única versus
 fixture-por-`schema_version`: fatia de #1053. Esta emenda não reabre nenhuma das duas.
+
+## Emenda 2 (2026-08-06) — golden fixture da forma corrente antes da primeira publicação
+
+Esta emenda corrige o alcance histórico da D2, sem reescrever as decisões originais: o
+regime de fixtures por `schema_version` pressupunha o registro de codecs por versão que a
+Emenda 2 da ADR-0110 aposenta para o período pré-publicação.
+
+### E2.1 — D1 continua valendo; o trem coordenado não cria duas formas publicáveis sob a mesma versão
+
+A **D1 continua valendo integralmente**: toda mudança de forma do envelope avança a versão
+corrente. Não é permitido deixar de avançar uma versão porque a alteração pareça pequena ou
+porque apenas um bloco provisório ganhou conteúdo real.
+
+Antes de haver produção ou certame publicado, mudanças de forma que pertencem à mesma janela
+e **só fazem sentido publicadas juntas** formam um trem coordenado. As entradas anteriores
+regeneram a golden fixture sem avançar a versão; a última entrada faz o único avanço que
+fecha o trem. Isto não é exceção à D1: nenhuma forma intermediária é publicável, portanto
+nunca há dois envelopes distintos publicados sob a mesma `schema_version`.
+
+O trem que fechou a forma `0.0.6` é o caso exercido: `315e4ca0` (valores selecionáveis),
+`339c1f87` (conjuntos simples), `3dab71a6` (cláusulas de predicado) e `69e01405`
+(divulgação) regeneraram a golden fixture ainda em `0.0.5`; `b29741ee` fez o avanço único
+para `0.0.6` e regenerou a fixture final. A regra vale somente antes do primeiro certame
+publicado em qualquer ambiente, inclusive homologação. A partir dele, cada mudança de forma
+exige o seu próprio avanço.
+
+### E2.2 — Cai a fixture por versão; permanece a prova de fidelidade da forma corrente
+
+Cai a parte da D2 que manda manter uma golden fixture por `schema_version`. Enquanto vigora
+o codec único, mantém-se somente a golden fixture da versão corrente, como prova de
+fidelidade byte a byte; a fixture da versão anterior sai no mesmo commit que avança a versão.
+No fechamento `b29741ee`, as fixtures `0.0.5` foram renomeadas para `0.0.6` e a `0.0.4`,
+órfã, foi removida.
+
+Permanece a outra parte da D2: mudar a forma sem regenerar a golden fixture corrente é
+impossível, e o diff continua tornando a mudança visível. Quando o primeiro certame for
+publicado em qualquer ambiente, inclusive homologação, volta o regime de preservação por
+versão da ADR-0110; então cada versão publicada terá a sua golden fixture preservada.

--- a/docs/adrs/0110-retificacao-como-sessao-editorial.md
+++ b/docs/adrs/0110-retificacao-como-sessao-editorial.md
@@ -244,3 +244,40 @@ E o `IdempotencyFilter` — código **compartilhado** — precisa mudar (D6). N�
 - Transições `Encerrado` / `Cancelado` — não há comando na `main`, e esta ADR não os cria. Ela apenas impede que esses estados sejam **mutáveis por omissão** (D4).
 - Expiração de rascunho abandonado.
 - Diff visual "o que mudou" entre a versão vigente e o rascunho — frontend; aqui entregam-se os dados que o tornam possível.
+
+## Emenda 2 (2026-08-06) — codec único até o primeiro certame publicado
+
+Esta emenda corrige o regime de codecs da D1 sem reescrever o texto histórico. A regra de
+avanço de `schema_version` da D1 da ADR-0109 **não cai** com esta emenda; o que cai é a
+preservação de encoder e decoder para cada versão antes de haver envelope publicado a
+preservar.
+
+### E2.1 — Cai o registro de codecs por versão; permanece um único codec vivo
+
+Enquanto não houver produção nem certame publicado, há **um único codec vivo**, reescrito no
+lugar a cada mudança de forma. Não se criam codecs de versão ao lado. `EnvelopeCodecV11`,
+`EnvelopeCodecV12` e `EnvelopeCodecV13` são bibliotecas de leitores de bloco reutilizadas
+pelo codec único, não codecs registrados por `schema_version`.
+
+Por consequência, a versão anterior deixa de ser reconhecida quando a corrente avança: uma
+configuração congelada nessa versão não é reidratável, e a abertura de retificação sobre ela
+é recusada na porta. Sem certame publicado, essa perda não tem custo jurídico; contudo,
+ambientes compartilhados de desenvolvimento e homologação guardam dados que sobrevivem ao
+deploy. Eles precisam ser verificados e, se necessário, recriados antes do avanço.
+
+A regra de avanço continua a da ADR-0109: toda mudança de forma avança a versão corrente. O
+trem coordenado pré-publicação, definido na Emenda 2 da ADR-0109, não relaxa essa regra: as
+formas intermediárias não são publicáveis e o único avanço da última entrada fecha todas as
+mudanças da janela.
+
+### E2.2 — Retorno ao regime forense
+
+O primeiro certame publicado em **qualquer ambiente, inclusive homologação**, encerra este
+regime transitório. Não se espera a primeira versão de produção: publicar em homologação já
+cria um envelope que precisa ser preservado. A partir desse marco, volta a valer o regime
+forense que a D1 descrevia: cada `schema_version` publicada mantém encoder e decoder, os
+encoders não são aposentados e cada mudança de forma recebe avanço próprio.
+
+Assim, a prova de fidelidade de uma configuração congelada permanece possível durante toda a
+vida de cada versão publicada; versões anteriores à primeira publicação permanecem
+deliberadamente fora desse compromisso.

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/Canonicalization/EnvelopeCodec.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/Canonicalization/EnvelopeCodec.cs
@@ -16,8 +16,9 @@ using Unifesspa.UniPlus.Selecao.Domain.ValueObjects;
 /// e a evolui livremente: mudar a forma reescreve a fixture, não gera um encoder congelado ao
 /// lado. O
 /// versionamento forense — um codec por <c>schema_version</c>, encoders aposentados só quando
-/// deixam de ser correntes — volta a valer quando a primeira release de produção fixar a
-/// versão <c>1.0.0</c>.
+/// deixam de ser correntes — volta a valer no primeiro certame publicado em qualquer ambiente,
+/// inclusive homologação. Não se espera a primeira release de produção: publicar em homologação
+/// já cria um envelope que precisa ser preservado.
 /// </summary>
 /// <remarks>
 /// <c>Codificar</c> delega ao <see cref="SnapshotPublicacaoCanonicalizer"/>, a projeção viva —

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/Canonicalization/SnapshotPublicacaoCanonicalizer.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/Canonicalization/SnapshotPublicacaoCanonicalizer.cs
@@ -105,10 +105,11 @@ public sealed class SnapshotPublicacaoCanonicalizer : ISnapshotPublicacaoCanonic
     /// lugar sob a mesma versão corrente quando a forma muda — bump livre,
     /// sem migration, mas também sem obrigação de bump a cada mudança. O
     /// versionamento forense (um bump por chave nova ou por stub virando
-    /// conteúdo real, com encoder anterior aposentado) começa a valer só a
-    /// partir da primeira release de produção. Toda versão aqui declarada tem
-    /// de ter a sua golden fixture correspondente — um teste de política falha
-    /// o build se não tiver.
+    /// conteúdo real, com encoder anterior aposentado) começa a valer a
+    /// partir do primeiro certame publicado em qualquer ambiente, inclusive
+    /// homologação — não da primeira release de produção. Toda versão aqui
+    /// declarada tem de ter a sua golden fixture correspondente — um teste
+    /// de política falha o build se não tiver.
     /// </summary>
     /// <remarks>
     /// Story #575: <c>cascataRemanejamento</c> sai de stub para bloco real

--- a/tests/Unifesspa.UniPlus.Selecao.ArchTests/RegraDeNomeAbreviadoUnicaTests.cs
+++ b/tests/Unifesspa.UniPlus.Selecao.ArchTests/RegraDeNomeAbreviadoUnicaTests.cs
@@ -48,8 +48,8 @@ public sealed class RegraDeNomeAbreviadoUnicaTests
             "aquela versão congelou — a prova de fidelidade (round-trip) vai acusar divergência em " +
             "certames legítimos. A correção é reintroduzir o transporte explícito da regra " +
             "congelada (um campo em EntradaCanonicalizacao/EnvelopeReidratado, propagado por " +
-            "RestauradorDeConfiguracao) — ou, se a primeira release de produção já tiver saído, " +
-            "resolver pelo regime de codec por versão (um decoder por schema_version, cada um " +
-            "com a semântica da sua época).");
+            "RestauradorDeConfiguracao) — ou, se o primeiro certame publicado em qualquer " +
+            "ambiente, inclusive homologação, já tiver ocorrido, resolver pelo regime de codec " +
+            "por versão (um decoder por schema_version, cada um com a semântica da sua época).");
     }
 }

--- a/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/ProcessosSeletivos/EnvelopeCodecRoundTripTests.cs
+++ b/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/ProcessosSeletivos/EnvelopeCodecRoundTripTests.cs
@@ -23,8 +23,9 @@ using Xunit;
 /// de identidade (etapa.Id). Prova o codec CORRENTE — no regime pré-produção (<c>EnvelopeCodec</c>,
 /// codec único, forma reescrita no lugar a cada bump), um bump de <c>schema_version</c> troca o
 /// codec corrente sem preservar o anterior no registro; o versionamento forense por codec
-/// (um por <c>schema_version</c>, nenhum jamais aposentado) só passa a valer a partir da primeira
-/// release de produção.
+/// (um por <c>schema_version</c>, nenhum jamais aposentado) só passa a valer a partir do primeiro
+/// certame publicado em qualquer ambiente, inclusive homologação — não da primeira release de
+/// produção.
 /// </summary>
 /// <remarks>
 /// <para>


### PR DESCRIPTION
## Resumo

As ADRs aceitavam o regime de codecs preservados por `schema_version` e golden fixture por versão. As emendas registram o regime pré-publicação que o código exerce: um único codec vivo, reescrito no lugar, e somente a golden fixture da versão corrente.

A regra de avanço de versão permanece obrigatória. O trem coordenado só reúne mudanças de forma que não podem ser publicadas separadamente: a última entrada realiza o único avanço; as anteriores apenas regeneram a fixture. A emenda também registra a perda deliberada de reidratação da versão anterior, a verificação de dados persistentes em desenvolvimento e homologação, e o retorno ao regime forense no primeiro certame publicado em qualquer ambiente, inclusive homologação.

## Por que a distinção importa

Separar o que caiu do que continua valendo evita que o abandono do decoder por versão seja lido como permissão para deixar de avançar a `schema_version`. Preserva ainda o marco que transforma um envelope em evidência a manter: publicação de certame, não a primeira versão de produção.

Closes #1053
