### PR TITLE
fix(selecao): recusa leitura de versão de envelope não reconhecida

### DIFF
--- a/src/selecao/Unifesspa.UniPlus.Selecao.Application/Queries/ProcessosSeletivos/ObterFormularioRenderizavelQueryHandler.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Application/Queries/ProcessosSeletivos/ObterFormularioRenderizavelQueryHandler.cs
@@ -3,6 +3,8 @@ namespace Unifesspa.UniPlus.Selecao.Application.Queries.ProcessosSeletivos;
 using System.Text.Json;
 using System.Text.Json.Nodes;
 
+using Abstractions;
+
 using Domain.Entities;
 using Domain.Interfaces;
 
@@ -15,18 +17,25 @@ using Unifesspa.UniPlus.Kernel.Results;
 /// resolve a versão vigente da configuração e projeta os blocos <c>formulario</c>/
 /// <c>fatosColetados</c> (incluindo <c>valoresSelecionaveis</c>) do envelope congelado. Distingue
 /// 404 (processo inexistente) de 422 (<c>Snapshot.VigenteAusente</c>) — mesmo contrato de erro de
-/// <see cref="ObterSnapshotVigenteQueryHandler"/>.
+/// <see cref="ObterSnapshotVigenteQueryHandler"/>. Antes de projetar, confere a
+/// <c>SchemaVersion</c> contra as capacidades de leitura que <see cref="IRegistroCodecsEnvelope"/>
+/// declara: sob o regime de codec único reescrito no lugar (ADR-0110 Emenda 2, ADR-0109 Emenda 2),
+/// uma versão que deixou de ser a corrente não ganha decodificador próprio, e bytes que
+/// coincidentemente têm a forma atual não a tornam reconhecida — a recusa é
+/// <c>EnvelopeCodec.VersaoDesconhecida</c>, decidida antes de qualquer parse.
 /// </summary>
 public static class ObterFormularioRenderizavelQueryHandler
 {
     public static async Task<Result<FormularioRenderizavelDto>> Handle(
         ObterFormularioRenderizavelQuery query,
         IProcessoSeletivoRepository processoSeletivoRepository,
+        IRegistroCodecsEnvelope registroCodecs,
         TimeProvider timeProvider,
         CancellationToken cancellationToken)
     {
         ArgumentNullException.ThrowIfNull(query);
         ArgumentNullException.ThrowIfNull(processoSeletivoRepository);
+        ArgumentNullException.ThrowIfNull(registroCodecs);
         ArgumentNullException.ThrowIfNull(timeProvider);
 
         // Endpoint público de renderização: sempre "agora", nunca um instante passado explícito
@@ -52,21 +61,41 @@ public static class ObterFormularioRenderizavelQueryHandler
                     $"Processo Seletivo {query.ProcessoSeletivoId} não encontrado."));
         }
 
+        if (!VersaoReconhecidaParaLeitura(registroCodecs, versao.SchemaVersion))
+        {
+            return Result<FormularioRenderizavelDto>.Failure(new DomainError(
+                ErrosCodecEnvelope.VersaoDesconhecida,
+                $"A versão '{versao.SchemaVersion}' do envelope congelado não está entre as capacidades de " +
+                "leitura reconhecidas pelo codec vivo — mesmo que os bytes tenham a forma atual, uma versão " +
+                "aposentada não é reidratada."));
+        }
+
         JsonObject envelope = (JsonObject)JsonNode.Parse(versao.ConfiguracaoCongelada)!;
         return Projetar(envelope);
     }
 
     /// <summary>
+    /// A <paramref name="schemaVersion"/> está entre as capacidades que o registro de codecs hoje
+    /// sabe LER? Comparação ordinal — <c>SchemaVersion</c> é token, não texto localizável, e
+    /// <c>"0.0.6"</c> não é apelido de <c>"0.0.06"</c> nem de variante de caixa.
+    /// </summary>
+    private static bool VersaoReconhecidaParaLeitura(IRegistroCodecsEnvelope registroCodecs, string schemaVersion) =>
+        registroCodecs.Capacidades.Any(capacidade =>
+            string.Equals(capacidade.SchemaVersion, schemaVersion, StringComparison.Ordinal) && capacidade.TemDecoder);
+
+    /// <summary>
     /// Projeta os blocos <c>formulario</c>/<c>fatosColetados</c> (incluindo
-    /// <c>valoresSelecionaveis</c>, issue #1059) do envelope congelado. Guardado contra QUALQUER
-    /// forma que não seja exatamente a esperada — versão vigente congelada ANTES de a
-    /// apresentação existir no envelope (sem as chaves novas), ou um valor de tipo/nulidade
-    /// incoerente (só alcançável por uma linha adulterada diretamente no banco, nunca pelo
-    /// caminho normal de escrita, que sempre passa pelo encoder). Nenhum
-    /// <c>Decodificar</c>/<c>LeitorEnvelope</c> disponível aqui (a Application não alcança a
-    /// Infrastructure, dona do codec) — a leitura tipada abaixo é o substituto local, mesma
-    /// disciplina: toda extração checa presença, tipo e nulidade antes de usar o valor, nunca um
-    /// cast bruto sobre entrada que não passou pelo encoder confiável.
+    /// <c>valoresSelecionaveis</c>, issue #1059) do envelope congelado, já com a
+    /// <c>SchemaVersion</c> confirmada como reconhecida por <see cref="IRegistroCodecsEnvelope"/>
+    /// (ver <see cref="Handle"/>). Guardado contra QUALQUER forma que não seja exatamente a
+    /// esperada — versão vigente congelada ANTES de a apresentação existir no envelope (sem as
+    /// chaves novas), ou um valor de tipo/nulidade incoerente (só alcançável por uma linha
+    /// adulterada diretamente no banco, nunca pelo caminho normal de escrita, que sempre passa
+    /// pelo encoder). O registro de codecs confirma a versão, mas decodifica para o grafo de
+    /// entidades das seis dimensões (<see cref="EnvelopeReidratado"/>), não para este DTO de
+    /// renderização — por isso a leitura abaixo permanece local, mesma disciplina: toda extração
+    /// checa presença, tipo e nulidade antes de usar o valor, nunca um cast bruto sobre entrada
+    /// que não passou pelo encoder confiável.
     /// </summary>
     private static Result<FormularioRenderizavelDto> Projetar(JsonObject envelope)
     {

--- a/tests/Unifesspa.UniPlus.Selecao.Application.UnitTests/Queries/ObterFormularioRenderizavelQueryHandlerTests.cs
+++ b/tests/Unifesspa.UniPlus.Selecao.Application.UnitTests/Queries/ObterFormularioRenderizavelQueryHandlerTests.cs
@@ -7,6 +7,7 @@ using AwesomeAssertions;
 using NSubstitute;
 
 using Unifesspa.UniPlus.Kernel.Results;
+using Unifesspa.UniPlus.Selecao.Application.Abstractions;
 using Unifesspa.UniPlus.Selecao.Application.DTOs;
 using Unifesspa.UniPlus.Selecao.Application.Queries.ProcessosSeletivos;
 using Unifesspa.UniPlus.Selecao.Domain.Entities;
@@ -14,22 +15,58 @@ using Unifesspa.UniPlus.Selecao.Domain.Interfaces;
 
 /// <summary>
 /// Cobertura do <see cref="ObterFormularioRenderizavelQueryHandler"/> (Story #559/#1059): a
-/// distinção 404/422/200, e a guarda contra versão vigente congelada ANTES de a apresentação do
-/// formulário — ou os valores selecionáveis (UNI-REQ-0072) — existirem no envelope. Sem
-/// <see cref="Unifesspa.UniPlus.Selecao.Infrastructure"/> disponível aqui (Application não a
-/// alcança), a projeção lê o JSON cru e tem de recusar com um erro nomeado, nunca estourar,
+/// distinção 404/422/200, a guarda contra versão vigente congelada ANTES de a apresentação do
+/// formulário — ou os valores selecionáveis (UNI-REQ-0072) — existirem no envelope, e a recusa de
+/// uma <c>SchemaVersion</c> aposentada (issue #1089) mesmo quando os bytes coincidem com a forma
+/// atual. Sem <see cref="Unifesspa.UniPlus.Selecao.Infrastructure"/> disponível aqui (Application
+/// não a alcança), a projeção lê o JSON cru e tem de recusar com um erro nomeado, nunca estourar,
 /// quando as chaves novas (rotulo/tipoRenderizacao/obrigatorio/formulario/valoresSelecionaveis)
 /// não existem, ou quando <c>valoresSelecionaveis</c> descumpre a bicondicional com
 /// <c>tipoRenderizacao</c>.
 /// </summary>
 public sealed class ObterFormularioRenderizavelQueryHandlerTests
 {
+    /// <summary>
+    /// A versão que o registro de codecs FAKE (<see cref="RegistroReconhecendoVersaoCorrente"/>)
+    /// declara como única capacidade de leitura — o caso corrente de todo teste que não é sobre o
+    /// gate de versão em si.
+    /// </summary>
+    private const string VersaoCorrenteReconhecida = "0.0.6";
+
+    /// <summary>
+    /// Uma versão que já foi corrente e deixou de ser reconhecida quando o codec vivo avançou —
+    /// usada SÓ no teste que prova a recusa (issue #1089); nenhum outro teste deste arquivo rotula
+    /// o caso corrente com ela.
+    /// </summary>
+    private const string VersaoAposentada = "0.0.5";
+
     private static readonly TimeProvider Relogio = TimeProvider.System;
+
+    /// <summary>
+    /// Substituto da porta reconhecendo, como única capacidade de leitura, exatamente
+    /// <see cref="VersaoCorrenteReconhecida"/> — o mesmo perfil do registro de produção, que hoje
+    /// tem um único codec vivo (ADR-0110 Emenda 2).
+    /// </summary>
+    private static readonly IRegistroCodecsEnvelope RegistroReconhecendoVersaoCorrente =
+        CriarRegistroReconhecendo(VersaoCorrenteReconhecida);
 
     private static Task<Result<FormularioRenderizavelDto>> HandleAsync(
         IProcessoSeletivoRepository repository, Guid processoId) =>
         ObterFormularioRenderizavelQueryHandler.Handle(
-            new ObterFormularioRenderizavelQuery(processoId), repository, Relogio, CancellationToken.None);
+            new ObterFormularioRenderizavelQuery(processoId),
+            repository,
+            RegistroReconhecendoVersaoCorrente,
+            Relogio,
+            CancellationToken.None);
+
+    private static IRegistroCodecsEnvelope CriarRegistroReconhecendo(params string[] schemaVersionsReconhecidas)
+    {
+        IRegistroCodecsEnvelope registro = Substitute.For<IRegistroCodecsEnvelope>();
+        registro.Capacidades.Returns(schemaVersionsReconhecidas
+            .Select(static v => new CapacidadeCodec(v, TemEncoder: true, TemDecoder: true, MotivoDaRecusa: null))
+            .ToList());
+        return registro;
+    }
 
     [Fact(DisplayName = "Processo inexistente retorna ProcessoSeletivo.NaoEncontrado")]
     public async Task Handle_ProcessoInexistente_RetornaNaoEncontrado()
@@ -169,6 +206,35 @@ public sealed class ObterFormularioRenderizavelQueryHandlerTests
     }
 
     /// <summary>
+    /// O teste central da issue #1089: a versão é aposentada, mas o JSON congelado tem a forma
+    /// ATUAL e é válido — exatamente o cenário em que decidir pela forma (o que o handler fazia
+    /// antes desta correção) mascara a recusa que o registro de codecs já dá em outras
+    /// superfícies (ex.: <c>AbrirRetificacaoCommandHandler</c>). Um envelope malformado não
+    /// provaria nada aqui: o handler já o recusava antes, por <c>FormularioInscricao.VersaoSemApresentacao</c>.
+    /// O que só esta correção resolve é a versão desconhecida com bytes que "passariam" no shape.
+    /// </summary>
+    [Fact(DisplayName = "Versão aposentada com bytes de forma corrente recusa com EnvelopeCodec.VersaoDesconhecida, sem tentar decidir pela forma")]
+    public async Task Handle_VersaoAposentadaComFormaCorrente_RetornaVersaoDesconhecida()
+    {
+        const string envelopeFormaCorrente = """
+            {
+              "formulario": {"titulo": "Formulário de Inscrição", "termoAceiteTexto": null},
+              "fatosColetados": []
+            }
+            """;
+        Guid processoId = Guid.CreateVersion7();
+        IProcessoSeletivoRepository repository = MockComVersaoVigente(processoId, envelopeFormaCorrente, VersaoAposentada);
+
+        Result<FormularioRenderizavelDto> resultado = await HandleAsync(repository, processoId);
+
+        resultado.IsFailure.Should().BeTrue(
+            $"a versão '{VersaoAposentada}' deixou de ser reconhecida quando o codec vivo avançou para " +
+            $"'{VersaoCorrenteReconhecida}' — bytes coincidentemente válidos na forma atual não a devolvem " +
+            "à lista de capacidades reconhecidas");
+        resultado.Error!.Code.Should().Be("EnvelopeCodec.VersaoDesconhecida");
+    }
+
+    /// <summary>
     /// Prova ESTRUTURAL (não comportamental) de que a leitura pública nunca reconsulta o
     /// catálogo: nenhum parâmetro do <c>Handle</c> é um leitor cross-módulo do catálogo de fatos
     /// (<c>IFatoCandidatoReader</c>) — os valores selecionáveis entregues vêm inteiramente do
@@ -190,12 +256,13 @@ public sealed class ObterFormularioRenderizavelQueryHandlerTests
             "no cadastro mudaria a resposta de uma versão já publicada, o que a imutabilidade do envelope proíbe");
     }
 
-    private static IProcessoSeletivoRepository MockComVersaoVigente(Guid processoId, string envelopeJson)
+    private static IProcessoSeletivoRepository MockComVersaoVigente(
+        Guid processoId, string envelopeJson, string schemaVersion = VersaoCorrenteReconhecida)
     {
         VersaoConfiguracao versao = VersaoConfiguracao.Abrir(
             processoId,
             Encoding.UTF8.GetBytes(envelopeJson),
-            "0.0.4",
+            schemaVersion,
             "canonical-json/sha256@v1",
             Guid.CreateVersion7(),
             new string('a', 64),

--- a/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/ProcessosSeletivos/FormularioRenderizavelPersistenciaTests.cs
+++ b/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/ProcessosSeletivos/FormularioRenderizavelPersistenciaTests.cs
@@ -46,6 +46,11 @@ public sealed class FormularioRenderizavelPersistenciaTests : IClassFixture<Proc
 {
     private static readonly SnapshotPublicacaoCanonicalizer Canonicalizer = new();
 
+    // O registro de PRODUÇÃO (não um substituto de teste): a leitura pública real, com
+    // Postgres real, tem de passar pelo mesmo gate de versão que o handler usa fora dos
+    // testes — reconhecendo hoje somente o codec vivo (ADR-0110 Emenda 2).
+    private static readonly IRegistroCodecsEnvelope RegistroCodecs = new RegistroCodecsEnvelope();
+
     private readonly ProcessoSeletivoDbFixture _fixture;
 
     public FormularioRenderizavelPersistenciaTests(ProcessoSeletivoDbFixture fixture)
@@ -169,7 +174,7 @@ public sealed class FormularioRenderizavelPersistenciaTests : IClassFixture<Proc
             await using SelecaoDbContext readContext = _fixture.CreateDbContext();
             ProcessoSeletivoRepository repository = new(readContext, TimeProvider.System);
             Result<FormularioRenderizavelDto> resultado = await ObterFormularioRenderizavelQueryHandler.Handle(
-                new ObterFormularioRenderizavelQuery(processoId), repository, TimeProvider.System, CancellationToken.None);
+                new ObterFormularioRenderizavelQuery(processoId), repository, RegistroCodecs, TimeProvider.System, CancellationToken.None);
             resultado.IsSuccess.Should().BeTrue(resultado.Error?.Message);
             return resultado.Value!;
         }


### PR DESCRIPTION
O leitor público do formulário lia a configuração congelada **sem conferir a `schema_version`**.

## O defeito

`ObterFormularioRenderizavelQueryHandler` carregava a `VersaoConfiguracao` vigente e ia direto de `ConfiguracaoCongelada` para `JsonNode.Parse`/`Projetar`. Não lia `versao.SchemaVersion` em ponto algum.

Se a versão vigente foi congelada sob uma forma que o codec corrente já não reconhece, o resultado depende dos bytes: `200` com projeção silenciosamente incorreta, `VersaoSemApresentacao`, ou exceção. Nenhum desses é a resposta certa — a resposta certa é recusar.

Isso importa porque o regime de codec mudou. Sob **um único codec vivo, reescrito no lugar** (ADR-0110, Emenda 2), a versão anterior **deixa de ser reconhecida** — ela não ganha decodificador próprio. Ler seus bytes com o decodificador atual é interpretar um formato antigo com a gramática nova.

## A correção

O `Handle` passa a receber `IRegistroCodecsEnvelope` — porta que **já existia e já estava registrada no DI**, sem alteração de composição — e valida a `schema_version` contra as capacidades de leitura reconhecidas, com comparação **ordinal**. Não reconhecida, devolve `EnvelopeCodec.VersaoDesconhecida`.

Duas decisões de desenho que o resultado depende:

**O gate vem antes do parse.** Se viesse depois, a mesma versão aposentada continuaria variando entre `VersaoSemApresentacao`, `200` e exceção conforme os bytes — que é exatamente o defeito. Recusar antes de tocar o conteúdo é o que torna o comportamento determinístico.

**Nenhum registro de codecs por versão foi criado.** Essa é a arquitetura que as Emendas 2 das ADRs 0109 e 0110 abandonaram. A porta apenas *informa* o que o codec vivo lê; a implementação de produção contém somente ele.

A Application continua sem depender de Infrastructure.

## Prova

```
Handle_VersaoAposentadaComFormaCorrente_RetornaVersaoDesconhecida
```

O nome carrega o essencial: a versão é aposentada **mas o JSON tem forma atual e é válido** — `formulario` com as duas propriedades, `fatosColetados: []`. Um teste com JSON malformado provaria que o parse falha, não que a versão é recusada.

Mutante executado — removida a checagem de versão:

```
Versão aposentada com bytes de forma corrente recusa com EnvelopeCodec.VersaoDesconhecida,
sem tentar decidir pela forma [FAIL]
  Expected resultado.IsFailure to be True, but found False.
Com falha! – Com falha: 1, Aprovado: 13
```

Só o teste novo falhou; os treze vizinhos da mesma classe seguiram verdes — o isolamento está correto. Desfeito por edição reversa.

O helper de mock foi parametrizado: ele fixava `"0.0.4"` como `schemaVersion` de **todos** os casos, inclusive o de sucesso, o que tornaria o teste novo ambíguo. Agora o caso de sucesso usa a versão corrente e só a regressão usa a aposentada.

## Um arquivo além do escopo

`FormularioRenderizavelPersistenciaTests` chama o handler diretamente e quebrou com a mudança de assinatura. Recebeu o registro **de produção** — não um substituto —, o que mantém o mesmo gate ativo fora dos mocks. Ajuste mecânico de call-site, sem decisão de desenho.

## Verificação

- suíte completa: **4.603 testes, 26 assemblies, zero falhas**
- build: **0 avisos, 0 erros**
- `dotnet format --verify-no-changes`: limpo

Sem migration: `schema_version` não tem `CHECK` e nenhuma linha precisa ser preservada.

Closes #1089
