### PR TITLE
test(selecao): deriva blocos da retificação em vez de listá-los

### DIFF
--- a/src/selecao/Unifesspa.UniPlus.Selecao.Application/Services/RestauradorDeConfiguracao.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Application/Services/RestauradorDeConfiguracao.cs
@@ -54,7 +54,7 @@ public sealed class RestauradorDeConfiguracao(IRegistroCodecsEnvelope registro) 
         //
         // A RetificacaoInfo é a ORIGINAL, recuperada do próprio bloco `retificacao`: ela não
         // vem do agregado (é parâmetro externo da canonicalização), e sem ela a versão N>1
-        // recanonicalizaria com 17 blocos em vez de 18.
+        // recanonicalizaria sem o bloco retificacao, que a acrescenta aos blocos da abertura.
         Result<SnapshotCanonico> recodificado = registro.Recodificar(
             versao.SchemaVersion,
             new EntradaCanonicalizacao(

--- a/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/ProcessosSeletivos/EnvelopeCodecRoundTripTests.cs
+++ b/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/ProcessosSeletivos/EnvelopeCodecRoundTripTests.cs
@@ -57,12 +57,12 @@ public sealed class EnvelopeCodecRoundTripTests
         AssertRoundTrip(processo, versao, congelado);
     }
 
-    [Fact(DisplayName = "A versão N>1 tem o 18º bloco: o round-trip usa a RetificacaoInfo ORIGINAL, recuperada do próprio envelope")]
+    [Fact(DisplayName = "A versão N>1 tem o bloco retificacao: o round-trip usa a RetificacaoInfo ORIGINAL, recuperada do próprio envelope")]
     public void RoundTrip_VersaoRetificada()
     {
-        // O round-trip de uma versão retificada NÃO é "os 17 blocos". Ela tem o 18º
-        // (`retificacao`), que não vem do agregado — é parâmetro externo da
-        // canonicalização. Recanonicalizar sem ele produziria um envelope de 17 blocos
+        // O round-trip de uma versão retificada não é o dos blocos da abertura sozinhos. Ela
+        // tem também o bloco `retificacao`, que não vem do agregado — é parâmetro externo da
+        // canonicalização. Recanonicalizar sem ele produziria um envelope sem esse bloco
         // e a comparação falharia por uma razão que nada tem a ver com a reidratação.
         ProcessoSeletivo processo = CorpusEnvelope.ProcessoRico();
         RetificacaoInfo retificacao = new(CorpusEnvelope.AtoAbertura, "Correção do quadro de vagas do curso de Direito");
@@ -76,7 +76,7 @@ public sealed class EnvelopeCodecRoundTripTests
 
         EnvelopeReidratado envelope = AssertRoundTrip(processo, v2, congelado);
 
-        envelope.Retificacao.Should().NotBeNull("a versão N>1 carrega o 18º bloco");
+        envelope.Retificacao.Should().NotBeNull("a versão N>1 carrega o bloco retificacao");
         envelope.Retificacao!.EditalRetificadoId.Should().Be(CorpusEnvelope.AtoAbertura);
         envelope.Retificacao.Motivo.Should().Be("Correção do quadro de vagas do curso de Direito");
     }

--- a/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/ProcessosSeletivos/PublicacaoSnapshotPersistenciaTests.cs
+++ b/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/ProcessosSeletivos/PublicacaoSnapshotPersistenciaTests.cs
@@ -193,18 +193,19 @@ public sealed class PublicacaoSnapshotPersistenciaTests : IClassFixture<Processo
             // interpretador e conjunto de modalidades ofertadas.
             "fatosColetados", "regrasDerivacao", "grafoDependencia", "versaoInterpretador", "modalidadesOfertadas",
         ];
-        blocosEsperados.Should().HaveCount(23, "pré-condição do próprio teste — o envelope tem 23 chaves (Story #928: fatos/regras/grafo)");
-
         JsonObject objeto = payload.AsObject();
         foreach (string bloco in blocosEsperados)
         {
             objeto.Should().ContainKey(bloco, $"o bloco canônico '{bloco}' deve estar presente no envelope");
         }
 
-        // A contagem é DERIVADA do envelope, não escrita à mão. Um bloco
-        // que sai de stub sem que este teste seja atualizado faz a contagem
-        // divergir — que é exatamente o sinal que se quer.
-        objeto.Should().HaveCount(23, "o envelope de abertura tem exatamente 23 chaves — nem mais, nem menos");
+        // Equivalência EXATA de conjunto entre as chaves do envelope e a lista literal acima —
+        // não só "os blocos esperados estão presentes" (o foreach acima, que por si só não
+        // reprovaria uma chave espúria), mas também "não sobra nenhuma outra". A lista literal
+        // FICA: este é o teste de contrato da abertura, e derivá-la do próprio objeto o
+        // tornaria tautológico — passaria com qualquer conjunto de chaves.
+        objeto.Select(static kvp => kvp.Key).Should().BeEquivalentTo(blocosEsperados,
+            "o envelope de abertura tem exatamente os blocos canônicos listados acima — nem mais, nem menos");
 
         string[] stubs = [.. objeto
             .Where(static kvp => kvp.Value is JsonObject bloco

--- a/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/ProcessosSeletivos/RetificacaoPersistenciaTests.cs
+++ b/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/ProcessosSeletivos/RetificacaoPersistenciaTests.cs
@@ -21,7 +21,7 @@ using Unifesspa.UniPlus.Selecao.Infrastructure.Persistence.Repositories;
 /// Cobertura de integração (Postgres real via Testcontainers) da retificação
 /// (RN08, ADR-0101/0103/0104): a retificação sucede a versão corrente com um ato que
 /// emenda o ato criador dela, e o novo snapshot acrescenta o bloco de retificação
-/// preservando os 17 anteriores; o snapshot da abertura permanece imutável.
+/// preservando integralmente os blocos da abertura; o snapshot da abertura permanece imutável.
 /// </summary>
 public sealed class RetificacaoPersistenciaTests : IClassFixture<ProcessoSeletivoDbFixture>
 {
@@ -173,7 +173,7 @@ public sealed class RetificacaoPersistenciaTests : IClassFixture<ProcessoSeletiv
             .GetValue<string>().Should().Be("Correção do prazo de inscrição");
     }
 
-    [Fact(DisplayName = "Snapshot de retificação carrega o bloco retificacao + os 17 blocos; o snapshot da abertura permanece imutável")]
+    [Fact(DisplayName = "Snapshot de retificação carrega os blocos da abertura mais o bloco retificacao; o snapshot da abertura permanece imutável")]
     public async Task Retificacao_SnapshotComBlocoRetificacao_AnteriorImutavel()
     {
         (_, VersaoConfiguracao versaoAbertura, VersaoConfiguracao versaoRetificacao) =
@@ -181,31 +181,29 @@ public sealed class RetificacaoPersistenciaTests : IClassFixture<ProcessoSeletiv
 
         await using SelecaoDbContext readContext = _fixture.CreateDbContext();
 
+        VersaoConfiguracao aberturaLida = await readContext.VersoesConfiguracao
+            .AsNoTracking().FirstAsync(v => v.Id == versaoAbertura.Id, CancellationToken.None);
+        JsonObject payloadAbertura = JsonNode.Parse(aberturaLida.ConfiguracaoCongelada)!.AsObject();
+
         VersaoConfiguracao retificacaoLida = await readContext.VersoesConfiguracao
             .AsNoTracking().FirstAsync(v => v.Id == versaoRetificacao.Id, CancellationToken.None);
         JsonObject payloadRetificacao = JsonNode.Parse(retificacaoLida.ConfiguracaoCongelada)!.AsObject();
 
-        // Os 17 blocos canônicos continuam presentes...
-        foreach (string bloco in new[]
-        {
-            "periodo", "etapas", "vagas", "distribuicao", "modalidades", "ofertas", "atendimento",
-            "bonusRegional", "criteriosDesempate", "classificacao", "hashesEdital", "documentosExigidos",
-            "formulario", "cascataRemanejamento", "divulgacao", "cronogramaFases", "identidadesUnidade",
-        })
-        {
-            payloadRetificacao.Should().ContainKey(bloco);
-        }
+        // Os blocos esperados na retificação são DERIVADOS do snapshot da abertura, não uma
+        // lista literal escrita à mão: são exatamente os blocos da abertura mais o bloco
+        // `retificacao` (ADR-0101). Assim, se a abertura ganhar um bloco novo e a retificação
+        // não o preservar — qualquer um deles, não só os que alguém lembrou de listar —, esta
+        // asserção falha sozinha, sem que ninguém precise atualizar um número.
+        IEnumerable<string> blocosEsperados = [.. payloadAbertura.Select(static kvp => kvp.Key), "retificacao"];
+        payloadRetificacao.Select(static kvp => kvp.Key).Should().BeEquivalentTo(blocosEsperados,
+            "a retificação preserva integralmente os blocos da abertura e acrescenta o bloco retificacao");
 
-        // ...e o 18º bloco de retificação foi acrescentado (ADR-0101).
-        payloadRetificacao.Should().ContainKey("retificacao");
         payloadRetificacao["retificacao"]!["motivo"]!.GetValue<string>().Should().Be("Correção do prazo de inscrição");
 
         // O snapshot da abertura permanece byte-a-byte idêntico (append-only).
-        VersaoConfiguracao aberturaLida = await readContext.VersoesConfiguracao
-            .AsNoTracking().FirstAsync(v => v.Id == versaoAbertura.Id, CancellationToken.None);
         aberturaLida.HashConfiguracao.Should().Be(versaoAbertura.HashConfiguracao);
         aberturaLida.ConfiguracaoCongeladaCanonica.Should().Equal(versaoAbertura.ConfiguracaoCongeladaCanonica);
-        JsonNode.Parse(aberturaLida.ConfiguracaoCongelada)!.AsObject().Should().NotContainKey("retificacao",
+        payloadAbertura.Should().NotContainKey("retificacao",
             "o snapshot da abertura nunca carrega o bloco de retificação");
     }
 


### PR DESCRIPTION
Um teste declarava cobrir "os 17 blocos" do envelope de retificação e deixava **seis chaves canônicas sem verificação nenhuma**.

## O que estava errado

O envelope tem **23 chaves na abertura** e **24 na retificação** — esta acrescenta o bloco `retificacao` preservando as 23 (ADR-0101).

`Retificacao_SnapshotComBlocoRetificacao_AnteriorImutavel` percorria uma lista literal de **17 nomes** e não conferia cardinalidade. Ficavam de fora `arvoreSatisfacao`, `fatosColetados`, `regrasDerivacao`, `grafoDependencia`, `versaoInterpretador` e `modalidadesOfertadas`: se a retificação deixasse de preservar qualquer uma delas, o teste continuaria verde. O `DisplayName` e o resumo da classe repetiam o número errado, de modo que quem lesse o teste concluiria que a cobertura era completa.

## Derivar onde o teste é consumidor; manter a lista onde ele é o contrato

A correção não é atualizar 17 para 23 — seria a mesma dívida com número novo.

**No teste da retificação, a lista passa a ser derivada:** as chaves esperadas são as do snapshot da **abertura**, lido no mesmo teste, mais `retificacao`. Se a abertura ganhar um bloco e a retificação não o preservar, este teste falha sozinho, sem depender de alguém lembrar de atualizar nada.

**No teste da abertura, a lista literal fica.** Ali ela *é* o contrato: derivá-la do próprio objeto tornaria o teste tautológico — passaria com qualquer conjunto de chaves. O que muda é a asserção, de `HaveCount(23)` para equivalência exata de conjunto, porque contar 23 aceita 23 chaves erradas.

Os textos que citavam o número em `EnvelopeCodecRoundTripTests` e `RestauradorDeConfiguracao` passam a descrever a **relação** — "a retificação acrescenta o bloco `retificacao` aos blocos da abertura" — em vez da contagem.

## Prova

Dois mutantes, ambos executados:

**A retificação omite `modalidadesOfertadas`** — uma das seis chaves antes descobertas. O teste falha:

```
Expected payloadRetificacao ... to be a collection with 24 item(s) ...
but {...} contains 1 item(s) less than {..., "modalidadesOfertadas", "retificacao"}
```

Antes desta mudança ele passaria, porque aquela chave não estava na lista.

**Chave espúria no payload da abertura** — `Snapshot_ContemBlocosCanonicos` falha na equivalência de conjunto:

```
Expected objeto ... to be a collection with 23 item(s) ... contains 1 item(s) more than {...}
```

Antes, com `HaveCount(23)` mais um `foreach` de presença, uma chave a mais somada a uma a menos passaria despercebida.

Ambos desfeitos por edição reversa.

## Verificação

- suíte completa: **4.601 testes, 26 assemblies, zero falhas** — os testes de integração rodaram de fato, com Docker disponível
- build: **0 avisos, 0 erros**
- `dotnet format --verify-no-changes`: limpo

## Fora do escopo, registrado na issue

Restam menções a "18º bloco" em `IRegistroCodecsEnvelope.cs`, `EnvelopeCodecV11.cs`, `CorpusEnvelope.cs` e `EnvelopeCodecRecusaTests.cs`. Ficaram de fora porque o escopo desta correção foi fechado nos quatro arquivos onde a contagem **produz cobertura falsa**; as demais são texto descritivo. Estão anotadas na issue para não se perderem.

Closes #1083
