### PR TITLE
refactor(revisao): remove referência à ferramenta de revisão do código-fonte

### DIFF
--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -75,7 +75,7 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Trivy — fs scan
-        # Pin imutável (Codex P1): trivy-action é third-party e teve incidente
+        # Pin imutável: trivy-action é third-party e teve incidente
         # de supply chain em março/2026 via retargeting de tag mutável. Para as
         # actions de orgs auditadas (actions/, docker/, github/) o projeto
         # mantém pin por major (consistência com codeql.yml e publish-images.yml).
@@ -153,7 +153,7 @@ jobs:
           cache-from: type=gha,scope=${{ matrix.module }}
 
       - name: Trivy — image scan
-        # Pin imutável (Codex P1): trivy-action é third-party e teve incidente
+        # Pin imutável: trivy-action é third-party e teve incidente
         # de supply chain em março/2026 via retargeting de tag mutável. Para as
         # actions de orgs auditadas (actions/, docker/, github/) o projeto
         # mantém pin por major (consistência com codeql.yml e publish-images.yml).

--- a/src/selecao/Unifesspa.UniPlus.Selecao.API/Errors/SelecaoDomainErrorRegistration.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.API/Errors/SelecaoDomainErrorRegistration.cs
@@ -417,7 +417,7 @@ internal sealed class SelecaoDomainErrorRegistration : IDomainErrorRegistration
         // guard acima: retirar PermiteComplementacao de uma fase referenciada por
         // exigência com consequência PENDENCIA_REENVIO.
         new("FaseCronograma.PendenciaReenvioExigeComplementacao", new DomainErrorMapping(StatusCodes.Status422UnprocessableEntity, "uniplus.selecao.fase_cronograma.pendencia_reenvio_exige_complementacao", "A fase não pode perder PermiteComplementacao — é referenciada por documento exigido com consequência PENDENCIA_REENVIO")),
-        // Achado Codex P2 (PR #900, 4ª rodada) — uma permutação cíclica de Ordem entre
+        // Uma permutação cíclica de Ordem entre
         // fases retidas não tem ordem de UPDATE que a resolva num único SaveChanges.
         new("FaseCronograma.PermutacaoDeOrdemNaoSuportada", new DomainErrorMapping(StatusCodes.Status422UnprocessableEntity, "uniplus.selecao.fase_cronograma.permutacao_de_ordem_nao_suportada", "A redefinição do cronograma troca a Ordem entre fases já existentes formando um ciclo fechado, que não pode ser persistido em uma única chamada")),
         // Gatilho DNF (Story #554, PR #896, issue #892) — CondicaoGatilho sobre PredicadoDnf,

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Application/Commands/ProcessosSeletivos/DefinirDistribuicaoVagasCommandHandler.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Application/Commands/ProcessosSeletivos/DefinirDistribuicaoVagasCommandHandler.cs
@@ -152,7 +152,7 @@ public static class DefinirDistribuicaoVagasCommandHandler
             return Result<ConfiguracaoDistribuicaoVagas>.Failure(regraAjusteResult.Error!);
         }
 
-        // Achado Codex (revisão do plano, ADR-0115 §2.1): o quadro traz um código que não
+        // ADR-0115 §2.1: o quadro traz um código que não
         // é modalidade selecionada é reconciliação de IDs crus — Application, não Domain.
         DomainError? erroQuadroOrfao = input.Quadro
             .Where(q => !input.ModalidadeIds.Contains(q.ModalidadeId))

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Application/Queries/ProcessosSeletivos/ObterProcessoSeletivoQueryHandler.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Application/Queries/ProcessosSeletivos/ObterProcessoSeletivoQueryHandler.cs
@@ -104,7 +104,7 @@ public static class ObterProcessoSeletivoQueryHandler
                 .Select(c => criar(c.Fato, c.Operador.ToCodigo(), c.Valor))])];
     }
 
-    // Achado Codex P2 (PR #896, issue #892): sem isto, um FIM_FASE/DATA_ESPECIFICA salvo
+    // issue #892: sem isto, um FIM_FASE/DATA_ESPECIFICA salvo
     // desaparecia do agregado GET, e o formulário de edição podia sobrescrevê-lo ou
     // removê-lo sem querer ao pré-preencher com um estado que não reflete o persistido.
     private static ReferenciaTemporalFatosDto? ProjectReferenciaTemporalFatos(ReferenciaTemporalFatos? referencia) =>

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Application/Validators/ProcessosSeletivos/DefinirBonusRegionalCommandValidator.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Application/Validators/ProcessosSeletivos/DefinirBonusRegionalCommandValidator.cs
@@ -34,7 +34,7 @@ public sealed class DefinirBonusRegionalCommandValidator : AbstractValidator<Def
 
         // Alinhado a ConfiguracaoBonusRegionalConfiguration (varchar(200)/(500))
         // — sem o limite aqui, um valor mais longo passa a validação e só
-        // falha em SaveChanges com erro de banco em vez de 422 (achado Codex).
+        // falha em SaveChanges com erro de banco em vez de 422.
         RuleFor(x => x.MunicipioConvenio)
             .MaximumLength(200)
             .WithMessage("Município do convênio deve ter no máximo 200 caracteres.");

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Domain/Entities/ConfiguracaoDistribuicaoVagas.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Domain/Entities/ConfiguracaoDistribuicaoVagas.cs
@@ -167,7 +167,7 @@ public sealed class ConfiguracaoDistribuicaoVagas : EntityBase
             // ComposicaoOrigemCodigo apontar para qualquer modalidade selecionada (para
             // servir também o ramo institucional/remanejamento), mas uma retirada
             // federal com origem diferente de AC descontaria de AC no cálculo sem
-            // nunca reduzir a modalidade que ela alega retirar — achado Codex.
+            // nunca reduzir a modalidade que ela alega retirar.
             ModalidadeSelecionada? retiradaForaDeAc = modalidades.FirstOrDefault(
                 m => m.ComposicaoVagas == ComposicaoVagasModalidade.RetiraDe
                     && !string.Equals(m.ComposicaoOrigemCodigo, ModalidadesFederaisLei12711.Ac, StringComparison.Ordinal));
@@ -390,7 +390,7 @@ public sealed class ConfiguracaoDistribuicaoVagas : EntityBase
     /// Valida que todo código de cruzamento (origem de RETIRA_DE, destino de
     /// DESTINO_UNICO, par/fallback de CRUZADO) referencia uma modalidade
     /// presente neste MESMO conjunto selecionado — não apenas uma modalidade
-    /// existente no cadastro global. Achado do Codex: sem esta checagem, uma
+    /// existente no cadastro global. Sem esta checagem, uma
     /// modalidade poderia apontar para um código nunca selecionado nesta
     /// oferta, deixando o motor de vagas/remanejamento futuro sem a
     /// modalidade referenciada.

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Domain/Entities/ProcessoSeletivo.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Domain/Entities/ProcessoSeletivo.cs
@@ -241,9 +241,9 @@ public sealed class ProcessoSeletivo : SoftDeletableEntity
         // INV-B6 sobrevive a DefinirEtapas: um critério de desempate
         // DESEMPATE-MAIOR-NOTA-ETAPA já configurado referencia uma etapa pelo
         // Id (dentro do Args); trocar as etapas sem revalidar deixaria o
-        // critério apontando para uma etapa removida — desempate inexecutável
-        // (achado Codex). Rejeita a troca de etapas em vez de silenciosamente
-        // invalidar o desempate; o admin reconfigura o desempate primeiro.
+        // critério apontando para uma etapa removida — desempate inexecutável.
+        // Rejeita a troca de etapas em vez de silenciosamente invalidar o
+        // desempate; o admin reconfigura o desempate primeiro.
         List<Guid> novosIdsEtapas = [.. etapas.Select(e => e.Id)];
         IEnumerable<(CriterioDesempate Criterio, ArgsDesempateMaiorNotaEtapa Args)> criteriosPorEtapa =
             _criteriosDesempate
@@ -303,7 +303,7 @@ public sealed class ProcessoSeletivo : SoftDeletableEntity
             return Result.Failure(bloqueio);
         }
 
-        // Story #554/issue #892 (achado Codex P2, PR #896, CA-03): um gatilho DNF com fato
+        // Story #554/issue #892 (CA-03): um gatilho DNF com fato
         // CONDICAO_ATENDIMENTO referencia um código de condição por VALOR (não por Guid —
         // diferente da fase), então a checagem é precisa: só recusa se o novo conjunto de
         // ofertas realmente deixaria de conter um código hoje referenciado por condição
@@ -368,7 +368,7 @@ public sealed class ProcessoSeletivo : SoftDeletableEntity
                 "O mesmo código de modalidade não pode ter ações divergentes de vaga quando indeferido em ofertas distintas do processo."));
         }
 
-        // Story #554/issue #892 (achado Codex P2, PR #896, CA-03): mesmo raciocínio do
+        // Story #554/issue #892 (CA-03): mesmo raciocínio do
         // guard de CONDICAO_ATENDIMENTO em DefinirOfertaAtendimento — MODALIDADE referencia
         // por código, então a checagem é precisa (só recusa se um código hoje referenciado
         // por condição viva deixaria de existir na nova distribuição).
@@ -634,8 +634,8 @@ public sealed class ProcessoSeletivo : SoftDeletableEntity
                 "A mesma fase canônica não pode aparecer duas vezes no cronograma."));
         }
 
-        // Story #554/issue #893 (PR #900, CA-04): reconciliação por FaseCanonicaOrigemId —
-        // achado Codex P2 (PR #900, 4ª rodada). FaseCanonicaOrigemId é a identidade ESTÁVEL
+        // Story #554/issue #893 (CA-04): reconciliação por FaseCanonicaOrigemId.
+        // FaseCanonicaOrigemId é a identidade ESTÁVEL
         // de uma fase no cronograma (índice único ux_fases_cronograma_processo_fase_canonica);
         // Ordem é só um ATRIBUTO mutável dela (uma fase pode ser reordenada sem deixar de
         // ser "a mesma fase"). Casar por Ordem (como as rodadas anteriores fizeram) confundia
@@ -681,7 +681,7 @@ public sealed class ProcessoSeletivo : SoftDeletableEntity
                     $"A fase '{antiga.Codigo}' (ordem {antiga.Ordem}) não pode perder PermiteComplementacao — é referenciada por uma exigência (folha ou grupo) com consequência PENDENCIA_REENVIO."));
             }
 
-            // Achado Codex P2 (PR #900): fase SOBREVIVENTE (mesma Ordem) cujo extremo
+            // Uma fase SOBREVIVENTE (mesma Ordem) cujo extremo
             // âncora (Início/Fim) deixa de existir — a checagem eager de
             // DefinirDocumentosExigidos só prova a coerência no INSTANTE da escrita da
             // exigência; sem este guard, uma redefinição de cronograma POSTERIOR poderia
@@ -703,7 +703,7 @@ public sealed class ProcessoSeletivo : SoftDeletableEntity
             }
         }
 
-        // Achado Codex P2 (PR #900, 5ª rodada): mesma lacuna do guard eager de
+        // Mesma lacuna do guard eager de
         // DefinirDocumentosExigidos — FIM_INSCRICAO não usa ReferenciaFaseId (a âncora é
         // implícita: a fase com ColetaInscricao), então os guards por fase acima (que só
         // olham ReferenciaFaseId) nunca pegam uma redefinição que deixa de ter QUALQUER
@@ -718,7 +718,7 @@ public sealed class ProcessoSeletivo : SoftDeletableEntity
                 "A redefinição do cronograma deixaria de ter uma fase que coleta inscrição com Fim definido, mas há documento exigido configurado com idade máxima de emissão ancorada em FIM_INSCRICAO."));
         }
 
-        // Achado Codex P2 (PR #900, 4ª rodada): mesmo casando por identidade estável, uma
+        // Mesmo casando por identidade estável, uma
         // PERMUTAÇÃO CÍCLICA de Ordem entre fases retidas (ex.: A@1,B@2 -> A@2,B@1, ou um
         // ciclo de 3+) ainda pede que linhas TROQUEM valores cobertos pelo índice único
         // ux_fases_cronograma_processo_ordem entre si — nenhuma ordem de UPDATE resolve um
@@ -826,7 +826,7 @@ public sealed class ProcessoSeletivo : SoftDeletableEntity
             }
         }
 
-        // Reconciliação por FaseCanonicaOrigemId (achado Codex P2, PR #900, 4ª rodada) — a
+        // Reconciliação por FaseCanonicaOrigemId — a
         // mesma chave de identidade do guard acima. Reusa a instância TRACKED existente
         // (retargetando-a via AtualizarSnapshot, preservando o Id) sempre que a fase
         // canônica persiste no cronograma, independente de Ordem: evita tanto FK Restrict
@@ -944,7 +944,7 @@ public sealed class ProcessoSeletivo : SoftDeletableEntity
             }
             else if (item.IdadeMaximaEmissao is { ReferenciaTipo: ReferenciaTipoIdadeEmissao.FimInscricao })
             {
-                // Achado Codex P2 (PR #900, 5ª rodada): FIM_INSCRICAO não usa
+                // FIM_INSCRICAO não usa
                 // ReferenciaFaseId (a âncora é implícita — a fase com ColetaInscricao do
                 // PRÓPRIO cronograma, não uma fase escolhida pelo chamador), então o
                 // branch acima nunca a valida. Sem esta checagem, um PUT aceitava a regra
@@ -952,7 +952,7 @@ public sealed class ProcessoSeletivo : SoftDeletableEntity
                 // externa) ou com a fase de coleta sem Fim definido, deixando-a
                 // irresolvível depois — mesmo sem gate de publicação para idade de
                 // emissão (issue #893 §1: é aviso, não bloqueio de presença).
-                // Achado Codex P2 (PR #900, 6ª rodada): nada no domínio impede MAIS de uma
+                // Nada no domínio impede MAIS de uma
                 // fase com ColetaInscricao — FirstOrDefault pegava a primeira, mesmo que
                 // outra (com Fim definido) resolvesse a regra; um processo com duas fases
                 // de coleta, a primeira sem Fim e a segunda com Fim, era um 422 falso. A
@@ -2033,7 +2033,7 @@ public sealed class ProcessoSeletivo : SoftDeletableEntity
     }
 
     /// <summary>
-    /// CA-03 (Story #554, issue #892 — achado Codex P2, PR #896): um gatilho DNF sobre um
+    /// CA-03 (Story #554, issue #892): um gatilho DNF sobre um
     /// fato categórico dinâmico (<c>MODALIDADE</c>, <c>CONDICAO_ATENDIMENTO</c>) referencia
     /// um valor por CÓDIGO — nunca por Guid, diferente de <c>FaseCronograma</c>. Isso
     /// permite checagem precisa (não o guard coarse de <c>FaseCronograma.ReferenciadaPorExigenciaViva</c>):

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Domain/ValueObjects/IdadeMaximaEmissao.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Domain/ValueObjects/IdadeMaximaEmissao.cs
@@ -87,7 +87,7 @@ public sealed record IdadeMaximaEmissao
                 "O valor da idade máxima de emissão deve ser maior que zero."));
         }
 
-        // Achado Codex P2 (PR #900, 3ª rodada): este factory é a fronteira do domínio — o
+        // Este factory é a fronteira do domínio — o
         // sentinel Nenhuma=0 (CA1008) não é um valor de negócio válido aqui, só existe para
         // permitir enum não-nulável em outros contextos. Sem esta checagem, um chamador que
         // passasse Nenhuma junto de um Valor positivo produziria um VO "completo" sem

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/Persistence/Configurations/ConfiguracaoDistribuicaoVagasConfiguration.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/Persistence/Configurations/ConfiguracaoDistribuicaoVagasConfiguration.cs
@@ -25,7 +25,7 @@ internal sealed class ConfiguracaoDistribuicaoVagasConfiguration : IEntityTypeCo
     // Alinhado ao ReferenciaReservaDemograficaConfiguration (Configuracao) —
     // o snapshot-copy (ADR-0061) precisa caber qualquer valor aceito na
     // origem, senão um Censo válido lá estoura em SaveChanges aqui em vez de
-    // persistir (achado Codex).
+    // persistir.
     private const int CensoMaxLength = 20;
     private const int BaseLegalMaxLength = 500;
 

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/Persistence/Configurations/CriterioDesempateConfiguration.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/Persistence/Configurations/CriterioDesempateConfiguration.cs
@@ -67,7 +67,7 @@ internal sealed class CriterioDesempateConfiguration : IEntityTypeConfiguration<
         // em ProcessoSeletivo.DefinirCriteriosDesempate é check-then-act
         // não-atômico — duas escritas concorrentes carregando o mesmo agregado
         // tracked poderiam ambas passar a checagem em memória e inserir a
-        // mesma ordem (achado Codex). A constraint do banco é a defesa
+        // mesma ordem. A constraint do banco é a defesa
         // realmente atômica.
         builder.HasIndex(c => new { c.ProcessoSeletivoId, c.Ordem })
             .IsUnique()

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/Persistence/Configurations/ObrigatoriedadeLegalConfiguration.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/Persistence/Configurations/ObrigatoriedadeLegalConfiguration.cs
@@ -106,8 +106,8 @@ internal sealed class ObrigatoriedadeLegalConfiguration
             .HasFilter("is_deleted = false")
             .HasDatabaseName("ux_obrigatoriedades_legais_hash_ativos");
 
-        // UNIQUE parcial sobre RegraCodigo entre regras ativas (Codex P1 de
-        // #461). O ExisteRegraCodigoAtivoAsync no handler é check-then-act
+        // UNIQUE parcial sobre RegraCodigo entre regras ativas (Story #461). O
+        // ExisteRegraCodigoAtivoAsync no handler é check-then-act
         // não-atômico — duas escritas concorrentes com o mesmo RegraCodigo
         // poderiam ambas passar a checagem e commitar, criando o cenário
         // ambíguo de "duas regras vigentes com mesmo código simbólico"

--- a/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Messaging/SchemaRegistry/OAuthBearerAuthProviderDisposeHostedService.cs
+++ b/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Messaging/SchemaRegistry/OAuthBearerAuthProviderDisposeHostedService.cs
@@ -13,7 +13,7 @@ using Microsoft.Extensions.Hosting;
 /// </summary>
 /// <remarks>
 /// <para>
-/// Por que esta classe existe (#360, eco do Codex P2 no PR #361):
+/// Por que esta classe existe (#360):
 /// <see cref="Microsoft.Extensions.DependencyInjection.ServiceCollectionServiceExtensions.AddSingleton{TService}(Microsoft.Extensions.DependencyInjection.IServiceCollection, TService)"/>
 /// com instância pré-criada (criada fora do container) <b>não transfere ownership</b>
 /// ao IServiceProvider — o container só dispõe o que ele próprio instancia (via tipo

--- a/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Messaging/SchemaRegistry/SchemaRegistryServiceCollectionExtensions.cs
+++ b/src/shared/Unifesspa.UniPlus.Infrastructure.Core/Messaging/SchemaRegistry/SchemaRegistryServiceCollectionExtensions.cs
@@ -205,7 +205,7 @@ public static class SchemaRegistryServiceCollectionExtensions
             // ownsHttpClient: true. O provider, por sua vez, é registrado no DI
             // abaixo para que o IHost dispõe via lifecycle de singleton IDisposable
             // — necessário porque CachedSchemaRegistryClient.Dispose não dispõe
-            // custom auth providers (Codex P2 na review do PR #359, issue #360).
+            // custom auth providers (issue #360).
             HttpClient httpClient = new();
             // TimeProvider.System explícito: este é um composition root genuíno
             // (callback do Wolverine que roda antes de builder.Build(), sem

--- a/tests/Unifesspa.UniPlus.Configuracao.Domain.UnitTests/Entities/TermoConsentimentoTests.cs
+++ b/tests/Unifesspa.UniPlus.Configuracao.Domain.UnitTests/Entities/TermoConsentimentoTests.cs
@@ -216,7 +216,7 @@ public sealed class TermoConsentimentoTests
     [Fact(DisplayName = "Promover duas vezes sem revisar de novo recusa a segunda promoção")]
     public void Promover_DuasVezesSemRevisarDeNovo_RecusaSegunda()
     {
-        // Codex #1019 P2: sem consumir a revisão, um retry acidental da promoção
+        // Sem consumir a revisão, um retry acidental da promoção
         // (outra Idempotency-Key, duplo clique) anexaria uma segunda versão
         // idêntica ao histórico forense a partir do MESMO conteúdo já revisado.
         TermoConsentimento termo = CriarRevisavel();
@@ -247,7 +247,7 @@ public sealed class TermoConsentimentoTests
     [Fact(DisplayName = "Hash distingue splits diferentes que concatenariam para o mesmo texto")]
     public void Promover_SplitDiferenteMesmaConcatenacao_HashDiferente()
     {
-        // Codex #1019 P2: sem prefixo de tamanho, ("AB","C") e ("A","BC") produziriam
+        // Sem prefixo de tamanho, ("AB","C") e ("A","BC") produziriam
         // o mesmo payload concatenado — e por isso o mesmo hash — mesmo sendo
         // conteúdos legalmente distintos.
         TermoConsentimento termoA = CriarRevisavel(texto: "AB", baseLegal: "C");

--- a/tests/Unifesspa.UniPlus.Configuracao.Domain.UnitTests/Entities/TermoConsentimentoVersaoTests.cs
+++ b/tests/Unifesspa.UniPlus.Configuracao.Domain.UnitTests/Entities/TermoConsentimentoVersaoTests.cs
@@ -12,7 +12,7 @@ public sealed class TermoConsentimentoVersaoTests
     [Fact(DisplayName = "Promover deriva o hash do próprio conteúdo — a factory não aceita hash de fora")]
     public void Promover_DerivaHashDoConteudo_NaoAceitaHashExterno()
     {
-        // Codex #1019 P2 (rodada 5): tornar a factory pública (exigência do
+        // Tornar a factory pública (exigência do
         // fitness test de entidades forenses, ADR-0063) abriria brecha para um
         // chamador gravar um hash divergente do conteúdo se a factory ainda
         // aceitasse `hash` por parâmetro. A assinatura atual não tem esse

--- a/tests/Unifesspa.UniPlus.Configuracao.IntegrationTests/CalendariosDiasUteis/CalendarioDiasUteisPersistenceTests.cs
+++ b/tests/Unifesspa.UniPlus.Configuracao.IntegrationTests/CalendariosDiasUteis/CalendarioDiasUteisPersistenceTests.cs
@@ -131,7 +131,7 @@ public sealed class CalendarioDiasUteisPersistenceTests
         // comita é o `using` da transação, não este método. A exclusion constraint
         // DEFERRED não é checada aqui: exatamente o cenário que fazia o handler
         // devolver 500 em vez de 409 (o commit real só rodaria no outbox do
-        // Wolverine, fora do try/catch do handler — achado de revisão do Codex).
+        // Wolverine, fora do try/catch do handler).
         await ctx2.SaveChangesAsync();
 
         Func<Task> act = async () => await ctx2.ForcarChecagemImediataDeConstraintsAsync();

--- a/tests/Unifesspa.UniPlus.Configuracao.IntegrationTests/Infrastructure/ConcorrenciaTestHelpers.cs
+++ b/tests/Unifesspa.UniPlus.Configuracao.IntegrationTests/Infrastructure/ConcorrenciaTestHelpers.cs
@@ -86,7 +86,7 @@ internal static class ConcorrenciaTestHelpers
             // transação explícita, então o PID capturado antes do loop podia
             // já ter voltado ao pool do Npgsql e sido reaproveitado pelo
             // PRÓPRIO handler sob teste, excluindo exatamente o backend que
-            // este método deveria encontrar (achado do Codex no PR #1036).
+            // este método deveria encontrar.
             int blockedBackends = await pollDb.Database
                 .SqlQuery<int>(
                     $"""

--- a/tests/Unifesspa.UniPlus.Configuracao.IntegrationTests/Infrastructure/ConcurrencyTestHelpersTests.cs
+++ b/tests/Unifesspa.UniPlus.Configuracao.IntegrationTests/Infrastructure/ConcurrencyTestHelpersTests.cs
@@ -22,9 +22,9 @@ using IMessageBus = Wolverine.IMessageBus;
 /// Prova de correção da issue #1031: <see cref="ConcorrenciaTestHelpers.WaitForBlockedBackendAsync"/>
 /// identifica o backend bloqueado correlacionando via <c>pg_blocking_pids</c> —
 /// imune tanto a texto de query coincidente quanto a qualquer OUTRO backend
-/// bloqueado por um lock não relacionado ao que o chamador está segurando (o
-/// achado P2 do Codex sobre a primeira versão deste teste, que só excluía PIDs
-/// conhecidos sem confirmar QUEM realmente bloqueava o candidato).
+/// bloqueado por um lock não relacionado ao que o chamador está segurando. A
+/// primeira versão deste teste só excluía PIDs conhecidos, sem confirmar QUEM
+/// realmente bloqueava o candidato.
 /// </summary>
 [Collection(ConfiguracaoEndpointCollection.Name)]
 [Trait("Category", "Integration")]
@@ -87,7 +87,7 @@ public sealed class ConcurrencyTestHelpersTests
         // decoyBlockedTask continua bloqueado quando o `await using` de
         // txDecoyBlocked/scopeDecoyBlocked começar a descartar a conexão —
         // Npgsql não aceita descartar uma conexão com um comando ainda em
-        // voo. Dois flags distintos (achado do Codex no PR #1036, 4ª rodada):
+        // voo. Dois flags distintos:
         // "o holder commitou" (não pode mais ser revertido por rollback) é
         // diferente de "o decoy foi de fato aguardado e descartado" — commitar
         // txDecoyHolder libera o lock do LADO DO SERVIDOR, mas não garante que

--- a/tests/Unifesspa.UniPlus.Configuracao.IntegrationTests/TermosConsentimento/TermoConsentimentoPersistenceTests.cs
+++ b/tests/Unifesspa.UniPlus.Configuracao.IntegrationTests/TermosConsentimento/TermoConsentimentoPersistenceTests.cs
@@ -113,7 +113,7 @@ public sealed class TermoConsentimentoPersistenceTests
     [Fact(DisplayName = "Promover concorrente com edição que reverte a revisão falha por concorrência (xmin)")]
     public async Task Promover_ConcorrenteComEdicaoQueReverteRevisao_FalhaPorConcorrencia()
     {
-        // Reproduz o achado do Codex (PR #1019, P1): request A lê o termo revisado
+        // Reproduz uma corrida de leitura-escrita: request A lê o termo revisado
         // (fica com uma cópia rastreada nesse estado); antes de A promover, request B
         // carrega o MESMO termo, edita o rascunho (o que reverte Revisado para false)
         // e comita. Sem o xmin amarrado a um write real no commit de A, a promoção
@@ -150,8 +150,8 @@ public sealed class TermoConsentimentoPersistenceTests
     [Fact(DisplayName = "Após o conflito capturado, descartar o rastreamento evita a segunda exceção do SaveChanges do outbox")]
     public async Task ConflitoDeConcorrencia_AposDescartarRastreamento_SegundoSaveChangesNaoLancaDeNovo()
     {
-        // Reproduz o achado do Codex (PR #1019, P2): o outbox do Wolverine
-        // (AutoApplyTransactions, ADR-0004) chama SaveChangesAsync no MESMO
+        // Reproduz a interação com o outbox do Wolverine
+        // (AutoApplyTransactions, ADR-0004), que chama SaveChangesAsync no MESMO
         // DbContext DEPOIS que o handler retorna. Se o handler capturar a
         // DbUpdateConcurrencyException e devolver a falha sem descartar o
         // rastreamento das entidades Added/Modified da tentativa fracassada, essa

--- a/tests/Unifesspa.UniPlus.Infrastructure.Core.UnitTests/Messaging/Middleware/CorrelationIdEnvelopeMiddlewareTests.cs
+++ b/tests/Unifesspa.UniPlus.Infrastructure.Core.UnitTests/Messaging/Middleware/CorrelationIdEnvelopeMiddlewareTests.cs
@@ -183,10 +183,10 @@ public sealed class CorrelationIdEnvelopeMiddlewareTests : IDisposable
     [InlineData("char-com-acentuação")]
     [InlineData("control\r\nchar")]
     // NUL byte literal embed em InlineData faria git renderizar o arquivo como binário
-    // e analisadores text-based quebrariam (Codex review do PR #411). O caso de NUL byte
+    // e analisadores text-based quebrariam. O caso de NUL byte
     // específico é coberto pela classe de equivalência 'control char' via
     // [InlineData("control\\r\\nchar")] acima — re-introduzir NUL literal aqui só
-    // recriaria o bug que o Codex apontou.
+    // recriaria esse problema de tooling.
     [InlineData("muito-longo-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")]
     public void Before_DadoHeaderInvalido_DeveRejeitarEGerarNovoGuid(string valorInvalido)
     {

--- a/tests/Unifesspa.UniPlus.Selecao.Application.UnitTests/Commands/DefinirBonusRegionalCommandHandlerTests.cs
+++ b/tests/Unifesspa.UniPlus.Selecao.Application.UnitTests/Commands/DefinirBonusRegionalCommandHandlerTests.cs
@@ -227,7 +227,7 @@ public sealed class DefinirBonusRegionalCommandHandlerTests
     }
 
     [Fact(DisplayName =
-        "Handle com processo já publicado propaga MutacaoPosPublicacaoBloqueada e NÃO persiste (CA-04, achado Codex PR #791)")]
+        "Handle com processo já publicado propaga MutacaoPosPublicacaoBloqueada e NÃO persiste (CA-04)")]
     public async Task Handle_ProcessoPublicado_PropagaBloqueioENaoPersiste()
     {
         ProcessoSeletivo processo = NovoProcessoPublicado();

--- a/tests/Unifesspa.UniPlus.Selecao.Application.UnitTests/Commands/PublicarProcessoSeletivoGateTests.cs
+++ b/tests/Unifesspa.UniPlus.Selecao.Application.UnitTests/Commands/PublicarProcessoSeletivoGateTests.cs
@@ -169,7 +169,7 @@ public sealed class PublicarProcessoSeletivoGateTests
         return processo;
     }
 
-    [Fact(DisplayName = "Publicar_ExigenciaComGatilhoPorFaixaEtariaSemReferenciaTemporal_NaoCanonicalizaAntesDoGuard — achado Codex (PR #903): o gate B-03 também precede a canonicalização (ADR-0109 D5)")]
+    [Fact(DisplayName = "Publicar_ExigenciaComGatilhoPorFaixaEtariaSemReferenciaTemporal_NaoCanonicalizaAntesDoGuard — o gate B-03 também precede a canonicalização (ADR-0109 D5)")]
     public async Task Publicar_ExigenciaComGatilhoPorFaixaEtariaSemReferenciaTemporal_NaoCanonicalizaAntesDoGuard()
     {
         ProcessoSeletivo processo = NovoProcessoConformeComGatilhoPorFaixaEtariaSemReferencia(out _);

--- a/tests/Unifesspa.UniPlus.Selecao.Application.UnitTests/Queries/ObterProcessoSeletivoQueryHandlerDocumentosExigidosTests.cs
+++ b/tests/Unifesspa.UniPlus.Selecao.Application.UnitTests/Queries/ObterProcessoSeletivoQueryHandlerDocumentosExigidosTests.cs
@@ -55,7 +55,7 @@ public sealed class ObterProcessoSeletivoQueryHandlerDocumentosExigidosTests
         projetado.TipoDocumentoOrigemId.Should().Be(tipoDocumentoOrigemId);
     }
 
-    [Fact(DisplayName = "Achado Codex P2 (PR #896, issue #892): projeta Condicoes do gatilho DNF — round-trip GET→PUT sem perda")]
+    [Fact(DisplayName = "Projeta Condicoes do gatilho DNF (issue #892) — round-trip GET→PUT sem perda")]
     public async Task Handle_CondicaoGatilho_EmiteTokenDeWireERoundTripDoValor()
     {
         ProcessoSeletivo processo = ProcessoSeletivo.Criar("PS Query", TipoProcesso.SiSU, OrigemCandidatos.ImportacaoExterna, Guid.NewGuid(), Unifesspa.UniPlus.Selecao.Domain.ValueObjects.UnidadeAdministradoraSnapshot.Criar("CEPS", "ceps", "Centro de Processos Seletivos", "ADMINISTRATIVA").Value!);
@@ -91,7 +91,7 @@ public sealed class ObterProcessoSeletivoQueryHandlerDocumentosExigidosTests
             .Should().BeEquivalentTo(["LB_PPI", "AC"]);
     }
 
-    [Fact(DisplayName = "Achado Codex P2 (PR #896, issue #892, 3ª rodada): projeta ReferenciaTemporalFatos no agregado GET — round-trip GET→PUT")]
+    [Fact(DisplayName = "Projeta ReferenciaTemporalFatos no agregado GET (issue #892) — round-trip GET→PUT")]
     public async Task Handle_ReferenciaTemporalFatos_EmiteTokenDeWire()
     {
         ProcessoSeletivo processo = ProcessoSeletivo.Criar("PS Query", TipoProcesso.SiSU, OrigemCandidatos.ImportacaoExterna, Guid.NewGuid(), Unifesspa.UniPlus.Selecao.Domain.ValueObjects.UnidadeAdministradoraSnapshot.Criar("CEPS", "ceps", "Centro de Processos Seletivos", "ADMINISTRATIVA").Value!);

--- a/tests/Unifesspa.UniPlus.Selecao.Application.UnitTests/Validators/DefinirDistribuicaoVagasCommandValidatorTests.cs
+++ b/tests/Unifesspa.UniPlus.Selecao.Application.UnitTests/Validators/DefinirDistribuicaoVagasCommandValidatorTests.cs
@@ -82,7 +82,7 @@ public sealed class DefinirDistribuicaoVagasCommandValidatorTests
         resultado.IsValid.Should().BeFalse();
     }
 
-    [Fact(DisplayName = "Quadro nulo gera erro de validação, sem lançar exceção (achado Codex)")]
+    [Fact(DisplayName = "Quadro nulo gera erro de validação, sem lançar exceção")]
     public void Validar_QuadroNulo_GeraErroSemLancarExcecao()
     {
         ConfiguracaoDistribuicaoVagasInput item = ItemValido() with { Quadro = null! };
@@ -93,7 +93,7 @@ public sealed class DefinirDistribuicaoVagasCommandValidatorTests
         resultado.IsValid.Should().BeFalse();
     }
 
-    [Fact(DisplayName = "Item nulo dentro do quadro gera erro de validação, sem lançar exceção (achado Codex)")]
+    [Fact(DisplayName = "Item nulo dentro do quadro gera erro de validação, sem lançar exceção")]
     public void Validar_ItemNuloDentroDoQuadro_GeraErroSemLancarExcecao()
     {
         ConfiguracaoDistribuicaoVagasInput item = ItemValido() with { Quadro = [null!] };

--- a/tests/Unifesspa.UniPlus.Selecao.Application.UnitTests/Validators/DefinirDocumentosExigidosCommandValidatorTests.cs
+++ b/tests/Unifesspa.UniPlus.Selecao.Application.UnitTests/Validators/DefinirDocumentosExigidosCommandValidatorTests.cs
@@ -91,7 +91,7 @@ public sealed class DefinirDocumentosExigidosCommandValidatorTests
     public void Aceita_TodasCombinacoesValidas(string abrangencia, string status) =>
         Validar(ItemCom(new BaseLegalInput("Referência", abrangencia, status, "Observação"))).IsValid.Should().BeTrue();
 
-    [Fact(DisplayName = "Achado Codex P2 (PR #898): referência acima de 500 caracteres é rejeitada — o mesmo teto de DocumentoExigidoBaseLegalConfiguration")]
+    [Fact(DisplayName = "Referência acima de 500 caracteres é rejeitada — o mesmo teto de DocumentoExigidoBaseLegalConfiguration")]
     public void Rejeita_ReferenciaAcimaDoTetoDePersistencia()
     {
         string referenciaLonga = new('a', 501);
@@ -106,7 +106,7 @@ public sealed class DefinirDocumentosExigidosCommandValidatorTests
     public void Aceita_ReferenciaNoTetoDePersistencia() =>
         Validar(ItemCom(new BaseLegalInput(new string('a', 500), "FEDERAL", "RESOLVIDO", null))).IsValid.Should().BeTrue();
 
-    [Fact(DisplayName = "Achado Codex P2 (PR #898): observação acima de 1000 caracteres é rejeitada")]
+    [Fact(DisplayName = "Observação acima de 1000 caracteres é rejeitada")]
     public void Rejeita_ObservacaoAcimaDoTetoDePersistencia()
     {
         string observacaoLonga = new('a', 1001);
@@ -117,7 +117,7 @@ public sealed class DefinirDocumentosExigidosCommandValidatorTests
         resultado.Errors.Should().Contain(e => e.ErrorMessage.Contains("1000 caracteres", StringComparison.Ordinal));
     }
 
-    [Fact(DisplayName = "Achado Codex P2 (PR #898, 2ª rodada): item de base legal nulo na lista é rejeitado")]
+    [Fact(DisplayName = "Item de base legal nulo na lista é rejeitado")]
     public void Rejeita_ItemDeBaseLegalNulo()
     {
         ItemDocumentoExigidoInput item = new(

--- a/tests/Unifesspa.UniPlus.Selecao.Application.UnitTests/Validators/DefinirReferenciaTemporalFatosCommandValidatorTests.cs
+++ b/tests/Unifesspa.UniPlus.Selecao.Application.UnitTests/Validators/DefinirReferenciaTemporalFatosCommandValidatorTests.cs
@@ -10,7 +10,7 @@ using Unifesspa.UniPlus.Selecao.Domain.ValueObjects;
 
 /// <summary>
 /// Cobertura de <see cref="DefinirReferenciaTemporalFatosCommandValidator"/> (Story #554,
-/// issue #892, PR #896) — inclui a regressão do achado Codex P2 (PR #896): <c>Tipo</c> nulo
+/// issue #892) — inclui a regra de que <c>Tipo</c> nulo
 /// (remoção) não pode carregar <c>Data</c>/<c>FaseId</c> soltos.
 /// </summary>
 public sealed class DefinirReferenciaTemporalFatosCommandValidatorTests
@@ -31,7 +31,7 @@ public sealed class DefinirReferenciaTemporalFatosCommandValidatorTests
     public void Rejeita_TipoDesconhecido() =>
         Validar("TIPO_INEXISTENTE", null, null).IsValid.Should().BeFalse();
 
-    [Fact(DisplayName = "Achado Codex P2 (PR #896): Tipo nulo com Data solta é recusado — não pode remover a referência silenciosamente")]
+    [Fact(DisplayName = "Tipo nulo com Data solta é recusado — não pode remover a referência silenciosamente")]
     public void Rejeita_TipoNuloComDataSolta()
     {
         ValidationResult resultado = Validar(null, new DateOnly(2026, 3, 1), null);
@@ -40,7 +40,7 @@ public sealed class DefinirReferenciaTemporalFatosCommandValidatorTests
         resultado.Errors.Should().Contain(e => e.ErrorMessage.Contains("Data e FaseId não são aceitos", StringComparison.Ordinal));
     }
 
-    [Fact(DisplayName = "Achado Codex P2 (PR #896): Tipo nulo com FaseId solta é recusado")]
+    [Fact(DisplayName = "Tipo nulo com FaseId solta é recusado")]
     public void Rejeita_TipoNuloComFaseIdSolta()
     {
         ValidationResult resultado = Validar(null, null, Guid.CreateVersion7());

--- a/tests/Unifesspa.UniPlus.Selecao.Domain.UnitTests/Entities/ConfiguracaoDistribuicaoVagasTests.cs
+++ b/tests/Unifesspa.UniPlus.Selecao.Domain.UnitTests/Entities/ConfiguracaoDistribuicaoVagasTests.cs
@@ -119,7 +119,7 @@ public sealed class ConfiguracaoDistribuicaoVagasTests
         resultado.Error!.Code.Should().Be("ConfiguracaoDistribuicaoVagas.ModalidadeDuplicada");
     }
 
-    [Fact(DisplayName = "Criar com RETIRA_DE apontando para código fora do conjunto selecionado falha (achado Codex)")]
+    [Fact(DisplayName = "Criar com RETIRA_DE apontando para código fora do conjunto selecionado falha")]
     public void Criar_ComposicaoOrigemForaDoConjunto_Falha()
     {
         ModalidadeSelecionada retiraDeSemOrigemSelecionada = ModalidadeSelecionada.Criar(
@@ -135,7 +135,7 @@ public sealed class ConfiguracaoDistribuicaoVagasTests
         resultado.Error!.Code.Should().Be("ConfiguracaoDistribuicaoVagas.ComposicaoOrigemNaoSelecionada");
     }
 
-    [Fact(DisplayName = "Criar com remanejamento CRUZADO apontando para par fora do conjunto falha (achado Codex)")]
+    [Fact(DisplayName = "Criar com remanejamento CRUZADO apontando para par fora do conjunto falha")]
     public void Criar_RemanejamentoParForaDoConjunto_Falha()
     {
         ModalidadeSelecionada indSemParSelecionado = ModalidadeSelecionada.Criar(
@@ -175,7 +175,7 @@ public sealed class ConfiguracaoDistribuicaoVagasTests
         resultado.Error!.Code.Should().Be("ConfiguracaoDistribuicaoVagas.ModalidadesFederaisIncompletas");
     }
 
-    [Fact(DisplayName = "Criar Lei 12.711 com retirada de origem diferente de AC falha (achado Codex)")]
+    [Fact(DisplayName = "Criar Lei 12.711 com retirada de origem diferente de AC falha")]
     public void Criar_Lei12711RetiradaForaDeAc_Falha()
     {
         ModalidadeSelecionada retiradaDeSubReserva = ModalidadeSelecionada.Criar(

--- a/tests/Unifesspa.UniPlus.Selecao.Domain.UnitTests/Entities/ProcessoSeletivoDocumentosExigidosTests.cs
+++ b/tests/Unifesspa.UniPlus.Selecao.Domain.UnitTests/Entities/ProcessoSeletivoDocumentosExigidosTests.cs
@@ -136,7 +136,7 @@ public sealed class ProcessoSeletivoDocumentosExigidosTests
 
         // Mesma Ordem (1) E mesma FaseCanonicaOrigemId — "editar a mesma fase" (o caso
         // comum de uma sessão editorial que só ajusta datas), não "trocar qual fase ocupa
-        // o slot" (achado Codex P2, PR #900): a reconciliação reusa a instância viva,
+        // o slot" — a reconciliação reusa a instância viva,
         // preserva o Id, e a exigência continua referenciando uma fase que existe.
         Result resultado = processo.DefinirCronogramaFases(
             [Fase(1, "INSCRICAO_REVISADA", fase.FaseCanonicaOrigemId)], [], PrecondicaoIfMatch.Curinga);
@@ -147,7 +147,7 @@ public sealed class ProcessoSeletivoDocumentosExigidosTests
         exigencia.ExigidoNaFaseId.Should().Be(fase.Id, "a exigência nunca deixou de referenciar uma fase existente");
     }
 
-    [Fact(DisplayName = "Achado Codex P2 (PR #900): trocar a fase canônica na MESMA Ordem, referenciada por exigência viva, é recusado — não retargeta o Id silenciosamente")]
+    [Fact(DisplayName = "Trocar a fase canônica na MESMA Ordem, referenciada por exigência viva, é recusado — não retargeta o Id silenciosamente")]
     public void DefinirCronogramaFases_TrocaFaseCanonicaNaMesmaOrdemComExigenciaViva_Recusa()
     {
         ProcessoSeletivo processo = NovoProcesso();
@@ -165,7 +165,7 @@ public sealed class ProcessoSeletivoDocumentosExigidosTests
         resultado.Error!.Code.Should().Be("FaseCronograma.ReferenciadaPorExigenciaViva");
     }
 
-    [Fact(DisplayName = "Achado Codex P2 (PR #900, 4ª rodada): trocar a fase canônica na MESMA Ordem, SEM exigência viva referenciando-a, é aceito como remoção+inserção — NÃO reusa a linha (o Id muda)")]
+    [Fact(DisplayName = "Trocar a fase canônica na MESMA Ordem, SEM exigência viva referenciando-a, é aceito como remoção+inserção — NÃO reusa a linha (o Id muda)")]
     public void DefinirCronogramaFases_TrocaFaseCanonicaNaMesmaOrdemSemExigenciaViva_AceitaComoRemocaoMaisInsercao()
     {
         ProcessoSeletivo processo = NovoProcesso();
@@ -186,7 +186,7 @@ public sealed class ProcessoSeletivoDocumentosExigidosTests
         processo.CronogramaFases.Single().Codigo.Should().Be("ANALISE");
     }
 
-    [Fact(DisplayName = "Achado Codex P2 (PR #900, 4ª rodada): permutação cíclica de Ordem entre 2 fases retidas é recusada — sem ordem de UPDATE que resolva a troca")]
+    [Fact(DisplayName = "Permutação cíclica de Ordem entre 2 fases retidas é recusada — sem ordem de UPDATE que resolva a troca")]
     public void DefinirCronogramaFases_PermutacaoCiclicaDeOrdemEntreDuasFases_Recusa()
     {
         ProcessoSeletivo processo = NovoProcesso();
@@ -202,7 +202,7 @@ public sealed class ProcessoSeletivoDocumentosExigidosTests
         resultado.Error!.Code.Should().Be("FaseCronograma.PermutacaoDeOrdemNaoSuportada");
     }
 
-    [Fact(DisplayName = "Achado Codex P2 (PR #900, 4ª rodada): permutação cíclica de Ordem entre 3 fases retidas é recusada")]
+    [Fact(DisplayName = "Permutação cíclica de Ordem entre 3 fases retidas é recusada")]
     public void DefinirCronogramaFases_PermutacaoCiclicaDeOrdemEntreTresFases_Recusa()
     {
         ProcessoSeletivo processo = NovoProcesso();
@@ -342,7 +342,7 @@ public sealed class ProcessoSeletivoDocumentosExigidosTests
         resultado.IsSuccess.Should().BeTrue(resultado.Error?.Message);
     }
 
-    // ── Story #554/issue #893 (achado Codex P2, PR #900) — IdadeMaximaEmissao.ReferenciaFaseId ──
+    // ── Story #554/issue #893 — IdadeMaximaEmissao.ReferenciaFaseId ──
 
     private static FaseCronograma FaseComExtremo(
         int ordem, string codigo, DateTimeOffset? inicio, DateTimeOffset? fim, Guid? faseCanonicaOrigemId = null) => FaseCronograma.Criar(
@@ -379,7 +379,7 @@ public sealed class ProcessoSeletivoDocumentosExigidosTests
             condicoes: [], basesLegais: [], idadeMaximaEmissao: idade, formatosPermitidos: FormatosPermitidos.Criar(true, null).Value!, tamanhoMaximoBytes: null).Value!;
     }
 
-    [Fact(DisplayName = "Achado Codex P2 (PR #900): remover fase usada só como âncora de IdadeMaximaEmissao (não ExigidoNaFaseId) é recusado")]
+    [Fact(DisplayName = "Remover fase usada só como âncora de IdadeMaximaEmissao (não ExigidoNaFaseId) é recusado")]
     public void DefinirCronogramaFases_RemoveFaseAncoraDeIdade_Recusa()
     {
         ProcessoSeletivo processo = NovoProcesso();
@@ -400,7 +400,7 @@ public sealed class ProcessoSeletivoDocumentosExigidosTests
         resultado.Error!.Code.Should().Be("FaseCronograma.ReferenciadaPorExigenciaViva");
     }
 
-    [Fact(DisplayName = "Achado Codex P2 (PR #900): fase sobrevivente que perde o extremo usado como âncora de idade é recusado")]
+    [Fact(DisplayName = "Fase sobrevivente que perde o extremo usado como âncora de idade é recusado")]
     public void DefinirCronogramaFases_FaseSobreviventePerdeExtremoAncoraDeIdade_Recusa()
     {
         ProcessoSeletivo processo = NovoProcesso();
@@ -438,7 +438,7 @@ public sealed class ProcessoSeletivoDocumentosExigidosTests
         resultado.IsSuccess.Should().BeTrue(resultado.Error?.Message, "o Fim continua definido — só o valor mudou, o que é uma edição legítima");
     }
 
-    // ── Story #554/issue #893 (achado Codex P2, PR #900, 5ª rodada) — FIM_INSCRICAO não
+    // ── Story #554/issue #893 — FIM_INSCRICAO não
     // usa ReferenciaFaseId (a âncora é implícita: a fase com ColetaInscricao) ──
 
     private static FaseCronograma FaseColetaInscricao(
@@ -475,7 +475,7 @@ public sealed class ProcessoSeletivoDocumentosExigidosTests
             condicoes: [], basesLegais: [], idadeMaximaEmissao: idade, formatosPermitidos: FormatosPermitidos.Criar(true, null).Value!, tamanhoMaximoBytes: null).Value!;
     }
 
-    [Fact(DisplayName = "Achado Codex P2 (PR #900, 5ª rodada): FIM_INSCRICAO sem NENHUMA fase que coleta inscrição no processo é recusado")]
+    [Fact(DisplayName = "FIM_INSCRICAO sem NENHUMA fase que coleta inscrição no processo é recusado")]
     public void DefinirDocumentosExigidos_FimInscricaoSemFaseDeColeta_Recusa()
     {
         ProcessoSeletivo processo = NovoProcesso();
@@ -488,7 +488,7 @@ public sealed class ProcessoSeletivoDocumentosExigidosTests
         resultado.Error!.Code.Should().Be("IdadeMaximaEmissao.FaseNaoPertenceAoProcesso");
     }
 
-    [Fact(DisplayName = "Achado Codex P2 (PR #900, 5ª rodada): FIM_INSCRICAO com fase de coleta SEM Fim definido é recusado")]
+    [Fact(DisplayName = "FIM_INSCRICAO com fase de coleta SEM Fim definido é recusado")]
     public void DefinirDocumentosExigidos_FimInscricaoComFaseDeColetaSemFim_Recusa()
     {
         ProcessoSeletivo processo = NovoProcesso();
@@ -514,7 +514,7 @@ public sealed class ProcessoSeletivoDocumentosExigidosTests
         resultado.IsSuccess.Should().BeTrue(resultado.Error?.Message);
     }
 
-    [Fact(DisplayName = "Achado Codex P2 (PR #900, 6ª rodada): com DUAS fases de coleta, a primeira sem Fim e a segunda com Fim, FIM_INSCRICAO é aceito — a pergunta é existencial (Any), não posicional (FirstOrDefault)")]
+    [Fact(DisplayName = "Com DUAS fases de coleta, a primeira sem Fim e a segunda com Fim, FIM_INSCRICAO é aceito — a pergunta é existencial (Any), não posicional (FirstOrDefault)")]
     public void DefinirDocumentosExigidos_FimInscricaoComPrimeiraFaseDeColetaSemFimEDemaisComFim_Aceita()
     {
         ProcessoSeletivo processo = NovoProcesso();
@@ -528,7 +528,7 @@ public sealed class ProcessoSeletivoDocumentosExigidosTests
         resultado.IsSuccess.Should().BeTrue(resultado.Error?.Message, "a segunda fase de coleta resolve FIM_INSCRICAO — escolher a primeira encontrada (sem Fim) seria um 422 falso");
     }
 
-    [Fact(DisplayName = "Achado Codex P2 (PR #900, 5ª rodada): redefinir o cronograma tirando o Fim da fase de coleta com exigência FIM_INSCRICAO viva é recusado")]
+    [Fact(DisplayName = "Redefinir o cronograma tirando o Fim da fase de coleta com exigência FIM_INSCRICAO viva é recusado")]
     public void DefinirCronogramaFases_FaseDeColetaPerdeFimComExigenciaFimInscricaoViva_Recusa()
     {
         ProcessoSeletivo processo = NovoProcesso();
@@ -562,7 +562,7 @@ public sealed class ProcessoSeletivoDocumentosExigidosTests
         resultado.IsSuccess.Should().BeTrue(resultado.Error?.Message);
     }
 
-    // ── Story #554/issue #892 (achado Codex P2, PR #896) — CA-03 backward guard ──
+    // ── Story #554/issue #892 — CA-03 backward guard ──
 
     private static CondicaoGatilho CondicaoDe(string fato, string valor) => CondicaoGatilho.Criar(
         0, fato, Operador.Igual, JsonSerializer.SerializeToElement(valor)).Value!;

--- a/tests/Unifesspa.UniPlus.Selecao.Domain.UnitTests/Entities/ProcessoSeletivoRestaurarConfiguracaoTests.cs
+++ b/tests/Unifesspa.UniPlus.Selecao.Domain.UnitTests/Entities/ProcessoSeletivoRestaurarConfiguracaoTests.cs
@@ -612,7 +612,7 @@ public sealed class ProcessoSeletivoRestaurarConfiguracaoTests
             "precisa repor esse estado vazio, não preservar o que a sessão descartada editou");
     }
 
-    [Fact(DisplayName = "Story #554/issue #892 (achado Codex P1) — restauração limpa ReferenciaTemporalFatos definida durante a sessão")]
+    [Fact(DisplayName = "Story #554/issue #892 — restauração limpa ReferenciaTemporalFatos definida durante a sessão")]
     public void Restauracao_LimpaReferenciaTemporalFatosDaSessao()
     {
         // Mesmo raciocínio de Restauracao_LimpaDocumentosExigidosDaSessao: o campo não é

--- a/tests/Unifesspa.UniPlus.Selecao.Domain.UnitTests/Entities/ProcessoSeletivoTests.cs
+++ b/tests/Unifesspa.UniPlus.Selecao.Domain.UnitTests/Entities/ProcessoSeletivoTests.cs
@@ -417,7 +417,7 @@ public sealed class ProcessoSeletivoTests
         result.Error!.Code.Should().Be("ProcessoSeletivo.EtapaRefDesempateInexistente");
     }
 
-    [Fact(DisplayName = "DefinirEtapas recusa remover uma etapa referenciada por critério de desempate (achado Codex)")]
+    [Fact(DisplayName = "DefinirEtapas recusa remover uma etapa referenciada por critério de desempate (INV-B6)")]
     public void DefinirEtapas_RemoverEtapaReferenciadaPorDesempate_Recusa()
     {
         ProcessoSeletivo processo = NovoProcesso();

--- a/tests/Unifesspa.UniPlus.Selecao.Domain.UnitTests/Services/CalculadoraQuadroVagasLei12711Tests.cs
+++ b/tests/Unifesspa.UniPlus.Selecao.Domain.UnitTests/Services/CalculadoraQuadroVagasLei12711Tests.cs
@@ -186,7 +186,7 @@ public sealed class CalculadoraQuadroVagasLei12711Tests
         quadro.VrFinal.Should().Be(28);
     }
 
-    [Fact(DisplayName = "V11 — floor-first: piso de I,II,III vence o excedente de I (achado Codex do protótipo)")]
+    [Fact(DisplayName = "V11 — floor-first: piso de I,II,III vence o excedente de I")]
     public void FloorFirst_PisoDosGruposPosterioresVenceExcedenteDoAnterior_CasoSimetrico()
     {
         Result<QuadroVagasCalculado> resultado = CalculadoraQuadroVagasLei12711.Calcular(

--- a/tests/Unifesspa.UniPlus.Selecao.Domain.UnitTests/ValueObjects/IdadeMaximaEmissaoTests.cs
+++ b/tests/Unifesspa.UniPlus.Selecao.Domain.UnitTests/ValueObjects/IdadeMaximaEmissaoTests.cs
@@ -77,7 +77,7 @@ public sealed class IdadeMaximaEmissaoTests
         resultado.Error!.Code.Should().Be("IdadeMaximaEmissao.ValorInvalido");
     }
 
-    [Theory(DisplayName = "Achado Codex P2 (PR #900, 3ª rodada): sentinel Nenhuma em Unidade ou ReferenciaTipo, com Valor positivo, é recusado")]
+    [Theory(DisplayName = "Sentinel Nenhuma em Unidade ou ReferenciaTipo, com Valor positivo, é recusado")]
     [InlineData(true, false)]
     [InlineData(false, true)]
     [InlineData(true, true)]

--- a/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/Assertions/HttpResponsePiiAssertionsTests.cs
+++ b/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/Assertions/HttpResponsePiiAssertionsTests.cs
@@ -53,8 +53,8 @@ public sealed class HttpResponsePiiAssertionsTests
         excecao!.Message.Should().Contain("CPF não mascarado");
     }
 
-    // ─── Regressão P1: traceId/UUID com dígitos adjacentes a letra hex não disparam
-    //     o padrão CPF cru (falso positivo reportado pelo Codex) ──────────────────
+    // ─── traceId/UUID com dígitos adjacentes a letra hex não disparam
+    //     o padrão CPF cru (falso positivo do regex anterior) ──────────────────
 
     [Fact]
     public void AssertBodyNoPii_DadoTraceIdComSequenciaDigitosAdjacenteALetraHex_NaoDeveGerarFalha()

--- a/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/Hosting/DocumentoEditalIdempotencyTtlSentinelTests.cs
+++ b/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/Hosting/DocumentoEditalIdempotencyTtlSentinelTests.cs
@@ -16,7 +16,7 @@ using Unifesspa.UniPlus.Selecao.Application.Commands.DocumentosEdital;
 
 /// <summary>
 /// Sentinela contra o TTL de idempotência do endpoint de iniciar upload
-/// (achado Codex no PR #790) divergir do TTL real da URL pre-assinada de
+/// divergir do TTL real da URL pre-assinada de
 /// PUT. Um <c>[RequiresIdempotencyKey]</c> sem override usa o teto de 24h
 /// (ADR-0027) — como a URL expira em <see cref="IniciarUploadDocumentoEditalCommandHandler.TtlUploadSegundos"/>
 /// (15 min), um replay depois disso devolveria uma URL inutilizável. O

--- a/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/ObrigatoriedadesLegais/ObrigatoriedadeLegalPersistenceTests.cs
+++ b/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/ObrigatoriedadesLegais/ObrigatoriedadeLegalPersistenceTests.cs
@@ -286,7 +286,7 @@ public sealed class ObrigatoriedadeLegalPersistenceTests : IClassFixture<Obrigat
         foraDaVigencia.Select(static regra => regra.RegraCodigo).Should().NotContain("RULESET_PSIQ");
     }
 
-    [Fact(DisplayName = "FK historico→regra bloqueia INSERT de histórico órfão (Codex P2)")]
+    [Fact(DisplayName = "FK historico→regra bloqueia INSERT de histórico órfão")]
     public async Task FkHistorico_BloqueiaOrfao()
     {
         // Tentar inserir uma linha de histórico apontando para regra_id que

--- a/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/ProcessosSeletivos/ClassificacaoPersistenciaTests.cs
+++ b/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/ProcessosSeletivos/ClassificacaoPersistenciaTests.cs
@@ -192,7 +192,7 @@ public sealed class ClassificacaoPersistenciaTests : IClassFixture<ProcessoSelet
         classificacao.RegrasEliminacao.Should().ContainSingle();
     }
 
-    [Fact(DisplayName = "Atualizar dados da MESMA etapa (Id preservado) mantém a eliminação referenciando-a (achado Codex, F3)")]
+    [Fact(DisplayName = "Atualizar dados da MESMA etapa (Id preservado) mantém a eliminação referenciando-a (F3)")]
     public async Task AtualizarEtapaMesmoId_MantemEliminacaoReferenciada()
     {
         ProcessoSeletivo processo = ProcessoSeletivo.Criar("PS 2026 — SiSU", TipoProcesso.SiSU, OrigemCandidatos.InscricaoPropria, Guid.NewGuid(), Unifesspa.UniPlus.Selecao.Domain.ValueObjects.UnidadeAdministradoraSnapshot.Criar("CEPS", "ceps", "Centro de Processos Seletivos", "ADMINISTRATIVA").Value!);

--- a/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/ProcessosSeletivos/DesempateBonusPersistenciaTests.cs
+++ b/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/ProcessosSeletivos/DesempateBonusPersistenciaTests.cs
@@ -146,7 +146,7 @@ public sealed class DesempateBonusPersistenciaTests : IClassFixture<ProcessoSele
         recarregado.BonusRegional.Teto.Should().Be(5m);
     }
 
-    [Fact(DisplayName = "Atualizar dados da MESMA etapa (Id preservado) mantém o desempate referenciando-a (achado Codex)")]
+    [Fact(DisplayName = "Atualizar dados da MESMA etapa (Id preservado) mantém o desempate referenciando-a (INV-B6)")]
     public async Task AtualizarEtapaMesmoId_MantemDesempateReferenciado()
     {
         ProcessoSeletivo processo = ProcessoSeletivo.Criar("PS 2026 — PSVR", TipoProcesso.PSVR, OrigemCandidatos.InscricaoPropria, Guid.NewGuid(), Unifesspa.UniPlus.Selecao.Domain.ValueObjects.UnidadeAdministradoraSnapshot.Criar("CEPS", "ceps", "Centro de Processos Seletivos", "ADMINISTRATIVA").Value!);

--- a/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/ProcessosSeletivos/NoExigenciaPersistenciaTests.cs
+++ b/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/ProcessosSeletivos/NoExigenciaPersistenciaTests.cs
@@ -18,7 +18,7 @@ using Unifesspa.UniPlus.Selecao.Infrastructure.Persistence.Repositories;
 /// (Story #920) — persiste via <see cref="ProcessoSeletivoRepository"/> e recarrega em uma
 /// SESSÃO NOVA do DbContext (simulando uma requisição HTTP diferente), pelo MESMO caminho de
 /// produção (<see cref="ProcessoSeletivoRepository.ObterParaMutacaoAsync"/>) — não uma query
-/// de teste hand-rolled. Achado de revisão (Codex, rodada de review desta PR): sem o
+/// de teste hand-rolled. Sem o
 /// <c>Include(p =&gt; p.NosExigencia)</c> no repositório, a coleção tracked nascia vazia em
 /// todo carregamento novo do agregado — furo real de "perda silenciosa" já no caminho
 /// ordinário (toda requisição recarrega o agregado do zero). Story #923: o antigo gate


### PR DESCRIPTION
Setenta e cinco trechos do código citavam a ferramenta de revisão automatizada como justificativa de uma mudança. A convenção do repositório proíbe: o comentário registra o **porquê técnico ou de negócio**, nunca o caminho burocrático que levou até ele.

## Os números, contados

| Natureza | Quantidade |
|---|---:|
| `DisplayName` de teste | 30 |
| Comentário de código | 42 |
| Continuação de `DisplayName` multilinha | 1 |
| Comentário em workflow YAML | 2 |
| **Total** | **75**, em 37 arquivos `.cs` + `trivy.yml` |

## O `DisplayName` era o caso mais grave, e não estava no escopo original da issue

Um teste chamado `"Story #554/issue #892 (achado Codex P1) — restauração limpa ReferenciaTemporalFatos..."` **aparece no relatório do CI** e em qualquer listagem de testes. É lido por quem nunca vai abrir o arquivo.

E o `DisplayName` é onde o teste declara o que prova. Trocar a atribuição pela invariante protegida não é cosmética: é a diferença entre um nome que informa e um nome que exige arqueologia.

## O critério: substituir, não apagar

O risco desta mudança era apagar a explicação técnica junto com a atribuição. A busca ficaria limpa e o repositório perderia o porquê — sem ninguém perceber.

O diff mostra **50 linhas de comentário removidas e 50 adicionadas**: cada trecho tocado foi reescrito, nenhum foi simplesmente eliminado.

Três exemplos do que isso significou na prática:

```csharp
// corte simples, quando o resto já se sustentava
- // Achado Codex P2 (PR #900, 4ª rodada) — uma permutação cíclica de Ordem entre
+ // Uma permutação cíclica de Ordem entre

// reescrita, quando cortar deixaria a frase pendurada
- // Reproduz o achado do Codex (PR #1019, P1): request A lê o termo revisado
+ // Reproduz uma corrida de leitura-escrita: request A lê o termo revisado

// reclassificação: o identificador era real, o rótulo é que estava errado
- // UNIQUE parcial sobre RegraCodigo entre regras ativas (Codex P1 de #461)
+ // UNIQUE parcial sobre RegraCodigo entre regras ativas (Story #461)
```

No último caso, a origem foi confirmada por busca em cinco outros arquivos antes de trocar o rótulo — `#461` é a Story do endpoint, não um artefato de revisão.

## O que ficou

**37 ocorrências de identificador rastreável preservadas** — `issue #892`, `Story #554`, `CA-03`, `CA-04`, `INV-B6`, `Lei 12.711`, `ADR-0004`, `ADR-0109`, `ADR-0115`, entre outros. Remover token legítimo seria regressão, não correção; a regra é que a prosa se sustente sem ele, não que ele desapareça.

Nos dois comentários de `trivy.yml`, a razão objetiva do pin imutável — "trivy-action é third-party e teve incidente" — permanece intacta.

## Decisões de julgamento, para conferência

- **Menções a `PR #900` sem "achado"/"rodada" foram mantidas.** Ele é o PR de implementação da Story #554, e aparece em construções como `Story #554/issue #893, PR #900, CA-04`, que são rastreabilidade legítima. Removidas apenas as menções em que o número acompanha "achado" ou "rodada".
- **`issue #892` foi preservado** nos `DisplayName` onde aparecia junto de `Story #554`, em vez de reduzir a apenas um dos dois.

## Verificação

- suíte completa: **4.602 testes, 26 assemblies, zero falhas**
- build: **0 avisos, 0 erros**
- `dotnet format --verify-no-changes`: limpo
- `grep -rni "\bCodex\b" src tests --include="*.cs"`: **zero**
- `grep -rniE '^\s*#.*\bCodex\b' .github`: **zero**

A busca limpa sozinha não provaria nada — ela ficaria limpa também com poda cega. A prova é o diff, e a paridade entre linhas removidas e adicionadas.

Mudança sem comportamento executável novo.

Closes #1084
