### PR TITLE
chore(selecao): remove listas de blocos provisórios sem uso

### DIFF
--- a/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/Canonicalization/EnvelopeCodecV11.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/Canonicalization/EnvelopeCodecV11.cs
@@ -36,41 +36,6 @@ using Unifesspa.UniPlus.Selecao.Domain.ValueObjects;
 internal static class EnvelopeCodecV11
 {
     /// <summary>
-    /// Os 4 blocos sem dono (ADR-0109 D8). Um bloco <b>real</b> nunca emite
-    /// <c>nao_construido</c> na raiz; um stub que virou objeto rico é forma nova, e forma
-    /// nova é bump de versão. <c>documentosExigidos</c> saiu daqui na Story #853 — ele
-    /// próprio virou bloco real, com a sub-chave <c>exigencias</c> (#554) ainda stub
-    /// <b>dentro</b> dele (ver <see cref="LerDocumentosExigidos"/>).
-    /// </summary>
-    private static readonly string[] Stubs =
-    [
-        "formulario",
-        "cascataRemanejamento",
-        "divulgacao",
-        "identidadesUnidade",
-    ];
-
-    private static readonly string[] BlocosReais =
-    [
-        "periodo",
-        "etapas",
-        "distribuicao",
-        "modalidades",
-        "ofertas",
-        "atendimento",
-        "bonusRegional",
-        "criteriosDesempate",
-        "classificacao",
-        "hashesEdital",
-        // Story #851 — cronogramaFases deixa de ser stub.
-        "cronogramaFases",
-        // Story #853 — documentosExigidos deixa de ser stub (obrigatoriedades[] real).
-        "documentosExigidos",
-        // issue #848/ADR-0115 — vagas deixa de ser stub (quadro sempre materializado).
-        "vagas",
-    ];
-
-    /// <summary>
     /// Chave duplicada é <b>erro</b>, não “a última ganha”. Um envelope com
     /// <c>"fator"</c> duas vezes tem duas leituras possíveis, e a que o hash cobre é
     /// indistinguível da que o parser escolheria.

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/Canonicalization/EnvelopeCodecV12.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/Canonicalization/EnvelopeCodecV12.cs
@@ -48,31 +48,6 @@ using Unifesspa.UniPlus.Selecao.Domain.ValueObjects;
 /// </remarks>
 internal static class EnvelopeCodecV12
 {
-    private static readonly string[] Stubs =
-    [
-        "formulario",
-        "cascataRemanejamento",
-        "divulgacao",
-        "identidadesUnidade",
-    ];
-
-    private static readonly string[] BlocosReais =
-    [
-        "periodo",
-        "etapas",
-        "distribuicao",
-        "modalidades",
-        "ofertas",
-        "atendimento",
-        "bonusRegional",
-        "criteriosDesempate",
-        "classificacao",
-        "hashesEdital",
-        "cronogramaFases",
-        "documentosExigidos",
-        "vagas",
-    ];
-
     /// <summary>
     /// Não valida <c>exigidoNaFaseId</c> contra as fases decodificadas nesta mesma
     /// passagem. Desde o achado de revisão que acrescentou <c>id</c> ao bloco

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/Canonicalization/EnvelopeCodecV13.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/Canonicalization/EnvelopeCodecV13.cs
@@ -44,32 +44,6 @@ using Unifesspa.UniPlus.Selecao.Domain.ValueObjects;
 /// </remarks>
 internal static class EnvelopeCodecV13
 {
-    private static readonly string[] Stubs =
-    [
-        "formulario",
-        "cascataRemanejamento",
-        "divulgacao",
-        "identidadesUnidade",
-    ];
-
-    private static readonly string[] BlocosReais =
-    [
-        "periodo",
-        "etapas",
-        "distribuicao",
-        "modalidades",
-        "ofertas",
-        "atendimento",
-        "bonusRegional",
-        "criteriosDesempate",
-        "classificacao",
-        "hashesEdital",
-        "cronogramaFases",
-        "documentosExigidos",
-        "vagas",
-    ];
-
-
     /// <summary>
     /// Story #919: a única leitura de bloco que difere de <see cref="EnvelopeCodecV12"/>.
     /// <c>exigencias</c>/<c>obrigatoriedades</c>/<c>referenciaTemporalFatos</c> mantêm a


### PR DESCRIPTION
Três leitores de versão antiga do envelope declaravam listas de blocos que **nada consome**, descrevendo um regime que o código abandonou.

## O que sai

Seis campos privados sem nenhuma referência — `Stubs` e `BlocosReais` em `EnvelopeCodecV11`, `V12` e `V13` —, mais o resumo que os acompanhava e afirmava existirem "os 4 blocos sem dono".

Nenhum dos quatro é provisório há tempo: `divulgacao` foi promovido pela #563 e `formulario`, `cascataRemanejamento` e `identidadesUnidade` pelas Stories #559, #575 e #849. A lista sobreviveu à promoção de todos os seus itens.

O diff é **só deleção**: 86 linhas, zero adições.

## O que fica, e por que a distinção importa

**Os campos são mortos; os leitores não.**

`EnvelopeCodecV11`, `V12` e `V13` deixaram de ser codecs por versão e passaram a ser **bibliotecas de leitores** reaproveitadas pelo codec único (ADR-0110, Emenda 2). O codec corrente os chama diretamente — `EnvelopeCodec.cs:97,113-117` e adiante —, e o V13 reaproveita leitores do V12 e do V11. Removê-los quebraria a reidratação de configuração congelada, que é o caminho do descarte de retificação.

Depois da mudança: **24 métodos de leitura no V11, 8 no V12, 5 no V13**, todos preservados.

`EnvelopeCodec.BlocosReais` — o do codec corrente, não os dos leitores — também fica. Ele é usado em `EnvelopeCodec.cs:108-109` para validar a forma da raiz, inclusive admitindo a chave `retificacao` quando é o caso. Removê-lo por analogia com os homônimos mortos eliminaria uma validação que hoje recusa envelope malformado.

## Por que uma lista morta não é inofensiva

Uma lista de blocos provisórios que sobrevive ao desaparecimento dos blocos provisórios **afirma que ainda há stub a tratar**. Quem lê o leitor conclui que o envelope tem forma incompleta e que existe um regime de tratamento a respeitar — e nenhuma das duas coisas é verdade. O custo não é o espaço em disco; é a descrição errada.

## Verificação

```
$ grep -nE "\b(Stubs|BlocosReais)\b" .../EnvelopeCodecV1{1,2,3}.cs
(sem resultado)

$ grep -n "BlocosReais" .../EnvelopeCodec.cs
32:    private static readonly string[] BlocosReais =
108:            ? [.. BlocosReais, "retificacao"]
109:            : BlocosReais;
```

- suíte completa: **4.601 testes, 26 assemblies, zero falhas** — `EnvelopeCodecRoundTripTests` e `EnvelopeCodecRecusaTests` continuam exercitando os leitores preservados
- build: **0 avisos, 0 erros**
- `dotnet format --verify-no-changes`: limpo

A suíte passar antes e depois é o esperado: remover declaração morta não muda comportamento. O que ela prova aqui é que **nada além dos campos foi removido**.

Closes #1082
