### PR TITLE
fix(selecao): torna o checklist bicondicional com os gates estruturais

### DIFF
--- a/src/selecao/Unifesspa.UniPlus.Selecao.API/Controllers/ProcessoSeletivoController.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.API/Controllers/ProcessoSeletivoController.cs
@@ -871,9 +871,17 @@ public sealed class ProcessoSeletivoController : ControllerBase
     }
 
     /// <summary>
-    /// Consulta a conformidade estrutural do processo (CA-07): checklist com
-    /// cada item obrigatório marcado ok/pendente, sem alterar o processo.
+    /// Consulta a conformidade ESTRUTURAL do processo (CA-07, issue #1092): checklist
+    /// bicondicional com os quatro gates estruturais de <c>Publicar</c>/<c>Retificar</c> — todo
+    /// item <c>Ok</c> se e somente se nenhum dos quatro gates tem pendência. Não altera o
+    /// processo.
     /// </summary>
+    /// <remarks>
+    /// <b>Não é "publicável".</b> Mesmo com todos os itens <c>Ok</c>, a publicação ainda pode
+    /// recusar por conformidade LEGAL (<see cref="ObterConformidadeLegal"/>), documento
+    /// confirmado, tipo de ato e outras leituras request-specific que só o comando de publicação
+    /// avalia — este checklist cobre só a publicabilidade estrutural do agregado.
+    /// </remarks>
     [HttpGet("{id:guid}/conformidade")]
     [VendorMediaType(Resource = "conformidade-processo-seletivo", Versions = [1])]
     [ProducesResponseType(typeof(ConformidadeProcessoSeletivoDto), StatusCodes.Status200OK)]

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Application/DTOs/ConformidadeProcessoSeletivoDto.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Application/DTOs/ConformidadeProcessoSeletivoDto.cs
@@ -1,21 +1,32 @@
 namespace Unifesspa.UniPlus.Selecao.Application.DTOs;
 
 /// <summary>
-/// Veredicto de um item obrigatório do checklist de conformidade do
-/// <c>ProcessoSeletivo</c> (Story #758, CA-07).
+/// Veredicto de um item do checklist de conformidade ESTRUTURAL do <c>ProcessoSeletivo</c>
+/// (Story #758, CA-07, issue #1092).
 /// </summary>
 public sealed record ItemConformidadeDto(string Item, bool Ok);
 
 /// <summary>
-/// Checklist de conformidade estrutural do <c>ProcessoSeletivo</c> (CA-07):
-/// cada dimensão estruturalmente OBRIGATÓRIA marcada ok/pendente, sem alterar
-/// o processo. Cobre Etapas (1..*), Oferta de atendimento especializado (1),
-/// Distribuição de vagas (1..*) e Classificação (1 — 15º bloco canônico).
-/// Bônus regional (0..1) e critérios de desempate (0..*) são deliberadamente
-/// opcionais na modelagem (P-B) e NÃO entram neste checklist — a ausência de
-/// bônus/desempate é um estado válido (RN05: ausência de bônus = sem bônus),
-/// não uma pendência.
+/// Checklist de conformidade ESTRUTURAL do <c>ProcessoSeletivo</c> (CA-07, issue #1092):
+/// bicondicional com os QUATRO gates estruturais que <c>Publicar</c>/<c>Retificar</c> aplicam —
+/// completude dos itens obrigatórios, coerência do cronograma, cobertura da cascata de
+/// remanejamento e as checagens de pré-canonicalização (exigências documentais, consequência de
+/// indeferimento, referência temporal de fatos, regras de derivação e o grafo de dependência
+/// conjunto). Nenhum item novo em <c>ItemConformidadeDto</c>; a leitura não altera o processo.
 /// </summary>
+/// <remarks>
+/// <b>Não é "publicável".</b> Todos os itens <c>Ok</c> significa que o agregado está
+/// estruturalmente completo e coerente — a publicação ainda pode recusar por conformidade legal
+/// (<c>GET /conformidade-legal</c>), documento confirmado, tipo de ato e outras leituras
+/// request-specific que só o comando de publicação avalia.
+/// <para>
+/// Bônus regional (0..1) e critérios de desempate (0..*) são deliberadamente opcionais na
+/// modelagem (P-B) e NÃO entram neste checklist — a ausência de bônus/desempate é um estado
+/// válido (RN05: ausência de bônus = sem bônus), não uma pendência. Etapa também deixou de ser
+/// item incondicional (Story #851 §3.5): um processo sem prova (SiSU, <c>CLASSIFICACAO-IMPORTADA</c>)
+/// publica sem etapa quando o cronograma é coerente.
+/// </para>
+/// </remarks>
 public sealed record ConformidadeProcessoSeletivoDto(
     Guid ProcessoSeletivoId,
     IReadOnlyList<ItemConformidadeDto> Itens);

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Application/Queries/ProcessosSeletivos/ObterConformidadeProcessoSeletivoQueryHandler.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Application/Queries/ProcessosSeletivos/ObterConformidadeProcessoSeletivoQueryHandler.cs
@@ -13,9 +13,10 @@ using DTOs;
 /// legais configuráveis aplicáveis ao processo.
 /// </summary>
 /// <remarks>
-/// O checklist em si vive em <c>ProcessoSeletivo.AvaliarConformidade()</c>
-/// (Domain) — reusado também pelo gate de <c>Publicar</c> (Story #759 CA-03),
-/// para que a leitura pública e o gate de publicação nunca divirjam.
+/// O checklist em si vive em <c>ProcessoSeletivo.AvaliarConformidade()</c> (Domain) — bicondicional
+/// com os QUATRO gates estruturais que <c>Publicar</c>/<c>Retificar</c> aplicam (issue #1092), não
+/// só o primeiro. Este handler apenas mapeia; a fonte única evita que a leitura pública e os gates
+/// de publicação divirjam.
 /// </remarks>
 public static class ObterConformidadeProcessoSeletivoQueryHandler
 {

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Domain/Entities/ProcessoSeletivo.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Domain/Entities/ProcessoSeletivo.cs
@@ -1329,34 +1329,30 @@ public sealed class ProcessoSeletivo : SoftDeletableEntity
             .Any(m => m.NaturezaLegal == NaturezaLegalModalidade.CotaReservada);
 
     /// <summary>
-    /// Checklist de conformidade estrutural (Story #758 CA-07; reusado por
-    /// <see cref="Publicar"/>, Story #759 CA-03) — cobre as dimensões
-    /// estruturalmente OBRIGATÓRIAS do agregado: Oferta de atendimento
-    /// especializado (1), Distribuição de vagas (1..*), Classificação (1) e
-    /// Cronograma de fases (1..*, Story #851). Bônus regional (0..1) e
-    /// critérios de desempate (0..*) são deliberadamente opcionais e NÃO
-    /// entram — a ausência é um estado válido (RN05: ausência de bônus = sem
-    /// bônus), não uma pendência. Única fonte de verdade do checklist: tanto
-    /// <c>ObterConformidadeProcessoSeletivoQueryHandler</c> quanto
-    /// <see cref="Publicar"/> chamam este método, nunca duplicam a lista.
+    /// Os itens do PRIMEIRO gate estrutural — <see cref="PendenciaDeConformidade"/> (Story #758
+    /// CA-07) — as dimensões estruturalmente OBRIGATÓRIAS do agregado: Oferta de atendimento
+    /// especializado (1), Distribuição de vagas (1..*), Classificação (1) e Cronograma de fases
+    /// (1..*, Story #851). Bônus regional (0..1) e critérios de desempate (0..*) são
+    /// deliberadamente opcionais e NÃO entram — a ausência é um estado válido (RN05: ausência de
+    /// bônus = sem bônus), não uma pendência.
     /// </summary>
     /// <remarks>
     /// <b>"Etapas" deixou de ser item incondicional (Story #851 §3.5).</b> Um processo
     /// sem prova (SiSU, <c>CLASSIFICACAO-IMPORTADA</c>) publica sem etapa — a fase que
     /// agrupa etapas existe se e somente se há etapa, e essa bicondicional é gate à
-    /// parte (<see cref="PendenciaDoCronograma"/>), não item do checklist booleano. O
-    /// que sobrevive aqui é a exigência de <see cref="RegraCalculoCodigo.FormulaMediaPonderada"/>:
-    /// sob essa fórmula, o divisor da média (<see cref="CalcularDivisorMedia"/>) tem de
-    /// ser maior que zero. Sob <see cref="RegraCalculoCodigo.ClassificacaoImportada"/>, a
-    /// classificação dispensa etapa, fórmula e precisão locais — nenhum item aqui.
-    /// </remarks>
-    /// <summary>
-    /// Os itens estruturais de conformidade — a fonte que <see cref="PendenciaDeConformidade"/>
-    /// agrega no <c>DomainError</c> genérico. Extraído de <see cref="AvaliarConformidade"/> na
-    /// Story #575 (achado de revisão de plano): a cascata de remanejamento tem erro NOMEADO
+    /// parte (<see cref="PendenciaDoCronograma"/>), projetada em <see cref="AvaliarConformidade"/>
+    /// por predicados próprios, não aqui. O que sobrevive aqui é a exigência de
+    /// <see cref="RegraCalculoCodigo.FormulaMediaPonderada"/>: sob essa fórmula, o divisor da
+    /// média (<see cref="CalcularDivisorMedia"/>) tem de ser maior que zero. Sob
+    /// <see cref="RegraCalculoCodigo.ClassificacaoImportada"/>, a classificação dispensa etapa,
+    /// fórmula e precisão locais — nenhum item aqui.
+    /// <para>
+    /// Fonte que <see cref="PendenciaDeConformidade"/> agrega no <c>DomainError</c> genérico
+    /// (Story #575, achado de revisão de plano): a cascata de remanejamento tem erro NOMEADO
     /// próprio (<see cref="PendenciaDaCascata"/>) e não pode entrar nesta lista, senão o
     /// agregador genérico intercepta o erro específico antes que ele seja alcançado.
-    /// </summary>
+    /// </para>
+    /// </remarks>
     private List<ItemConformidade> ItensEstruturaisDeConformidade()
     {
         List<ItemConformidade> itens =
@@ -1385,13 +1381,69 @@ public sealed class ProcessoSeletivo : SoftDeletableEntity
     }
 
     /// <summary>
-    /// O checklist completo que <c>GET /conformidade</c> exibe — itens estruturais mais o item
-    /// de exibição da cascata de remanejamento (Story #575). O item da cascata NUNCA alimenta
-    /// <see cref="PendenciaDeConformidade"/>: o erro específico, nomeando oferta e modalidade,
-    /// só existe via <see cref="PendenciaDaCascata"/>.
+    /// Checklist de conformidade ESTRUTURAL do agregado (issue #1092): bicondicional com os
+    /// QUATRO gates que <see cref="Publicar"/>/<see cref="SucederVersao"/> aplicam, nesta ordem
+    /// — <see cref="PendenciaDeConformidade"/>, <see cref="PendenciaDoCronograma"/>,
+    /// <see cref="PendenciaDaCascata"/> e <see cref="PendenciaPreCanonicalizacao"/>. Todos os
+    /// itens ficam <see langword="true"/> se e somente se os quatro gates não têm pendência —
+    /// não existe estado em que este checklist declare tudo <c>Ok</c> e a publicação recuse por
+    /// razão estrutural.
     /// </summary>
+    /// <remarks>
+    /// <b>Delimitação — "estrutural" não é "publicável".</b> Mesmo com os quatro gates verdes, a
+    /// publicação ainda pode recusar por conformidade LEGAL (motor data-driven, <c>GET
+    /// /conformidade-legal</c>), documento confirmado, tipo de ato e outras leituras
+    /// request-specific que só o command handler de publicação avalia (ADR-0109). Este método
+    /// cobre só a publicabilidade ESTRUTURAL do agregado, nunca o ensaio completo do command
+    /// handler.
+    /// <para>
+    /// <b>Sem segunda lista de predicados.</b> Cada item abaixo vem de um predicado privado
+    /// NOMEADO que o gate correspondente TAMBÉM chama (os <c>Ha*</c> de
+    /// <see cref="PendenciaDoCronograma"/>, os <c>Existe*</c> de <see cref="PendenciaDaCascata"/>
+    /// e da coerência de indeferimento, os <c>ReferenciaTemporalFatos*</c>, e os sub-gates de
+    /// <see cref="PendenciaPreCanonicalizacao"/> chamados diretamente) — o gate escolhe a
+    /// PRIMEIRA falha na precedência que <see cref="Publicar"/> já fixa; este método projeta
+    /// TODOS os vereditos. Uma razão nova acrescentada a um predicado compartilhado aparece nos
+    /// dois ao mesmo tempo, por construção — não há um segundo <c>if</c> para lembrar de manter
+    /// sincronizado.
+    /// </para>
+    /// <para>
+    /// Ordem estável: a ordem dos itens é a ordem de declaração abaixo, nunca a ordem de
+    /// iteração de uma coleção do EF.
+    /// </para>
+    /// </remarks>
     public IReadOnlyList<ItemConformidade> AvaliarConformidade() =>
-        [.. ItensEstruturaisDeConformidade(), new ItemConformidade("Cascata de remanejamento", PendenciaDaCascata() is null)];
+    [
+        .. ItensEstruturaisDeConformidade(),
+        new ItemConformidade("Cascata de remanejamento", PendenciaDaCascata() is null),
+
+        // ── PendenciaDoCronograma (Story #851 §3.4/§3.5) ──
+        new ItemConformidade("Cronograma: fase que agrupa etapas só quando há etapa pontuada", !HaFaseDeAvaliacaoSemEtapa()),
+        new ItemConformidade("Cronograma: etapa pontuada tem fase que agrupa etapas", !HaEtapaSemFaseDeAvaliacao()),
+        new ItemConformidade("Cronograma: inscrição própria tem fase que coleta inscrição", !HaInscricaoPropriaSemFaseDeColeta()),
+        new ItemConformidade("Cronograma: vagas ofertadas têm fase que produz resultado", !HaVagasSemFaseQueProduzResultado()),
+
+        // ── PendenciaDaCascata, detalhamento por razão (RN-CASCATA-1/2/2b/3, Story #575) ──
+        new ItemConformidade("Cascata: modalidade SegueCascata usa a regra de distribuição federal", !ExisteCascataForaDoRegimeFederal()),
+        new ItemConformidade("Cascata: origem SegueCascata declarada na cascata de remanejamento", !ExisteCascataOrigemAusente()),
+        new ItemConformidade("Cascata: fallback e destinos resolvíveis nas modalidades ofertadas", !ExisteCascataFallbackNaoSelecionadoNaOferta()),
+        new ItemConformidade("Cascata: origem declarada corresponde a modalidade SegueCascata ofertada", !ExisteCascataOrigemNaoSegueCascata()),
+        new ItemConformidade("Cascata: destino declarado corresponde a modalidade ofertada", !ExisteCascataDestinoDesconhecido()),
+
+        // ── PendenciaPreCanonicalizacao, na mesma ordem do gate (Story #554/#920/#927/#928) ──
+        new ItemConformidade("Exigência documental: sem CONDICIONAL vazia que determina resultado", PendenciaDasExigenciasDocumentais() is null),
+        new ItemConformidade("Consequência de indeferimento: REMOVE_VANTAGEM com vantagem viva (exigência)", !ExisteExigenciaRemoveVantagemSemVantagemViva()),
+        new ItemConformidade("Consequência de indeferimento: coerente com a ação da vaga (exigência)", !ExisteExigenciaConsequenciaIncoerenteComAcaoDaVaga()),
+        new ItemConformidade("Consequência de indeferimento: REMOVE_VANTAGEM com vantagem viva (grupo)", !ExisteGrupoRemoveVantagemSemVantagemViva()),
+        new ItemConformidade("Consequência de indeferimento: coerente com a ação da vaga (grupo)", !ExisteGrupoConsequenciaIncoerenteComAcaoDaVaga()),
+        new ItemConformidade("Referência temporal de fatos: configurada quando há gatilho por faixa etária", !ReferenciaTemporalFatosAusenteQuandoExigida()),
+        new ItemConformidade("Referência temporal de fatos: fase âncora pertence ao cronograma", !ReferenciaTemporalFatosFaseNaoPertenceAoCronograma()),
+        new ItemConformidade("Referência temporal de fatos: extremo da fase âncora definido", !ReferenciaTemporalFatosExtremoDaFaseAusente()),
+        new ItemConformidade("Referência temporal de fatos: fase de coleta com Fim definido para FIM_INSCRICAO", !ReferenciaTemporalFatosFimInscricaoIndisponivel()),
+        new ItemConformidade("Regras de derivação: fatos citados existem no processo", PendenciaDeFatosCitados() is null),
+        new ItemConformidade("Regras de derivação: código contribuído pertence ao domínio ofertado", PendenciaDoDominioDeContribuicao() is null),
+        new ItemConformidade("Grafo de dependência conjunto: sem ciclo", PendenciaDoGrafoConjunto() is null),
+    ];
 
     /// <summary>Grupos <c>OU</c>/<c>N-de</c> com <see cref="NoExigencia.Consequencia"/> própria (Story #920) — cada um precisa de ≥1 <see cref="NoExigenciaBaseLegal"/> <see cref="StatusBaseLegal.Resolvido"/>, mesma semântica de <see cref="Services.ValidadorBaseLegalExigencias"/> para folha.</summary>
     private bool GruposComConsequenciaTemBaseLegalResolvida() =>
@@ -1458,7 +1510,7 @@ public sealed class ProcessoSeletivo : SoftDeletableEntity
 
             // RN-CASCATA-2b: SegueCascata só é coberta pela cascata única do processo quando a
             // oferta usa o regime federal — fora dele, a cascata não tem o que validar.
-            if (oferta.RegraDistribuicao.Codigo != RegraDistribuicaoVagasCodigo.Lei12711)
+            if (OfertaForaDoRegimeFederal(oferta))
             {
                 return new DomainError(
                     "ProcessoSeletivo.CascataForaDoRegimeFederal",
@@ -1472,9 +1524,7 @@ public sealed class ProcessoSeletivo : SoftDeletableEntity
                     $"A oferta {oferta.OfertaCursoOrigemId} tem modalidade \"{modalidadesSegueCascata[0].Codigo}\" com SegueCascata, mas o processo não tem cascata de remanejamento configurada.");
             }
 
-            HashSet<string> codigosDaOferta = new(oferta.Modalidades.Select(static m => m.Codigo), StringComparer.Ordinal);
-
-            if (!codigosDaOferta.Contains(Cascata.FallbackCodigo))
+            if (FallbackNaoSelecionadoNaOferta(oferta, Cascata.FallbackCodigo))
             {
                 return new DomainError(
                     "ProcessoSeletivo.CascataFallbackNaoSelecionadoNaOferta",
@@ -1483,22 +1533,14 @@ public sealed class ProcessoSeletivo : SoftDeletableEntity
 
             foreach (ModalidadeSelecionada modalidade in modalidadesSegueCascata)
             {
-                bool temDestinoResolvivelNaOferta = Cascata.Destinos
-                    .Where(d => string.Equals(d.ModalidadeOrigemCodigo, modalidade.Codigo, StringComparison.Ordinal))
-                    .OrderBy(static d => d.Ordem)
-                    .Any(d => codigosDaOferta.Contains(d.ModalidadeDestinoCodigo));
-
-                bool origemDeclaradaNaCascata = Cascata.Destinos
-                    .Any(d => string.Equals(d.ModalidadeOrigemCodigo, modalidade.Codigo, StringComparison.Ordinal));
-
-                if (!origemDeclaradaNaCascata)
+                if (OrigemNaoDeclaradaNaCascata(modalidade.Codigo))
                 {
                     return new DomainError(
                         "ProcessoSeletivo.CascataOrigemAusente",
                         $"A oferta {oferta.OfertaCursoOrigemId} tem modalidade \"{modalidade.Codigo}\" com SegueCascata, mas a cascata não declara nenhum destino para ela.");
                 }
 
-                if (!temDestinoResolvivelNaOferta)
+                if (DestinoDaOrigemNaoResolvivelNaOferta(oferta, modalidade.Codigo))
                 {
                     return new DomainError(
                         "ProcessoSeletivo.CascataFallbackNaoSelecionadoNaOferta",
@@ -1549,22 +1591,154 @@ public sealed class ProcessoSeletivo : SoftDeletableEntity
         return null;
     }
 
+    /// <summary>A oferta exige a cascata única do processo: tem ≥1 modalidade SegueCascata (RN-CASCATA-2b).</summary>
+    private static bool OfertaExigeCascata(ConfiguracaoDistribuicaoVagas oferta) =>
+        oferta.Modalidades.Any(static m => m.RegraRemanejamento == RegraRemanejamentoModalidade.SegueCascata);
+
+    /// <summary>A oferta não usa o regime federal (Lei 12.711/2012) — condição de <c>CascataForaDoRegimeFederal</c>.</summary>
+    private static bool OfertaForaDoRegimeFederal(ConfiguracaoDistribuicaoVagas oferta) =>
+        oferta.RegraDistribuicao.Codigo != RegraDistribuicaoVagasCodigo.Lei12711;
+
+    /// <summary>O fallback da cascata não é modalidade selecionada na oferta — condição de <c>CascataFallbackNaoSelecionadoNaOferta</c> (nível oferta).</summary>
+    private static bool FallbackNaoSelecionadoNaOferta(ConfiguracaoDistribuicaoVagas oferta, string fallbackCodigo) =>
+        !oferta.Modalidades.Select(static m => m.Codigo).Contains(fallbackCodigo, StringComparer.Ordinal);
+
+    /// <summary>A cascata não declara nenhum destino para a origem — condição de <c>CascataOrigemAusente</c> (nível modalidade).</summary>
+    private bool OrigemNaoDeclaradaNaCascata(string modalidadeOrigemCodigo) =>
+        Cascata is not null
+        && !Cascata.Destinos.Any(d => string.Equals(d.ModalidadeOrigemCodigo, modalidadeOrigemCodigo, StringComparison.Ordinal));
+
+    /// <summary>Nenhum destino declarado da origem é modalidade selecionada NESTA oferta — condição de <c>CascataFallbackNaoSelecionadoNaOferta</c> (nível modalidade).</summary>
+    private bool DestinoDaOrigemNaoResolvivelNaOferta(ConfiguracaoDistribuicaoVagas oferta, string modalidadeOrigemCodigo)
+    {
+        if (Cascata is null)
+        {
+            return false;
+        }
+
+        HashSet<string> codigosDaOferta = new(oferta.Modalidades.Select(static m => m.Codigo), StringComparer.Ordinal);
+        return !Cascata.Destinos
+            .Where(d => string.Equals(d.ModalidadeOrigemCodigo, modalidadeOrigemCodigo, StringComparison.Ordinal))
+            .OrderBy(static d => d.Ordem)
+            .Any(d => codigosDaOferta.Contains(d.ModalidadeDestinoCodigo));
+    }
+
     /// <summary>
-    /// Pendências do cronograma que não cabem no checklist booleano de
-    /// <see cref="AvaliarConformidade"/> — cada uma tem o seu próprio <c>DomainError</c>
+    /// Existe alguma oferta com modalidade SegueCascata sob regime não-federal — mesmo predicado
+    /// de <see cref="OfertaForaDoRegimeFederal"/> que o gate usa, agregado sobre TODAS as ofertas
+    /// (não só a primeira) para o item do checklist estrutural.
+    /// </summary>
+    private bool ExisteCascataForaDoRegimeFederal() =>
+        _distribuicaoVagas.Any(o => OfertaExigeCascata(o) && OfertaForaDoRegimeFederal(o));
+
+    /// <summary>Existe alguma origem SegueCascata (cascata ausente, ou destino não declarado) alcançável por uma oferta federal.</summary>
+    private bool ExisteCascataOrigemAusente()
+    {
+        foreach (ConfiguracaoDistribuicaoVagas oferta in _distribuicaoVagas)
+        {
+            if (!OfertaExigeCascata(oferta) || OfertaForaDoRegimeFederal(oferta))
+            {
+                continue;
+            }
+
+            if (Cascata is null)
+            {
+                return true;
+            }
+
+            if (oferta.Modalidades
+                .Where(static m => m.RegraRemanejamento == RegraRemanejamentoModalidade.SegueCascata)
+                .Any(m => OrigemNaoDeclaradaNaCascata(m.Codigo)))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>Existe fallback ou destino não resolvível numa oferta federal que exige cascata.</summary>
+    private bool ExisteCascataFallbackNaoSelecionadoNaOferta()
+    {
+        foreach (ConfiguracaoDistribuicaoVagas oferta in _distribuicaoVagas)
+        {
+            if (!OfertaExigeCascata(oferta) || OfertaForaDoRegimeFederal(oferta) || Cascata is null)
+            {
+                continue;
+            }
+
+            if (FallbackNaoSelecionadoNaOferta(oferta, Cascata.FallbackCodigo))
+            {
+                return true;
+            }
+
+            if (oferta.Modalidades
+                .Where(static m => m.RegraRemanejamento == RegraRemanejamentoModalidade.SegueCascata)
+                .Any(m => !OrigemNaoDeclaradaNaCascata(m.Codigo) && DestinoDaOrigemNaoResolvivelNaOferta(oferta, m.Codigo)))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>Existe origem declarada na cascata que nenhuma oferta do processo marca como SegueCascata.</summary>
+    private bool ExisteCascataOrigemNaoSegueCascata()
+    {
+        if (Cascata is null)
+        {
+            return false;
+        }
+
+        HashSet<string> todasAsOrigensSegueCascata = new(
+            _distribuicaoVagas.SelectMany(static o => o.Modalidades)
+                .Where(static m => m.RegraRemanejamento == RegraRemanejamentoModalidade.SegueCascata)
+                .Select(static m => m.Codigo),
+            StringComparer.Ordinal);
+
+        return Cascata.Destinos
+            .Select(static d => d.ModalidadeOrigemCodigo)
+            .Distinct(StringComparer.Ordinal)
+            .Any(origem => !todasAsOrigensSegueCascata.Contains(origem));
+    }
+
+    /// <summary>Existe destino declarado na cascata que não é modalidade selecionada em nenhuma oferta do processo.</summary>
+    private bool ExisteCascataDestinoDesconhecido()
+    {
+        if (Cascata is null)
+        {
+            return false;
+        }
+
+        HashSet<string> todosOsCodigosOfertados = new(
+            _distribuicaoVagas.SelectMany(static o => o.Modalidades).Select(static m => m.Codigo),
+            StringComparer.Ordinal);
+
+        return Cascata.Destinos.Any(d => !todosOsCodigosOfertados.Contains(d.ModalidadeDestinoCodigo));
+    }
+
+    /// <summary>
+    /// Pendências do cronograma que não cabem no checklist booleano ORIGINAL de
+    /// <see cref="PendenciaDeConformidade"/> — cada uma tem o seu próprio <c>DomainError</c>
     /// nomeado (Story #851 §3.4/§3.5, CA-11/CA-13/CA-14). Chamado por
     /// <see cref="Publicar"/> e por <see cref="SucederVersao"/> (Retificar/FecharRetificacao),
     /// sempre <b>depois</b> de <see cref="PendenciaDeConformidade"/>.
     /// </summary>
+    /// <remarks>
+    /// Issue #1092: cada <c>if</c> abaixo testa um predicado privado nomeado
+    /// (<c>Ha*</c>) em vez de uma expressão inline — <see cref="AvaliarConformidade"/>
+    /// chama os MESMOS quatro predicados para projetar um item por razão. A precedência
+    /// (qual falha é devolvida primeiro) continua decidida só aqui, pela ORDEM dos
+    /// <c>if</c>; o checklist não reordena nem filtra — só projeta todos os quatro.
+    /// </remarks>
     private DomainError? PendenciaDoCronograma()
     {
-        bool existeFaseDeAvaliacao = _cronogramaFases.Any(static f => f.AgrupaEtapas);
-
         // §3.5, direção "fase de avaliação sem etapa" — defesa em profundidade: o mesmo
         // sentido já é bloqueado eagerly em DefinirCronogramaFases, mas uma etapa
         // removida DEPOIS (via DefinirEtapas) deixaria uma fase de avaliação órfã sem
         // que nada a pegasse na hora — o gate de publicação é a rede de segurança.
-        if (existeFaseDeAvaliacao && _etapas.Count == 0)
+        if (HaFaseDeAvaliacaoSemEtapa())
         {
             return new DomainError(
                 "ProcessoSeletivo.AvaliacaoSemEtapa",
@@ -1573,7 +1747,7 @@ public sealed class ProcessoSeletivo : SoftDeletableEntity
 
         // §3.5, direção "etapa sem fase de avaliação" — lazy por natureza (a etapa pode
         // ser declarada depois do cronograma).
-        if (_etapas.Count > 0 && !existeFaseDeAvaliacao)
+        if (HaEtapaSemFaseDeAvaliacao())
         {
             return new DomainError(
                 "ProcessoSeletivo.EtapaSemFaseDeAvaliacao",
@@ -1581,8 +1755,7 @@ public sealed class ProcessoSeletivo : SoftDeletableEntity
         }
 
         // §3.4 — piso mínimo derivado da ORIGEM DOS CANDIDATOS, nunca do tipo.
-        if (OrigemCandidatos == OrigemCandidatos.InscricaoPropria
-            && !_cronogramaFases.Any(static f => f.ColetaInscricao))
+        if (HaInscricaoPropriaSemFaseDeColeta())
         {
             return new DomainError(
                 "ProcessoSeletivo.InscricaoPropriaSemFaseDeColeta",
@@ -1591,8 +1764,7 @@ public sealed class ProcessoSeletivo : SoftDeletableEntity
 
         // §3.4 — havendo vagas ofertadas, o cronograma precisa de ao menos uma fase que
         // produza resultado.
-        bool temVagasOfertadas = _distribuicaoVagas.Any(static d => d.VoBase > 0);
-        if (temVagasOfertadas && !_cronogramaFases.Any(static f => f.ProduzResultado))
+        if (HaVagasSemFaseQueProduzResultado())
         {
             return new DomainError(
                 "ProcessoSeletivo.VagasSemFaseQueProduzResultado",
@@ -1601,6 +1773,22 @@ public sealed class ProcessoSeletivo : SoftDeletableEntity
 
         return null;
     }
+
+    /// <summary>Fase que agrupa etapas existe, mas o processo não tem etapa pontuada (§3.5).</summary>
+    private bool HaFaseDeAvaliacaoSemEtapa() =>
+        _cronogramaFases.Any(static f => f.AgrupaEtapas) && _etapas.Count == 0;
+
+    /// <summary>Etapa pontuada existe, mas nenhuma fase do cronograma agrupa etapas (§3.5).</summary>
+    private bool HaEtapaSemFaseDeAvaliacao() =>
+        _etapas.Count > 0 && !_cronogramaFases.Any(static f => f.AgrupaEtapas);
+
+    /// <summary>Origem InscricaoPropria sem nenhuma fase que colete inscrição (§3.4).</summary>
+    private bool HaInscricaoPropriaSemFaseDeColeta() =>
+        OrigemCandidatos == OrigemCandidatos.InscricaoPropria && !_cronogramaFases.Any(static f => f.ColetaInscricao);
+
+    /// <summary>Há vagas ofertadas (VoBase > 0), mas nenhuma fase do cronograma produz resultado (§3.4).</summary>
+    private bool HaVagasSemFaseQueProduzResultado() =>
+        _distribuicaoVagas.Any(static d => d.VoBase > 0) && !_cronogramaFases.Any(static f => f.ProduzResultado);
 
     /// <summary>
     /// Documentos exigidos, coerência de consequência e referência temporal de fatos —
@@ -1820,18 +2008,14 @@ public sealed class ProcessoSeletivo : SoftDeletableEntity
                 continue;
             }
 
-            if (consequencia == "REMOVE_VANTAGEM" && BonusRegional is null)
+            if (ConsequenciaRemoveVantagemSemVantagemViva(consequencia))
             {
                 return new DomainError(
                     "DocumentoExigido.RemoveVantagemSemVantagemViva",
                     $"A exigência '{exigencia.TipoDocumentoCodigo}' declara REMOVE_VANTAGEM, mas o processo não tem nenhuma vantagem viva (ex.: bônus regional) para remover.");
             }
 
-            string consequenciaComoAcaoDaVaga = NormalizarConsequenciaParaAcaoDaVaga(consequencia);
-            ModalidadeSelecionada? modalidadeIncoerente = ModalidadesAlcancadasPor(exigencia)
-                .FirstOrDefault(modalidade => modalidade.AcaoQuandoIndeferido is { } acao
-                    && !string.Equals(acao, consequenciaComoAcaoDaVaga, StringComparison.Ordinal));
-            if (modalidadeIncoerente is not null)
+            if (ModalidadeIncoerenteComConsequencia(consequencia, ModalidadesAlcancadasPor(exigencia)) is { } modalidadeIncoerente)
             {
                 return new DomainError(
                     "DocumentoExigido.ConsequenciaIncoerenteComAcaoDaVaga",
@@ -1846,18 +2030,14 @@ public sealed class ProcessoSeletivo : SoftDeletableEntity
         {
             string consequenciaDoGrupo = grupo.Consequencia!;
 
-            if (consequenciaDoGrupo == "REMOVE_VANTAGEM" && BonusRegional is null)
+            if (ConsequenciaRemoveVantagemSemVantagemViva(consequenciaDoGrupo))
             {
                 return new DomainError(
                     "NoExigencia.RemoveVantagemSemVantagemViva",
                     $"O grupo '{grupo.Id}' declara REMOVE_VANTAGEM, mas o processo não tem nenhuma vantagem viva (ex.: bônus regional) para remover.");
             }
 
-            string consequenciaDoGrupoComoAcaoDaVaga = NormalizarConsequenciaParaAcaoDaVaga(consequenciaDoGrupo);
-            ModalidadeSelecionada? modalidadeIncoerenteDoGrupo = ModalidadesAlcancadasPor(grupo)
-                .FirstOrDefault(modalidade => modalidade.AcaoQuandoIndeferido is { } acao
-                    && !string.Equals(acao, consequenciaDoGrupoComoAcaoDaVaga, StringComparison.Ordinal));
-            if (modalidadeIncoerenteDoGrupo is not null)
+            if (ModalidadeIncoerenteComConsequencia(consequenciaDoGrupo, ModalidadesAlcancadasPor(grupo)) is { } modalidadeIncoerenteDoGrupo)
             {
                 return new DomainError(
                     "NoExigencia.ConsequenciaIncoerenteComAcaoDaVaga",
@@ -1867,6 +2047,42 @@ public sealed class ProcessoSeletivo : SoftDeletableEntity
 
         return null;
     }
+
+    /// <summary>A consequência é REMOVE_VANTAGEM sem nenhuma vantagem viva no processo (bônus regional, RN05).</summary>
+    private bool ConsequenciaRemoveVantagemSemVantagemViva(string? consequencia) =>
+        consequencia == "REMOVE_VANTAGEM" && BonusRegional is null;
+
+    /// <summary>
+    /// A primeira modalidade alcançada cuja <c>AcaoQuandoIndeferido</c> declarada é incoerente com a
+    /// consequência — ou <see langword="null"/> quando todas as que declaram ação concordam. Devolve a
+    /// ENTIDADE (não um bool) porque tanto o gate (mensagem nomeando oferta/modalidade) quanto o
+    /// checklist (presença) derivam do mesmo cálculo, sem recomputar a busca duas vezes.
+    /// </summary>
+    private static ModalidadeSelecionada? ModalidadeIncoerenteComConsequencia(
+        string consequencia, IEnumerable<ModalidadeSelecionada> modalidadesAlcancadas)
+    {
+        string consequenciaComoAcaoDaVaga = NormalizarConsequenciaParaAcaoDaVaga(consequencia);
+        return modalidadesAlcancadas.FirstOrDefault(modalidade => modalidade.AcaoQuandoIndeferido is { } acao
+            && !string.Equals(acao, consequenciaComoAcaoDaVaga, StringComparison.Ordinal));
+    }
+
+    /// <summary>Existe <see cref="DocumentoExigido"/> (folha) com REMOVE_VANTAGEM sem vantagem viva.</summary>
+    private bool ExisteExigenciaRemoveVantagemSemVantagemViva() =>
+        _documentosExigidos.Any(e => ConsequenciaRemoveVantagemSemVantagemViva(e.ConsequenciaIndeferimento));
+
+    /// <summary>Existe <see cref="DocumentoExigido"/> (folha) com consequência incoerente com a ação de alguma modalidade alcançada.</summary>
+    private bool ExisteExigenciaConsequenciaIncoerenteComAcaoDaVaga() =>
+        _documentosExigidos.Any(e => e.ConsequenciaIndeferimento is { } c
+            && ModalidadeIncoerenteComConsequencia(c, ModalidadesAlcancadasPor(e)) is not null);
+
+    /// <summary>Existe grupo OU/N-de com consequência própria REMOVE_VANTAGEM sem vantagem viva (Story #920).</summary>
+    private bool ExisteGrupoRemoveVantagemSemVantagemViva() =>
+        _nosExigencia.Any(no => no.Tipo == TipoNo.GrupoOu && ConsequenciaRemoveVantagemSemVantagemViva(no.Consequencia));
+
+    /// <summary>Existe grupo OU/N-de com consequência própria incoerente com a ação de alguma modalidade alcançada (Story #920).</summary>
+    private bool ExisteGrupoConsequenciaIncoerenteComAcaoDaVaga() =>
+        _nosExigencia.Any(no => no.Tipo == TipoNo.GrupoOu && no.Consequencia is { } c
+            && ModalidadeIncoerenteComConsequencia(c, ModalidadesAlcancadasPor(no)) is not null);
 
     /// <summary>
     /// Ponte entre os dois vocabulários fechados de "ação de indeferimento" — Story #554
@@ -1918,34 +2134,30 @@ public sealed class ProcessoSeletivo : SoftDeletableEntity
     /// </remarks>
     private DomainError? PendenciaDaReferenciaTemporalFatos()
     {
-        bool existeGatilhoPorFaixaEtaria = _documentosExigidos
-            .SelectMany(static d => d.Condicoes)
-            .Any(static c => string.Equals(c.Fato, "FAIXA_ETARIA", StringComparison.Ordinal));
-
-        if (!existeGatilhoPorFaixaEtaria)
+        if (!ExisteGatilhoPorFaixaEtaria())
         {
             return null;
         }
 
-        if (ReferenciaTemporalFatos is not { } referencia)
+        if (ReferenciaTemporalFatosAusenteQuandoExigida())
         {
             return new DomainError(
                 "ProcessoSeletivo.ReferenciaTemporalFatosAusente",
                 "Existe gatilho por FAIXA_ETARIA, mas nenhuma referência temporal de fatos foi configurada — a publicação não pode resolver a idade do candidato sem fallback silencioso (ADR-0111).");
         }
 
+        ReferenciaTemporalFatos referencia = ReferenciaTemporalFatos!;
+
         if (referencia.Tipo is ReferenciaTipo.InicioFase or ReferenciaTipo.FimFase)
         {
-            FaseCronograma? fase = _cronogramaFases.FirstOrDefault(f => f.Id == referencia.FaseId);
-            if (fase is null)
+            if (ReferenciaTemporalFatosFaseNaoPertenceAoCronograma())
             {
                 return new DomainError(
                     "ProcessoSeletivo.ReferenciaTemporalFatosFaseInexistente",
                     "A fase âncora da referência temporal de fatos não pertence (mais) ao cronograma deste processo.");
             }
 
-            DateTimeOffset? extremo = referencia.Tipo == ReferenciaTipo.InicioFase ? fase.Inicio : fase.Fim;
-            if (extremo is null)
+            if (ReferenciaTemporalFatosExtremoDaFaseAusente())
             {
                 return new DomainError(
                     "ProcessoSeletivo.ReferenciaTemporalFatosExtremoAusente",
@@ -1956,10 +2168,8 @@ public sealed class ProcessoSeletivo : SoftDeletableEntity
         {
             // Achado de revisão (Story #554, PR #903): nada no domínio impede MAIS de uma
             // fase com ColetaInscricao (mesma família de guard já corrigida para
-            // IdadeMaximaEmissao, PR #900) — FirstOrDefault pegava a primeira, mesmo que
-            // outra (com Fim definido) resolvesse a referência. A pergunta certa é
-            // existencial (Any), não posicional.
-            if (!_cronogramaFases.Any(static f => f.ColetaInscricao && f.Fim is not null))
+            // IdadeMaximaEmissao, PR #900) — a pergunta certa é existencial (Any), não posicional.
+            if (ReferenciaTemporalFatosFimInscricaoIndisponivel())
             {
                 return new DomainError(
                     "ProcessoSeletivo.ReferenciaTemporalFatosFimInscricaoIndisponivel",
@@ -1970,6 +2180,36 @@ public sealed class ProcessoSeletivo : SoftDeletableEntity
         // DATA_ESPECIFICA: ReferenciaTemporalFatos.Criar já garante Data presente — nada a checar aqui.
         return null;
     }
+
+    /// <summary>Existe gatilho por FAIXA_ETARIA em algum <see cref="DocumentoExigido"/> — sem ele, a referência temporal é opcional.</summary>
+    private bool ExisteGatilhoPorFaixaEtaria() =>
+        _documentosExigidos.SelectMany(static d => d.Condicoes)
+            .Any(static c => string.Equals(c.Fato, "FAIXA_ETARIA", StringComparison.Ordinal));
+
+    /// <summary>A fase âncora de InicioFase/FimFase — <see langword="null"/> quando o tipo não usa fase ou ela não pertence (mais) ao cronograma.</summary>
+    private FaseCronograma? FaseAncoraDaReferenciaTemporal() =>
+        ReferenciaTemporalFatos is { Tipo: ReferenciaTipo.InicioFase or ReferenciaTipo.FimFase } referencia
+            ? _cronogramaFases.FirstOrDefault(f => f.Id == referencia.FaseId)
+            : null;
+
+    private bool ReferenciaTemporalFatosAusenteQuandoExigida() =>
+        ExisteGatilhoPorFaixaEtaria() && ReferenciaTemporalFatos is null;
+
+    private bool ReferenciaTemporalFatosFaseNaoPertenceAoCronograma() =>
+        ExisteGatilhoPorFaixaEtaria()
+        && ReferenciaTemporalFatos is { Tipo: ReferenciaTipo.InicioFase or ReferenciaTipo.FimFase }
+        && FaseAncoraDaReferenciaTemporal() is null;
+
+    private bool ReferenciaTemporalFatosExtremoDaFaseAusente() =>
+        ExisteGatilhoPorFaixaEtaria()
+        && ReferenciaTemporalFatos is { Tipo: ReferenciaTipo.InicioFase or ReferenciaTipo.FimFase } referencia
+        && FaseAncoraDaReferenciaTemporal() is { } fase
+        && (referencia.Tipo == ReferenciaTipo.InicioFase ? fase.Inicio : fase.Fim) is null;
+
+    private bool ReferenciaTemporalFatosFimInscricaoIndisponivel() =>
+        ExisteGatilhoPorFaixaEtaria()
+        && ReferenciaTemporalFatos is { Tipo: ReferenciaTipo.FimInscricao }
+        && !_cronogramaFases.Any(static f => f.ColetaInscricao && f.Fim is not null);
 
     /// <summary>
     /// Resolve <see cref="ReferenciaTemporalFatos"/> para a <see cref="DateOnly"/> concreta

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Domain/ValueObjects/ItemConformidade.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Domain/ValueObjects/ItemConformidade.cs
@@ -1,11 +1,18 @@
 namespace Unifesspa.UniPlus.Selecao.Domain.ValueObjects;
 
 /// <summary>
-/// Veredicto de um item obrigatório do checklist de conformidade estrutural
-/// do <c>ProcessoSeletivo</c> (<see cref="Entities.ProcessoSeletivo.AvaliarConformidade"/>,
-/// Story #758 CA-07 e Story #759 CA-03). Tipo de Domain — a versão
-/// Application-facing (<c>ItemConformidadeDto</c>) é mapeada a partir deste
-/// no query handler, para que o checklist usado pela leitura pública e o
-/// gate de <c>Publicar</c> nunca divirjam.
+/// Veredicto de um item do checklist de conformidade ESTRUTURAL do <c>ProcessoSeletivo</c>
+/// (<see cref="Entities.ProcessoSeletivo.AvaliarConformidade"/>, Story #758 CA-07, Story #759
+/// CA-03, issue #1092). Tipo de Domain — a versão Application-facing (<c>ItemConformidadeDto</c>)
+/// é mapeada a partir deste no query handler, para que o checklist usado pela leitura pública e
+/// os quatro gates de <c>Publicar</c>/<c>SucederVersao</c> nunca divirjam: <c>AvaliarConformidade</c>
+/// projeta um item por razão de recusa ALCANÇÁVEL nos quatro gates, a partir dos MESMOS predicados
+/// que os gates chamam — nunca uma segunda lista copiada.
 /// </summary>
+/// <remarks>
+/// <b>"Estrutural" não é "publicável".</b> Todo item <see langword="true"/> significa que o
+/// agregado está estruturalmente completo e coerente — não que a publicação vai necessariamente
+/// aceitar. Conformidade legal, documento confirmado e tipo de ato são avaliados à parte
+/// (<c>GET /conformidade-legal</c> e o command handler de publicação), nunca aqui.
+/// </remarks>
 public sealed record ItemConformidade(string Item, bool Ok);

--- a/tests/Unifesspa.UniPlus.Selecao.Application.UnitTests/Queries/ObterConformidadeProcessoSeletivoQueryHandlerTests.cs
+++ b/tests/Unifesspa.UniPlus.Selecao.Application.UnitTests/Queries/ObterConformidadeProcessoSeletivoQueryHandlerTests.cs
@@ -4,6 +4,7 @@ using AwesomeAssertions;
 
 using NSubstitute;
 
+using Unifesspa.UniPlus.Kernel.Results;
 using Unifesspa.UniPlus.Selecao.Application.DTOs;
 using Unifesspa.UniPlus.Selecao.Application.Queries.ProcessosSeletivos;
 using Unifesspa.UniPlus.Selecao.Domain.Entities;
@@ -47,7 +48,69 @@ public sealed class ObterConformidadeProcessoSeletivoQueryHandlerTests
         result.Itens.Should().Contain(i => i.Item == "Cronograma de fases" && !i.Ok);
     }
 
-    [Fact(DisplayName = "Handle com todos os itens obrigatórios configurados devolve checklist sem pendências")]
+    [Fact(DisplayName = "Handle com InscricaoPropria sem fase de coleta NÃO declara o checklist inteiramente verde (issue #1092 — regressão do falso verde)")]
+    public async Task Handle_InscricaoPropriaSemFaseDeColeta_NaoDeclaraChecklistTodoVerde()
+    {
+        // Cenário da issue #1092: PendenciaDoCronograma tem quatro razões, mas antes da correção
+        // só a de "inscrição própria sem fase de coleta" (via item genérico incondicional) nunca
+        // aparecia no checklist — GET /conformidade devolvia tudo Ok enquanto POST /publicacao
+        // recusava com 422. Todas as outras dimensões estão presentes; só falta a fase de coleta.
+        ProcessoSeletivo processo = ProcessoSeletivo.Criar("PS 2026 — Falso Verde", TipoProcesso.SiSU, OrigemCandidatos.InscricaoPropria, Guid.NewGuid(), Unifesspa.UniPlus.Selecao.Domain.ValueObjects.UnidadeAdministradoraSnapshot.Criar("CEPS", "ceps", "Centro de Processos Seletivos", "ADMINISTRATIVA").Value!);
+        processo.DefinirEtapas([], PrecondicaoIfMatch.Ausente).IsSuccess.Should().BeTrue(
+            "Story #851 §3.5: lista vazia é estado válido sob CLASSIFICACAO-IMPORTADA — sem etapa, não precisamos de fase que agrupe etapas");
+        processo.DefinirOfertaAtendimento(OfertaAtendimentoEspecializado.Criar([], [], []).Value!, PrecondicaoIfMatch.Ausente).IsSuccess.Should().BeTrue();
+
+        ModalidadeSelecionada ampla = ModalidadeSelecionada.Criar(
+            Guid.CreateVersion7(), "AC", null, NaturezaLegalModalidade.Ampla, ComposicaoVagasModalidade.ResidualDoVo,
+            null, RegraRemanejamentoModalidade.Nenhuma, null, null, null, [], null, "base legal", quantidadeDeclarada: 50).Value!;
+        ReferenciaRegra regraInstitucional = ReferenciaRegra.Criar(
+            RegraDistribuicaoVagasCodigo.Institucional, "v1", new string('a', 64)).Value!;
+        ConfiguracaoDistribuicaoVagas distribuicao = ConfiguracaoDistribuicaoVagas.Criar(
+            Guid.CreateVersion7(), voBase: 50, pr: 1m, regraInstitucional, regraAjuste: null, referenciaDemografica: null, [ampla]).Value!;
+        processo.DefinirDistribuicaoVagas([distribuicao], PrecondicaoIfMatch.Ausente).IsSuccess.Should().BeTrue();
+
+        ConfiguracaoClassificacao classificacao = ConfiguracaoClassificacao.Criar(
+            ReferenciaRegra.Criar(RegraCalculoCodigo.ClassificacaoImportada, "v1", new string('b', 64)).Value!,
+            null, null,
+            ReferenciaRegra.Criar(RegraOrdemAlocacaoCodigo.AlocacaoOpcoesRn04, "v1", new string('d', 64)).Value!,
+            1, [], baseadoEmEnem: false).Value!;
+        processo.DefinirClassificacao(classificacao, PrecondicaoIfMatch.Ausente).IsSuccess.Should().BeTrue();
+
+        // Fase que PRODUZ RESULTADO (satisfaz "vagas ofertadas"), mas NÃO agrupa etapas (não
+        // precisa — sem etapa) e, sobretudo, NÃO coleta inscrição, embora a origem seja própria.
+        FaseCronograma faseSemColeta = FaseCronograma.Criar(
+            ordem: 1, faseCanonicaOrigemId: Guid.CreateVersion7(), codigo: "RESULTADO_FINAL",
+            donoInstitucional: "CEPS", origemData: OrigemDataFase.Propria,
+            agrupaEtapas: false, permiteComplementacao: false, produzResultado: true, resultadoDefinitivo: true,
+            coletaInscricao: false,
+            inicio: new DateTimeOffset(2026, 1, 1, 0, 0, 0, TimeSpan.Zero), fim: new DateTimeOffset(2026, 1, 31, 0, 0, 0, TimeSpan.Zero),
+            atoProduzidoCodigo: "RESULTADO_FINAL", atoProduzidoEfeitoIrreversivel: false, bancasRequeridas: [], regraRecurso: null).Value!;
+        processo.DefinirCronogramaFases([faseSemColeta], [], PrecondicaoIfMatch.Ausente).IsSuccess.Should().BeTrue();
+
+        IProcessoSeletivoRepository repository = Substitute.For<IProcessoSeletivoRepository>();
+        repository.ObterComConfiguracaoAsync(processo.Id, Arg.Any<CancellationToken>()).Returns(processo);
+
+        ConformidadeProcessoSeletivoDto? result = await ObterConformidadeProcessoSeletivoQueryHandler.Handle(
+            new ObterConformidadeProcessoSeletivoQuery(processo.Id), repository, CancellationToken.None);
+
+        result.Should().NotBeNull();
+        result!.Itens.Should().Contain(
+            i => i.Item == "Cronograma: inscrição própria tem fase que coleta inscrição" && !i.Ok,
+            "a origem é InscricaoPropria e nenhuma fase coleta inscrição — antes da correção este item nem existia, e o checklist devolvia tudo Ok");
+        result.Itens.Should().ContainSingle(i => !i.Ok,
+            "isolar a asserção: só esta razão deveria estar vermelha neste estado — as outras três razões do cronograma e os demais gates estão satisfeitos");
+
+        // A mesma pendência que o checklist agora denuncia é a que Publicar já recusava — as
+        // duas superfícies concordam depois da correção (a prova da bicondicional).
+        Result<VersaoConfiguracao> publicar = processo.Publicar(
+            DadosEdital.Criar("001/2026", new DateOnly(2026, 1, 1), new DateOnly(2026, 1, 31), Guid.CreateVersion7()).Value!,
+            "{}"u8.ToArray(), "1.1", "canonical-json/sha256@v1", new string('a', 64), "teste", TimeProvider.System);
+
+        publicar.IsFailure.Should().BeTrue();
+        publicar.Error!.Code.Should().Be("ProcessoSeletivo.InscricaoPropriaSemFaseDeColeta");
+    }
+
+    [Fact(DisplayName = "Handle com todos os itens obrigatórios configurados devolve checklist sem pendências, e a publicação aceita (bicondicional, issue #1092)")]
     public async Task Handle_TodosOsItens_SemPendencia()
     {
         ProcessoSeletivo processo = ProcessoSeletivo.Criar("PS 2026 — SiSU", TipoProcesso.SiSU, OrigemCandidatos.InscricaoPropria, Guid.NewGuid(), Unifesspa.UniPlus.Selecao.Domain.ValueObjects.UnidadeAdministradoraSnapshot.Criar("CEPS", "ceps", "Centro de Processos Seletivos", "ADMINISTRATIVA").Value!);
@@ -99,5 +162,14 @@ public sealed class ObterConformidadeProcessoSeletivoQueryHandlerTests
 
         result.Should().NotBeNull();
         result!.Itens.Should().OnlyContain(i => i.Ok);
+
+        // issue #1092 — a bicondicional exige mais do que "todas as dimensões presentes": o
+        // checklist inteiramente verde TEM de significar que Publicar aceita. Fora do escopo
+        // estrutural (não afetado aqui): conformidade legal, documento confirmado, tipo de ato.
+        Result<VersaoConfiguracao> publicar = processo.Publicar(
+            DadosEdital.Criar("001/2026", new DateOnly(2026, 1, 1), new DateOnly(2026, 1, 31), Guid.CreateVersion7()).Value!,
+            "{}"u8.ToArray(), "1.1", "canonical-json/sha256@v1", new string('a', 64), "teste", TimeProvider.System);
+
+        publicar.IsSuccess.Should().BeTrue(publicar.Error?.Message);
     }
 }

--- a/tests/Unifesspa.UniPlus.Selecao.Domain.UnitTests/Entities/ConformidadePublicabilidadeEstruturalTests.cs
+++ b/tests/Unifesspa.UniPlus.Selecao.Domain.UnitTests/Entities/ConformidadePublicabilidadeEstruturalTests.cs
@@ -1,0 +1,766 @@
+namespace Unifesspa.UniPlus.Selecao.Domain.UnitTests.Entities;
+
+using System.Text.Json;
+
+using AwesomeAssertions;
+
+using Unifesspa.UniPlus.Kernel.Results;
+using Unifesspa.UniPlus.Selecao.Domain.Entities;
+using Unifesspa.UniPlus.Selecao.Domain.Enums;
+using Unifesspa.UniPlus.Selecao.Domain.ValueObjects;
+
+/// <summary>
+/// A matriz da issue #1092: pareia cada um dos códigos de recusa alcançáveis nos quatro gates
+/// estruturais (<c>PendenciaDeConformidade</c>, <c>PendenciaDoCronograma</c>,
+/// <c>PendenciaDaCascata</c>, <c>PendenciaPreCanonicalizacao</c>) com o item vermelho
+/// correspondente em <see cref="ProcessoSeletivo.AvaliarConformidade"/>, e confirma que
+/// <see cref="ProcessoSeletivo.Publicar"/> continua recusando com o MESMO <c>DomainError</c> —
+/// coletar todos os vereditos para exibição não pode mudar qual é a primeira falha.
+/// </summary>
+/// <remarks>
+/// Cada teste isola UMA razão a partir de um processo estruturalmente conforme
+/// (<see cref="ProcessoConforme"/>) — as contraprovas ao final cobrem os ramos mais fáceis de
+/// confundir com falso vermelho (SiSU/classificação importada sem etapa, cronograma coerente,
+/// cascata não aplicável, ausência de gatilho por faixa etária).
+/// </remarks>
+public sealed class ConformidadePublicabilidadeEstruturalTests
+{
+    private static readonly string HashFixo = new('a', 64);
+
+    private static ReferenciaRegra Regra(string codigo, char semente) =>
+        ReferenciaRegra.Criar(codigo, "v1", new string(semente, 64)).Value!;
+
+    private static DadosEdital Dados() => DadosEdital.Criar(
+        "001/2026", new DateOnly(2026, 1, 1), new DateOnly(2026, 1, 31), Guid.CreateVersion7()).Value!;
+
+    private static Result<VersaoConfiguracao> Publicar(ProcessoSeletivo processo) => processo.Publicar(
+        Dados(), "{}"u8.ToArray(), "1.1", "canonical-json/sha256@v1", HashFixo, "teste", TimeProvider.System);
+
+    private static ConfiguracaoClassificacao ClassificacaoImportada() => ConfiguracaoClassificacao.Criar(
+        Regra(RegraCalculoCodigo.ClassificacaoImportada, 'b'), null, null,
+        Regra(RegraOrdemAlocacaoCodigo.AlocacaoOpcoesRn04, 'c'), 1, [], baseadoEmEnem: false).Value!;
+
+    private static ModalidadeSelecionada Modalidade(
+        string codigo,
+        NaturezaLegalModalidade natureza,
+        RegraRemanejamentoModalidade remanejamento,
+        int? quantidadeDeclarada,
+        string? acaoQuandoIndeferido = null) =>
+        ModalidadeSelecionada.Criar(
+            Guid.CreateVersion7(), codigo, null, natureza,
+            natureza == NaturezaLegalModalidade.Ampla ? ComposicaoVagasModalidade.ResidualDoVo : ComposicaoVagasModalidade.DentroDoVr,
+            null, remanejamento, null, null, null, [], acaoQuandoIndeferido, "base legal", quantidadeDeclarada).Value!;
+
+    private static ConfiguracaoDistribuicaoVagas DistribuicaoAmpla(int voBase, string? acaoQuandoIndeferido = null) =>
+        ConfiguracaoDistribuicaoVagas.Criar(
+            Guid.CreateVersion7(), voBase, pr: 1m,
+            Regra(RegraDistribuicaoVagasCodigo.Institucional, 'a'), regraAjuste: null, referenciaDemografica: null,
+            [Modalidade("AC", NaturezaLegalModalidade.Ampla, RegraRemanejamentoModalidade.Nenhuma, voBase, acaoQuandoIndeferido)]).Value!;
+
+    /// <summary>Fase mínima e coerente: não agrupa etapas (dispensável sem prova), produz resultado, não coleta inscrição.</summary>
+    private static FaseCronograma FaseBase(bool coletaInscricao = false) => FaseCronograma.Criar(
+        1, Guid.CreateVersion7(), "RESULTADO_FINAL", "CEPS", OrigemDataFase.Delegada,
+        agrupaEtapas: false, permiteComplementacao: false, produzResultado: true, resultadoDefinitivo: true,
+        coletaInscricao, inicio: null, fim: null,
+        atoProduzidoCodigo: "RESULTADO_FINAL", atoProduzidoEfeitoIrreversivel: false,
+        bancasRequeridas: [], regraRecurso: null).Value!;
+
+    /// <summary>
+    /// Processo estruturalmente conforme aos QUATRO gates: sem etapa (ImportacaoExterna +
+    /// ClassificacaoImportada dispensam prova), atendimento, distribuição, classificação e
+    /// cronograma coerente com uma única fase que produz resultado. Sem cascata (nenhuma
+    /// modalidade SegueCascata) e sem exigências/regras de derivação/fatos coletados — os quatro
+    /// gates ficam vazios/Ok até que o teste acrescente a única razão que quer isolar.
+    /// </summary>
+    private static ProcessoSeletivo ProcessoConforme(IReadOnlyList<ConfiguracaoDistribuicaoVagas>? distribuicao = null)
+    {
+        ProcessoSeletivo processo = ProcessoSeletivo.Criar(
+            "PS Matriz Estrutural", TipoProcesso.SiSU, OrigemCandidatos.ImportacaoExterna, Guid.NewGuid(),
+            Unifesspa.UniPlus.Selecao.Domain.ValueObjects.UnidadeAdministradoraSnapshot.Criar(
+                "CEPS", "ceps", "Centro de Processos Seletivos", "ADMINISTRATIVA").Value!);
+
+        processo.DefinirOfertaAtendimento(OfertaAtendimentoEspecializado.Criar([], [], []).Value!, PrecondicaoIfMatch.Ausente)
+            .IsSuccess.Should().BeTrue();
+        processo.DefinirDistribuicaoVagas(distribuicao ?? [DistribuicaoAmpla(10)], PrecondicaoIfMatch.Ausente)
+            .IsSuccess.Should().BeTrue();
+        processo.DefinirClassificacao(ClassificacaoImportada(), PrecondicaoIfMatch.Ausente)
+            .IsSuccess.Should().BeTrue();
+        processo.DefinirCronogramaFases([FaseBase()], [], PrecondicaoIfMatch.Ausente)
+            .IsSuccess.Should().BeTrue();
+
+        return processo;
+    }
+
+    private static DocumentoExigidoBaseLegal BaseLegalResolvida() => DocumentoExigidoBaseLegal.Criar(
+        "Lei 12.711/2012, art. 3º", TipoAbrangencia.InternaEdital, StatusBaseLegal.Resolvido, null).Value!;
+
+    private static NoExigenciaBaseLegal BaseLegalDoGrupo(StatusBaseLegal status) =>
+        NoExigenciaBaseLegal.Criar("Lei 12.711/2012, art. 3º", TipoAbrangencia.Federal, status, null).Value!;
+
+    // ══════════════════════════════════════════════════════════════════════════════════════
+    // PendenciaDoCronograma — quatro razões (§3.4/§3.5)
+    // ══════════════════════════════════════════════════════════════════════════════════════
+
+    [Fact(DisplayName = "Cronograma: fase de avaliação sem etapa pontuada — item vermelho e Publicar recusa com AvaliacaoSemEtapa")]
+    public void Cronograma_FaseDeAvaliacaoSemEtapa()
+    {
+        ProcessoSeletivo processo = ProcessoConforme();
+        // DefinirCronogramaFases bloqueia EAGERLY uma fase que agrupa etapas sem etapa nenhuma —
+        // por isso a etapa é definida ANTES (torna a fase agrupa-etapas válida na hora), e só
+        // DEPOIS removida via DefinirEtapas([]): a fase de avaliação fica órfã, e essa direção só
+        // o gate de publicação (LAZY) pega — é exatamente o defeito que o docblock de
+        // PendenciaDoCronograma descreve como "defesa em profundidade".
+        processo.DefinirEtapas(
+            [EtapaProcesso.Criar("Prova", CaraterEtapa.Classificatoria, peso: 1m, ordem: 1)], PrecondicaoIfMatch.Curinga)
+            .IsSuccess.Should().BeTrue();
+        processo.DefinirCronogramaFases(
+            [FaseCronograma.Criar(
+                1, Guid.CreateVersion7(), "RESULTADO_FINAL", "CEPS", OrigemDataFase.Delegada,
+                agrupaEtapas: true, permiteComplementacao: false, produzResultado: true, resultadoDefinitivo: true,
+                coletaInscricao: false, inicio: null, fim: null,
+                atoProduzidoCodigo: "RESULTADO_FINAL", atoProduzidoEfeitoIrreversivel: false,
+                bancasRequeridas: [], regraRecurso: null).Value!],
+            [], PrecondicaoIfMatch.Curinga).IsSuccess.Should().BeTrue();
+        processo.DefinirEtapas([], PrecondicaoIfMatch.Curinga).IsSuccess.Should().BeTrue();
+
+        processo.AvaliarConformidade().Should().ContainSingle(i => !i.Ok)
+            .Which.Item.Should().Be("Cronograma: fase que agrupa etapas só quando há etapa pontuada");
+
+        Result<VersaoConfiguracao> resultado = Publicar(processo);
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be("ProcessoSeletivo.AvaliacaoSemEtapa");
+    }
+
+    [Fact(DisplayName = "Cronograma: etapa pontuada sem fase de avaliação — item vermelho e Publicar recusa com EtapaSemFaseDeAvaliacao")]
+    public void Cronograma_EtapaSemFaseDeAvaliacao()
+    {
+        ProcessoSeletivo processo = ProcessoConforme();
+        processo.DefinirEtapas(
+            [EtapaProcesso.Criar("Prova", CaraterEtapa.Classificatoria, peso: 1m, ordem: 1)], PrecondicaoIfMatch.Curinga)
+            .IsSuccess.Should().BeTrue();
+        // Fase permanece sem agrupar etapas (herdada de ProcessoConforme).
+
+        processo.AvaliarConformidade().Should().ContainSingle(i => !i.Ok)
+            .Which.Item.Should().Be("Cronograma: etapa pontuada tem fase que agrupa etapas");
+
+        Result<VersaoConfiguracao> resultado = Publicar(processo);
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be("ProcessoSeletivo.EtapaSemFaseDeAvaliacao");
+    }
+
+    [Fact(DisplayName = "Cronograma: InscricaoPropria sem fase de coleta — item vermelho e Publicar recusa com InscricaoPropriaSemFaseDeColeta (cenário da issue)")]
+    public void Cronograma_InscricaoPropriaSemFaseDeColeta()
+    {
+        ProcessoSeletivo processo = ProcessoSeletivo.Criar(
+            "PS Matriz Estrutural", TipoProcesso.SiSU, OrigemCandidatos.InscricaoPropria, Guid.NewGuid(),
+            Unifesspa.UniPlus.Selecao.Domain.ValueObjects.UnidadeAdministradoraSnapshot.Criar(
+                "CEPS", "ceps", "Centro de Processos Seletivos", "ADMINISTRATIVA").Value!);
+        processo.DefinirOfertaAtendimento(OfertaAtendimentoEspecializado.Criar([], [], []).Value!, PrecondicaoIfMatch.Ausente)
+            .IsSuccess.Should().BeTrue();
+        processo.DefinirDistribuicaoVagas([DistribuicaoAmpla(10)], PrecondicaoIfMatch.Ausente).IsSuccess.Should().BeTrue();
+        processo.DefinirClassificacao(ClassificacaoImportada(), PrecondicaoIfMatch.Ausente).IsSuccess.Should().BeTrue();
+        processo.DefinirCronogramaFases([FaseBase(coletaInscricao: false)], [], PrecondicaoIfMatch.Ausente).IsSuccess.Should().BeTrue();
+
+        processo.AvaliarConformidade().Should().ContainSingle(i => !i.Ok)
+            .Which.Item.Should().Be("Cronograma: inscrição própria tem fase que coleta inscrição");
+
+        Result<VersaoConfiguracao> resultado = Publicar(processo);
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be("ProcessoSeletivo.InscricaoPropriaSemFaseDeColeta");
+    }
+
+    [Fact(DisplayName = "Cronograma: vagas ofertadas sem fase que produz resultado — item vermelho e Publicar recusa com VagasSemFaseQueProduzResultado")]
+    public void Cronograma_VagasSemFaseQueProduzResultado()
+    {
+        ProcessoSeletivo processo = ProcessoConforme();
+        processo.DefinirCronogramaFases(
+            [FaseCronograma.Criar(
+                1, Guid.CreateVersion7(), "MATRICULA", "CEPS", OrigemDataFase.Delegada,
+                agrupaEtapas: false, permiteComplementacao: false, produzResultado: false, resultadoDefinitivo: false,
+                coletaInscricao: false, inicio: null, fim: null,
+                atoProduzidoCodigo: null, atoProduzidoEfeitoIrreversivel: false,
+                bancasRequeridas: [], regraRecurso: null).Value!],
+            [], PrecondicaoIfMatch.Curinga).IsSuccess.Should().BeTrue();
+
+        processo.AvaliarConformidade().Should().ContainSingle(i => !i.Ok)
+            .Which.Item.Should().Be("Cronograma: vagas ofertadas têm fase que produz resultado");
+
+        Result<VersaoConfiguracao> resultado = Publicar(processo);
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be("ProcessoSeletivo.VagasSemFaseQueProduzResultado");
+    }
+
+    // ══════════════════════════════════════════════════════════════════════════════════════
+    // PendenciaDaCascata — cinco razões (RN-CASCATA-1/2/2b/3)
+    // ══════════════════════════════════════════════════════════════════════════════════════
+
+    private static ReferenciaRegra RegraLei12711() => Regra(RegraDistribuicaoVagasCodigo.Lei12711, 'f');
+
+    private static ReferenciaRegra RegraCascataRemanejamento() => Regra(RegraRemanejamentoCodigo.Cascata, 'e');
+
+    private static DestinoRemanejamento Destino(string origem, int ordem, string destino) =>
+        DestinoRemanejamento.Criar(origem, ordem, destino).Value!;
+
+    private static ReferenciaReservaDemograficaSnapshot Demografica() =>
+        ReferenciaReservaDemograficaSnapshot.Criar(Guid.CreateVersion7(), "2022", 79m, 1.5m, 8.5m, "Censo 2022").Value!;
+
+    private static readonly string[] OrigensFederais =
+    [
+        ModalidadesFederaisLei12711.LbPpi, ModalidadesFederaisLei12711.LbQ, ModalidadesFederaisLei12711.LbPcd, ModalidadesFederaisLei12711.LbEp,
+        ModalidadesFederaisLei12711.LiPpi, ModalidadesFederaisLei12711.LiQ, ModalidadesFederaisLei12711.LiPcd, ModalidadesFederaisLei12711.LiEp,
+    ];
+
+    /// <summary>
+    /// As 8 modalidades federais (SegueCascata) + AC — INV-6 exige o conjunto completo sob Lei
+    /// 12.711. Sem <c>quantidadeDeclarada</c>: sob o ramo federal, DENTRO_DO_VR e RESIDUAL_DO_VO
+    /// são CALCULADAS pela fórmula do art. 10 — declarar quantidade aqui é recusado
+    /// (QuantidadeCalculadaNaoInformavel).
+    /// </summary>
+    private static List<ModalidadeSelecionada> AsOitoFederaisMaisAc() =>
+    [
+        .. OrigensFederais.Select(codigo =>
+            Modalidade(codigo, NaturezaLegalModalidade.CotaReservada, RegraRemanejamentoModalidade.SegueCascata, quantidadeDeclarada: null)),
+        Modalidade(ModalidadesFederaisLei12711.Ac, NaturezaLegalModalidade.Ampla, RegraRemanejamentoModalidade.Nenhuma, quantidadeDeclarada: null),
+    ];
+
+    private static ReferenciaRegra RegraAjusteArt11() => Regra("RECONCILIACAO-VAGAS-ART11-PU", 'd');
+
+    private static ConfiguracaoDistribuicaoVagas OfertaFederalCompleta() => ConfiguracaoDistribuicaoVagas.Criar(
+        Guid.CreateVersion7(), voBase: 40, pr: 0.5m, RegraLei12711(), RegraAjusteArt11(), Demografica(), AsOitoFederaisMaisAc()).Value!;
+
+    /// <summary>A matriz legal completa (8×7), fallback AC — cada origem resolve nas outras sete, todas ofertadas.</summary>
+    private static ConfiguracaoCascataRemanejamento CascataCompleta()
+    {
+        List<DestinoRemanejamento> destinos = [];
+        foreach (string origem in OrigensFederais)
+        {
+            string[] ordemDestinos = [.. OrigensFederais.Where(o => o != origem)];
+            for (int i = 0; i < ordemDestinos.Length; i++)
+            {
+                destinos.Add(Destino(origem, i + 1, ordemDestinos[i]));
+            }
+        }
+
+        return ConfiguracaoCascataRemanejamento.Criar(RegraCascataRemanejamento(), ModalidadesFederaisLei12711.Ac, destinos).Value!;
+    }
+
+    /// <summary>Só os itens de <see cref="ProcessoSeletivo.AvaliarConformidade"/> que se espera ver vermelhos.</summary>
+    private static void SoEstesItensVermelhos(ProcessoSeletivo processo, params string[] itensVermelhos) =>
+        processo.AvaliarConformidade().Where(static i => !i.Ok).Select(static i => i.Item)
+            .Should().BeEquivalentTo(itensVermelhos);
+
+    [Fact(DisplayName = "Cascata: modalidade SegueCascata fora do regime federal — item vermelho e Publicar recusa com CascataForaDoRegimeFederal")]
+    public void Cascata_ForaDoRegimeFederal()
+    {
+        ConfiguracaoDistribuicaoVagas oferta = ConfiguracaoDistribuicaoVagas.Criar(
+            Guid.CreateVersion7(), voBase: 10, pr: 1m,
+            Regra(RegraDistribuicaoVagasCodigo.Institucional, 'a'), regraAjuste: null, referenciaDemografica: null,
+            [
+                Modalidade("AC", NaturezaLegalModalidade.Ampla, RegraRemanejamentoModalidade.Nenhuma, 8),
+                Modalidade("LB_PPI", NaturezaLegalModalidade.CotaReservada, RegraRemanejamentoModalidade.SegueCascata, 2),
+            ]).Value!;
+        ProcessoSeletivo processo = ProcessoConforme([oferta]);
+
+        // A cascata (item agregado, comportamento pré-existente) TAMBÉM vai a vermelho —
+        // ela já cobria este código antes da issue #1092; o item NOVO é o detalhamento.
+        SoEstesItensVermelhos(
+            processo, "Cascata de remanejamento", "Cascata: modalidade SegueCascata usa a regra de distribuição federal");
+
+        Result<VersaoConfiguracao> resultado = Publicar(processo);
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be("ProcessoSeletivo.CascataForaDoRegimeFederal");
+    }
+
+    [Fact(DisplayName = "Cascata: oferta federal SegueCascata sem cascata configurada — item vermelho e Publicar recusa com CascataOrigemAusente")]
+    public void Cascata_OrigemAusente()
+    {
+        ProcessoSeletivo processo = ProcessoConforme([OfertaFederalCompleta()]);
+        // Nenhuma DefinirCascataRemanejamento — a origem exigida não tem cascata configurada.
+
+        SoEstesItensVermelhos(
+            processo, "Cascata de remanejamento", "Cascata: origem SegueCascata declarada na cascata de remanejamento");
+
+        Result<VersaoConfiguracao> resultado = Publicar(processo);
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be("ProcessoSeletivo.CascataOrigemAusente");
+    }
+
+    [Fact(DisplayName = "Cascata: fallback fora das modalidades da oferta — item vermelho e Publicar recusa com CascataFallbackNaoSelecionadoNaOferta")]
+    public void Cascata_FallbackNaoSelecionadoNaOferta()
+    {
+        ProcessoSeletivo processo = ProcessoConforme([OfertaFederalCompleta()]);
+        ConfiguracaoCascataRemanejamento cascataComFallbackInexistente = ConfiguracaoCascataRemanejamento.Criar(
+            RegraCascataRemanejamento(), "FALLBACK_INEXISTENTE",
+            [.. CascataCompleta().Destinos]).Value!;
+        processo.DefinirCascataRemanejamento(cascataComFallbackInexistente, PrecondicaoIfMatch.Ausente)
+            .IsSuccess.Should().BeTrue();
+
+        SoEstesItensVermelhos(
+            processo, "Cascata de remanejamento", "Cascata: fallback e destinos resolvíveis nas modalidades ofertadas");
+
+        Result<VersaoConfiguracao> resultado = Publicar(processo);
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be("ProcessoSeletivo.CascataFallbackNaoSelecionadoNaOferta");
+    }
+
+    [Fact(DisplayName = "Cascata: origem declarada que nenhuma oferta marca SegueCascata — item vermelho e Publicar recusa com CascataOrigemNaoSegueCascata")]
+    public void Cascata_OrigemNaoSegueCascata()
+    {
+        ConfiguracaoDistribuicaoVagas oferta = ConfiguracaoDistribuicaoVagas.Criar(
+            Guid.CreateVersion7(), voBase: 10, pr: 1m,
+            Regra(RegraDistribuicaoVagasCodigo.Institucional, 'a'), regraAjuste: null, referenciaDemografica: null,
+            [Modalidade("AC", NaturezaLegalModalidade.Ampla, RegraRemanejamentoModalidade.Nenhuma, 10)]).Value!;
+        ProcessoSeletivo processo = ProcessoConforme([oferta]);
+        // Nenhuma modalidade desta oferta é SegueCascata — o loop por oferta não recusa nada; só
+        // a checagem global (origem declarada × origens SegueCascata em alguma oferta) alcança.
+        processo.DefinirCascataRemanejamento(
+            ConfiguracaoCascataRemanejamento.Criar(
+                RegraCascataRemanejamento(), "AC", [Destino(ModalidadesFederaisLei12711.LbPpi, 1, "AC")]).Value!,
+            PrecondicaoIfMatch.Ausente).IsSuccess.Should().BeTrue();
+
+        SoEstesItensVermelhos(
+            processo, "Cascata de remanejamento", "Cascata: origem declarada corresponde a modalidade SegueCascata ofertada");
+
+        Result<VersaoConfiguracao> resultado = Publicar(processo);
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be("ProcessoSeletivo.CascataOrigemNaoSegueCascata");
+    }
+
+    [Fact(DisplayName = "Cascata: destino declarado que não é modalidade de nenhuma oferta — item vermelho e Publicar recusa com CascataDestinoDesconhecido")]
+    public void Cascata_DestinoDesconhecido()
+    {
+        ProcessoSeletivo processo = ProcessoConforme([OfertaFederalCompleta()]);
+        // A matriz legal completa resolve todas as origens dentro da oferta (o loop por oferta
+        // não recusa nada); LB_PPI ganha um OITAVO destino (ordem contígua) apontando para um
+        // código que não é modalidade de nenhuma oferta — só a checagem GLOBAL, que roda depois
+        // do loop por oferta, alcança esse destino sobressalente. LB_Q perde um destino legal
+        // (fica com 6, ainda contíguo a partir de 1 — os 6 restantes continuam todos resolvíveis
+        // nesta oferta) para abrir espaço sob o teto de 56 destinos (7×7 + 6 + 1 = 56).
+        List<DestinoRemanejamento> destinos =
+        [
+            .. CascataCompleta().Destinos.Where(d => !(d.ModalidadeOrigemCodigo == ModalidadesFederaisLei12711.LbQ && d.Ordem == 7)),
+            Destino(ModalidadesFederaisLei12711.LbPpi, 8, "CODIGO_FORA_DA_OFERTA"),
+        ];
+        processo.DefinirCascataRemanejamento(
+            ConfiguracaoCascataRemanejamento.Criar(RegraCascataRemanejamento(), ModalidadesFederaisLei12711.Ac, destinos).Value!,
+            PrecondicaoIfMatch.Ausente).IsSuccess.Should().BeTrue();
+
+        SoEstesItensVermelhos(
+            processo, "Cascata de remanejamento", "Cascata: destino declarado corresponde a modalidade ofertada");
+
+        Result<VersaoConfiguracao> resultado = Publicar(processo);
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be("ProcessoSeletivo.CascataDestinoDesconhecido");
+    }
+
+    // ══════════════════════════════════════════════════════════════════════════════════════
+    // PendenciaPreCanonicalizacao — doze razões (Story #554/#920/#927/#928)
+    // ══════════════════════════════════════════════════════════════════════════════════════
+
+    [Fact(DisplayName = "Pré-canonicalização: exigência CONDICIONAL vazia que determina resultado — item vermelho e Publicar recusa com CondicionalVaziaDeterminaResultado")]
+    public void PreCanon_CondicionalVaziaDeterminaResultado()
+    {
+        ProcessoSeletivo processo = ProcessoConforme();
+        Guid faseId = processo.CronogramaFases.Single().Id;
+        DocumentoExigido exigencia = DocumentoExigido.Criar(
+            faseId, Guid.CreateVersion7(), "CERTIDAO_RESERVISTA", "Certidão de reservista", "MILITAR",
+            Aplicabilidade.Condicional, obrigatorio: true, consequenciaIndeferimento: null,
+            condicoes: [], basesLegais: [BaseLegalResolvida()], idadeMaximaEmissao: null,
+            formatosPermitidos: FormatosPermitidos.Criar(true, null).Value!, tamanhoMaximoBytes: null).Value!;
+        processo.DefinirDocumentosExigidos([NoExigencia.CriarFolha(exigencia, 0).Value!], PrecondicaoIfMatch.Ausente)
+            .IsSuccess.Should().BeTrue();
+
+        processo.AvaliarConformidade().Should().ContainSingle(i => !i.Ok)
+            .Which.Item.Should().Be("Exigência documental: sem CONDICIONAL vazia que determina resultado");
+
+        Result<VersaoConfiguracao> resultado = Publicar(processo);
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be("DocumentoExigido.CondicionalVaziaDeterminaResultado");
+    }
+
+    [Fact(DisplayName = "Pré-canonicalização: exigência (folha) REMOVE_VANTAGEM sem vantagem viva — item vermelho e Publicar recusa com DocumentoExigido.RemoveVantagemSemVantagemViva")]
+    public void PreCanon_ExigenciaRemoveVantagemSemVantagemViva()
+    {
+        ProcessoSeletivo processo = ProcessoConforme();
+        Guid faseId = processo.CronogramaFases.Single().Id;
+        DocumentoExigido exigencia = DocumentoExigido.Criar(
+            faseId, Guid.CreateVersion7(), "DOC_GERAL", "Documento geral", "PESSOAL",
+            Aplicabilidade.Geral, obrigatorio: true, consequenciaIndeferimento: "REMOVE_VANTAGEM",
+            condicoes: [], basesLegais: [BaseLegalResolvida()], idadeMaximaEmissao: null,
+            formatosPermitidos: FormatosPermitidos.Criar(true, null).Value!, tamanhoMaximoBytes: null).Value!;
+        processo.DefinirDocumentosExigidos([NoExigencia.CriarFolha(exigencia, 0).Value!], PrecondicaoIfMatch.Ausente)
+            .IsSuccess.Should().BeTrue();
+        // Sem DefinirBonusRegional — nenhuma vantagem viva para remover.
+
+        processo.AvaliarConformidade().Should().ContainSingle(i => !i.Ok)
+            .Which.Item.Should().Be("Consequência de indeferimento: REMOVE_VANTAGEM com vantagem viva (exigência)");
+
+        Result<VersaoConfiguracao> resultado = Publicar(processo);
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be("DocumentoExigido.RemoveVantagemSemVantagemViva");
+    }
+
+    [Fact(DisplayName = "Pré-canonicalização: exigência (folha) com consequência incoerente com a ação da vaga — item vermelho e Publicar recusa com DocumentoExigido.ConsequenciaIncoerenteComAcaoDaVaga")]
+    public void PreCanon_ExigenciaConsequenciaIncoerenteComAcaoDaVaga()
+    {
+        ConfiguracaoDistribuicaoVagas oferta = DistribuicaoAmpla(10, acaoQuandoIndeferido: "RECLASSIFICAR_AC");
+        ProcessoSeletivo processo = ProcessoConforme([oferta]);
+        Guid faseId = processo.CronogramaFases.Single().Id;
+        DocumentoExigido exigencia = DocumentoExigido.Criar(
+            faseId, Guid.CreateVersion7(), "DOC_GERAL", "Documento geral", "PESSOAL",
+            Aplicabilidade.Geral, obrigatorio: true, consequenciaIndeferimento: "ELIMINA",
+            condicoes: [], basesLegais: [BaseLegalResolvida()], idadeMaximaEmissao: null,
+            formatosPermitidos: FormatosPermitidos.Criar(true, null).Value!, tamanhoMaximoBytes: null).Value!;
+        processo.DefinirDocumentosExigidos([NoExigencia.CriarFolha(exigencia, 0).Value!], PrecondicaoIfMatch.Ausente)
+            .IsSuccess.Should().BeTrue();
+
+        processo.AvaliarConformidade().Should().ContainSingle(i => !i.Ok)
+            .Which.Item.Should().Be("Consequência de indeferimento: coerente com a ação da vaga (exigência)");
+
+        Result<VersaoConfiguracao> resultado = Publicar(processo);
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be("DocumentoExigido.ConsequenciaIncoerenteComAcaoDaVaga");
+    }
+
+    [Fact(DisplayName = "Pré-canonicalização: grupo OU/N-de REMOVE_VANTAGEM sem vantagem viva — item vermelho e Publicar recusa com NoExigencia.RemoveVantagemSemVantagemViva")]
+    public void PreCanon_GrupoRemoveVantagemSemVantagemViva()
+    {
+        ProcessoSeletivo processo = ProcessoConforme();
+        Guid faseId = processo.CronogramaFases.Single().Id;
+        DocumentoExigido documento = DocumentoExigido.Criar(
+            faseId, Guid.CreateVersion7(), "DOC_GERAL", "Documento geral", "PESSOAL",
+            Aplicabilidade.Geral, obrigatorio: false, consequenciaIndeferimento: null,
+            condicoes: [], basesLegais: [], idadeMaximaEmissao: null,
+            formatosPermitidos: FormatosPermitidos.Criar(true, null).Value!, tamanhoMaximoBytes: null).Value!;
+        NoExigencia folha = NoExigencia.CriarFolha(documento, 0).Value!;
+        NoExigencia grupo = NoExigencia.CriarGrupo(
+            TipoNo.GrupoOu, 0, 1, "REMOVE_VANTAGEM", [BaseLegalDoGrupo(StatusBaseLegal.Resolvido)], [folha]).Value!;
+        processo.DefinirDocumentosExigidos([grupo], PrecondicaoIfMatch.Ausente).IsSuccess.Should().BeTrue();
+
+        processo.AvaliarConformidade().Should().ContainSingle(i => !i.Ok)
+            .Which.Item.Should().Be("Consequência de indeferimento: REMOVE_VANTAGEM com vantagem viva (grupo)");
+
+        Result<VersaoConfiguracao> resultado = Publicar(processo);
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be("NoExigencia.RemoveVantagemSemVantagemViva");
+    }
+
+    [Fact(DisplayName = "Pré-canonicalização: grupo OU/N-de com consequência incoerente com a ação da vaga — item vermelho e Publicar recusa com NoExigencia.ConsequenciaIncoerenteComAcaoDaVaga")]
+    public void PreCanon_GrupoConsequenciaIncoerenteComAcaoDaVaga()
+    {
+        ConfiguracaoDistribuicaoVagas oferta = DistribuicaoAmpla(10, acaoQuandoIndeferido: "RECLASSIFICAR_AC");
+        ProcessoSeletivo processo = ProcessoConforme([oferta]);
+        Guid faseId = processo.CronogramaFases.Single().Id;
+        DocumentoExigido documento = DocumentoExigido.Criar(
+            faseId, Guid.CreateVersion7(), "DOC_GERAL", "Documento geral", "PESSOAL",
+            Aplicabilidade.Geral, obrigatorio: false, consequenciaIndeferimento: null,
+            condicoes: [], basesLegais: [], idadeMaximaEmissao: null,
+            formatosPermitidos: FormatosPermitidos.Criar(true, null).Value!, tamanhoMaximoBytes: null).Value!;
+        NoExigencia folha = NoExigencia.CriarFolha(documento, 0).Value!;
+        NoExigencia grupo = NoExigencia.CriarGrupo(
+            TipoNo.GrupoOu, 0, 1, "ELIMINA", [BaseLegalDoGrupo(StatusBaseLegal.Resolvido)], [folha]).Value!;
+        processo.DefinirDocumentosExigidos([grupo], PrecondicaoIfMatch.Ausente).IsSuccess.Should().BeTrue();
+
+        processo.AvaliarConformidade().Should().ContainSingle(i => !i.Ok)
+            .Which.Item.Should().Be("Consequência de indeferimento: coerente com a ação da vaga (grupo)");
+
+        Result<VersaoConfiguracao> resultado = Publicar(processo);
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be("NoExigencia.ConsequenciaIncoerenteComAcaoDaVaga");
+    }
+
+    private static CondicaoGatilho GatilhoFaixaEtaria() =>
+        CondicaoGatilho.Criar(0, "FAIXA_ETARIA", Operador.MaiorIgual, JsonSerializer.SerializeToElement(18)).Value!;
+
+    [Fact(DisplayName = "Pré-canonicalização: gatilho por FAIXA_ETARIA sem referência temporal configurada — item vermelho e Publicar recusa com ReferenciaTemporalFatosAusente")]
+    public void PreCanon_ReferenciaTemporalFatosAusente()
+    {
+        ProcessoSeletivo processo = ProcessoConforme();
+        Guid faseId = processo.CronogramaFases.Single().Id;
+        DocumentoExigido exigencia = DocumentoExigido.Criar(
+            faseId, Guid.CreateVersion7(), "DECLARACAO_MAIORIDADE", "Declaração de maioridade", "PESSOAL",
+            Aplicabilidade.Condicional, obrigatorio: true, consequenciaIndeferimento: null,
+            condicoes: [GatilhoFaixaEtaria()], basesLegais: [BaseLegalResolvida()], idadeMaximaEmissao: null,
+            formatosPermitidos: FormatosPermitidos.Criar(true, null).Value!, tamanhoMaximoBytes: null).Value!;
+        processo.DefinirDocumentosExigidos([NoExigencia.CriarFolha(exigencia, 0).Value!], PrecondicaoIfMatch.Ausente)
+            .IsSuccess.Should().BeTrue();
+        // Nenhuma ReferenciaTemporalFatos configurada.
+
+        processo.AvaliarConformidade().Should().ContainSingle(i => !i.Ok)
+            .Which.Item.Should().Be("Referência temporal de fatos: configurada quando há gatilho por faixa etária");
+
+        Result<VersaoConfiguracao> resultado = Publicar(processo);
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be("ProcessoSeletivo.ReferenciaTemporalFatosAusente");
+    }
+
+    [Fact(DisplayName = "Pré-canonicalização: referência temporal aponta para fase removida depois — item vermelho e Publicar recusa com ReferenciaTemporalFatosFaseInexistente")]
+    public void PreCanon_ReferenciaTemporalFatosFaseInexistente()
+    {
+        ProcessoSeletivo processo = ProcessoConforme();
+        // Duas fases: a que fica com a exigência (sobrevive) e a que ancora a referência
+        // temporal (será removida DEPOIS, deixando a referência órfã — §3.5-like, mas para
+        // ReferenciaTemporalFatos, que DefinirCronogramaFases não guarda contra remoção).
+        FaseCronograma faseComExigencia = FaseBase();
+        FaseCronograma faseAncora = FaseCronograma.Criar(
+            2, Guid.CreateVersion7(), "HOMOLOGACAO", "CEPS", OrigemDataFase.Propria,
+            agrupaEtapas: false, permiteComplementacao: false, produzResultado: false, resultadoDefinitivo: false,
+            coletaInscricao: false,
+            inicio: new DateTimeOffset(2026, 1, 1, 0, 0, 0, TimeSpan.Zero), fim: new DateTimeOffset(2026, 1, 31, 0, 0, 0, TimeSpan.Zero),
+            atoProduzidoCodigo: null, atoProduzidoEfeitoIrreversivel: false, bancasRequeridas: [], regraRecurso: null).Value!;
+        processo.DefinirCronogramaFases([faseComExigencia, faseAncora], [], PrecondicaoIfMatch.Curinga)
+            .IsSuccess.Should().BeTrue();
+
+        DocumentoExigido exigencia = DocumentoExigido.Criar(
+            faseComExigencia.Id, Guid.CreateVersion7(), "DECLARACAO_MAIORIDADE", "Declaração de maioridade", "PESSOAL",
+            Aplicabilidade.Condicional, obrigatorio: true, consequenciaIndeferimento: null,
+            condicoes: [GatilhoFaixaEtaria()], basesLegais: [BaseLegalResolvida()], idadeMaximaEmissao: null,
+            formatosPermitidos: FormatosPermitidos.Criar(true, null).Value!, tamanhoMaximoBytes: null).Value!;
+        processo.DefinirDocumentosExigidos([NoExigencia.CriarFolha(exigencia, 0).Value!], PrecondicaoIfMatch.Curinga)
+            .IsSuccess.Should().BeTrue();
+
+        processo.DefinirReferenciaTemporalFatos(
+            ReferenciaTemporalFatos.Criar(ReferenciaTipo.FimFase, null, faseAncora.Id).Value!, PrecondicaoIfMatch.Curinga)
+            .IsSuccess.Should().BeTrue();
+
+        // Remove a fase-âncora do cronograma — só faseComExigencia sobrevive (mesma
+        // FaseCanonicaOrigemId, então DefinirDocumentosExigidos.ExigidoNaFaseId não fica órfão).
+        processo.DefinirCronogramaFases([faseComExigencia], [], PrecondicaoIfMatch.Curinga)
+            .IsSuccess.Should().BeTrue();
+
+        processo.AvaliarConformidade().Should().ContainSingle(i => !i.Ok)
+            .Which.Item.Should().Be("Referência temporal de fatos: fase âncora pertence ao cronograma");
+
+        Result<VersaoConfiguracao> resultado = Publicar(processo);
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be("ProcessoSeletivo.ReferenciaTemporalFatosFaseInexistente");
+    }
+
+    [Fact(DisplayName = "Pré-canonicalização: referência temporal aponta para fase sem o extremo definido — item vermelho e Publicar recusa com ReferenciaTemporalFatosExtremoAusente")]
+    public void PreCanon_ReferenciaTemporalFatosExtremoAusente()
+    {
+        ProcessoSeletivo processo = ProcessoConforme();
+        FaseCronograma faseSemExtremo = FaseCronograma.Criar(
+            2, Guid.CreateVersion7(), "HOMOLOGACAO", "CEPS", OrigemDataFase.Delegada,
+            agrupaEtapas: false, permiteComplementacao: false, produzResultado: false, resultadoDefinitivo: false,
+            coletaInscricao: false, inicio: null, fim: null,
+            atoProduzidoCodigo: null, atoProduzidoEfeitoIrreversivel: false, bancasRequeridas: [], regraRecurso: null).Value!;
+        processo.DefinirCronogramaFases([FaseBase(), faseSemExtremo], [], PrecondicaoIfMatch.Curinga)
+            .IsSuccess.Should().BeTrue();
+
+        Guid faseComExigenciaId = processo.CronogramaFases.Single(f => f.Ordem == 1).Id;
+        DocumentoExigido exigencia = DocumentoExigido.Criar(
+            faseComExigenciaId, Guid.CreateVersion7(), "DECLARACAO_MAIORIDADE", "Declaração de maioridade", "PESSOAL",
+            Aplicabilidade.Condicional, obrigatorio: true, consequenciaIndeferimento: null,
+            condicoes: [GatilhoFaixaEtaria()], basesLegais: [BaseLegalResolvida()], idadeMaximaEmissao: null,
+            formatosPermitidos: FormatosPermitidos.Criar(true, null).Value!, tamanhoMaximoBytes: null).Value!;
+        processo.DefinirDocumentosExigidos([NoExigencia.CriarFolha(exigencia, 0).Value!], PrecondicaoIfMatch.Curinga)
+            .IsSuccess.Should().BeTrue();
+
+        processo.DefinirReferenciaTemporalFatos(
+            ReferenciaTemporalFatos.Criar(ReferenciaTipo.FimFase, null, faseSemExtremo.Id).Value!, PrecondicaoIfMatch.Curinga)
+            .IsSuccess.Should().BeTrue();
+
+        processo.AvaliarConformidade().Should().ContainSingle(i => !i.Ok)
+            .Which.Item.Should().Be("Referência temporal de fatos: extremo da fase âncora definido");
+
+        Result<VersaoConfiguracao> resultado = Publicar(processo);
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be("ProcessoSeletivo.ReferenciaTemporalFatosExtremoAusente");
+    }
+
+    [Fact(DisplayName = "Pré-canonicalização: FIM_INSCRICAO sem fase de coleta com Fim definido — item vermelho e Publicar recusa com ReferenciaTemporalFatosFimInscricaoIndisponivel")]
+    public void PreCanon_ReferenciaTemporalFatosFimInscricaoIndisponivel()
+    {
+        ProcessoSeletivo processo = ProcessoConforme();
+        Guid faseId = processo.CronogramaFases.Single().Id;
+        DocumentoExigido exigencia = DocumentoExigido.Criar(
+            faseId, Guid.CreateVersion7(), "DECLARACAO_MAIORIDADE", "Declaração de maioridade", "PESSOAL",
+            Aplicabilidade.Condicional, obrigatorio: true, consequenciaIndeferimento: null,
+            condicoes: [GatilhoFaixaEtaria()], basesLegais: [BaseLegalResolvida()], idadeMaximaEmissao: null,
+            formatosPermitidos: FormatosPermitidos.Criar(true, null).Value!, tamanhoMaximoBytes: null).Value!;
+        processo.DefinirDocumentosExigidos([NoExigencia.CriarFolha(exigencia, 0).Value!], PrecondicaoIfMatch.Ausente)
+            .IsSuccess.Should().BeTrue();
+        // FaseBase() não coleta inscrição — nenhuma fase resolve FIM_INSCRICAO.
+        processo.DefinirReferenciaTemporalFatos(
+            ReferenciaTemporalFatos.Criar(ReferenciaTipo.FimInscricao, null, null).Value!, PrecondicaoIfMatch.Curinga)
+            .IsSuccess.Should().BeTrue();
+
+        processo.AvaliarConformidade().Should().ContainSingle(i => !i.Ok)
+            .Which.Item.Should().Be("Referência temporal de fatos: fase de coleta com Fim definido para FIM_INSCRICAO");
+
+        Result<VersaoConfiguracao> resultado = Publicar(processo);
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be("ProcessoSeletivo.ReferenciaTemporalFatosFimInscricaoIndisponivel");
+    }
+
+    [Fact(DisplayName = "Pré-canonicalização: regra de derivação cita fato que o processo não coleta nem deriva — item vermelho e Publicar recusa com FatoColetadoErrorCodes.PrecondicaoCitaFatoNaoColetado")]
+    public void PreCanon_RegraDeDerivacaoCitaFatoNaoColetado()
+    {
+        ProcessoSeletivo processo = ProcessoConforme();
+        CondicaoRegraDerivacao condicao = CondicaoRegraDerivacao.Criar(
+            1, "BOGUS", Operador.Igual, JsonSerializer.SerializeToElement(true)).Value!;
+        RegraDerivacaoConfigurada regra = RegraDerivacaoConfigurada.Criar(0, "X", [condicao]).Value!;
+        ConfiguracaoDerivacaoFato configuracao = ConfiguracaoDerivacaoFato.Criar("D1", [regra]).Value!;
+        processo.DefinirRegrasDerivacao([configuracao], PrecondicaoIfMatch.Ausente).IsSuccess.Should().BeTrue(
+            "a definição isolada só valida forma e unicidade — não conhece o universo de fatos do processo");
+
+        processo.AvaliarConformidade().Should().ContainSingle(i => !i.Ok)
+            .Which.Item.Should().Be("Regras de derivação: fatos citados existem no processo");
+
+        Result<VersaoConfiguracao> resultado = Publicar(processo);
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be(FatoColetadoErrorCodes.PrecondicaoCitaFatoNaoColetado);
+    }
+
+    [Fact(DisplayName = "Pré-canonicalização: MODALIDADE contribui código fora do domínio ofertado — item vermelho e Publicar recusa com RegrasDerivacaoFatoErrorCodes.ContribuiForaDoDominio")]
+    public void PreCanon_ModalidadeContribuiForaDoDominio()
+    {
+        ProcessoSeletivo processo = ProcessoConforme([DistribuicaoAmpla(10)]); // domínio ofertado = { AC }
+        RegraDerivacaoConfigurada ancora = RegraDerivacaoConfigurada.Criar(0, "V", condicoes: null).Value!;
+        ConfiguracaoDerivacaoFato configuracao = ConfiguracaoDerivacaoFato.Criar("MODALIDADE", [ancora]).Value!;
+        processo.DefinirRegrasDerivacao([configuracao], PrecondicaoIfMatch.Ausente).IsSuccess.Should().BeTrue(
+            "\"V\" é rótulo de exibição de AC_PCD no edital, nunca código de entrada — e não está no domínio ofertado (só AC)");
+
+        processo.AvaliarConformidade().Should().ContainSingle(i => !i.Ok)
+            .Which.Item.Should().Be("Regras de derivação: código contribuído pertence ao domínio ofertado");
+
+        Result<VersaoConfiguracao> resultado = Publicar(processo);
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be(RegrasDerivacaoFatoErrorCodes.ContribuiForaDoDominio);
+    }
+
+    [Fact(DisplayName = "Pré-canonicalização: ciclo entre duas configurações de derivação — item vermelho e Publicar recusa com GrafoDependenciaConjuntaErrorCodes.GrafoConjuntoComCiclo")]
+    public void PreCanon_GrafoConjuntoComCiclo()
+    {
+        ProcessoSeletivo processo = ProcessoConforme();
+        CondicaoRegraDerivacao citaD2 = CondicaoRegraDerivacao.Criar(1, "D2", Operador.Igual, JsonSerializer.SerializeToElement(true)).Value!;
+        CondicaoRegraDerivacao citaD1 = CondicaoRegraDerivacao.Criar(1, "D1", Operador.Igual, JsonSerializer.SerializeToElement(true)).Value!;
+        ConfiguracaoDerivacaoFato d1 = ConfiguracaoDerivacaoFato.Criar(
+            "D1", [RegraDerivacaoConfigurada.Criar(0, "X", [citaD2]).Value!]).Value!;
+        ConfiguracaoDerivacaoFato d2 = ConfiguracaoDerivacaoFato.Criar(
+            "D2", [RegraDerivacaoConfigurada.Criar(0, "Y", [citaD1]).Value!]).Value!;
+        processo.DefinirRegrasDerivacao([d1, d2], PrecondicaoIfMatch.Ausente).IsSuccess.Should().BeTrue(
+            "a definição isolada só barra código duplicado — o ciclo cruza duas configurações e passa aqui");
+
+        processo.AvaliarConformidade().Should().ContainSingle(i => !i.Ok)
+            .Which.Item.Should().Be("Grafo de dependência conjunto: sem ciclo");
+
+        Result<VersaoConfiguracao> resultado = Publicar(processo);
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be(GrafoDependenciaConjuntaErrorCodes.GrafoConjuntoComCiclo);
+    }
+
+    // ══════════════════════════════════════════════════════════════════════════════════════
+    // Precedência: coletar todos os vereditos não pode mudar qual DomainError vem primeiro
+    // ══════════════════════════════════════════════════════════════════════════════════════
+
+    [Fact(DisplayName = "Precedência preservada: com Gate 1 (itens estruturais) e Gate 2 (cronograma) pendentes ao mesmo tempo, Publicar devolve ConformidadeInsuficiente primeiro — mas o checklist mostra os DOIS itens vermelhos")]
+    public void Precedencia_GatesSimultaneos_PublicarDevolveOPrimeiroNaOrdem()
+    {
+        ProcessoSeletivo processo = ProcessoSeletivo.Criar(
+            "PS Precedência", TipoProcesso.SiSU, OrigemCandidatos.InscricaoPropria, Guid.NewGuid(),
+            Unifesspa.UniPlus.Selecao.Domain.ValueObjects.UnidadeAdministradoraSnapshot.Criar(
+                "CEPS", "ceps", "Centro de Processos Seletivos", "ADMINISTRATIVA").Value!);
+        // OfertaAtendimento NUNCA definida — Gate 1 (PendenciaDeConformidade) fica pendente.
+        processo.DefinirDistribuicaoVagas([DistribuicaoAmpla(10)], PrecondicaoIfMatch.Ausente).IsSuccess.Should().BeTrue();
+        processo.DefinirClassificacao(ClassificacaoImportada(), PrecondicaoIfMatch.Ausente).IsSuccess.Should().BeTrue();
+        // Fase sem coleta de inscrição, com InscricaoPropria — Gate 2 (cronograma) TAMBÉM pendente.
+        processo.DefinirCronogramaFases([FaseBase(coletaInscricao: false)], [], PrecondicaoIfMatch.Ausente).IsSuccess.Should().BeTrue();
+
+        IReadOnlyList<ItemConformidade> checklist = processo.AvaliarConformidade();
+        checklist.Should().Contain(i => i.Item == "Atendimento especializado" && !i.Ok,
+            "Gate 1 também está pendente — o checklist projeta TODOS os vereditos, não só o primeiro");
+        checklist.Should().Contain(i => i.Item == "Cronograma: inscrição própria tem fase que coleta inscrição" && !i.Ok);
+
+        Result<VersaoConfiguracao> resultado = Publicar(processo);
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be(
+            "ProcessoSeletivo.ConformidadeInsuficiente",
+            "PendenciaDeConformidade é checado ANTES de PendenciaDoCronograma em Publicar (e em SucederVersao) — " +
+            "coletar todos os vereditos para o checklist não pode mudar essa ordem");
+    }
+
+    // ══════════════════════════════════════════════════════════════════════════════════════
+    // Contraprovas — estados VÁLIDOS que não podem virar falso vermelho
+    // ══════════════════════════════════════════════════════════════════════════════════════
+
+    [Fact(DisplayName = "Contraprova: processo estruturalmente conforme tem o checklist inteiramente verde E Publicar aceita (cronograma coerente, cascata não aplicável, sem gatilho etário)")]
+    public void Contraprova_ProcessoConforme_ChecklistVerdeEPublica()
+    {
+        ProcessoSeletivo processo = ProcessoConforme();
+
+        processo.AvaliarConformidade().Should().OnlyContain(i => i.Ok);
+
+        Result<VersaoConfiguracao> resultado = Publicar(processo);
+        resultado.IsSuccess.Should().BeTrue(resultado.Error?.Message);
+    }
+
+    [Fact(DisplayName = "Contraprova: SiSU com CLASSIFICACAO-IMPORTADA e SEM etapa é estado válido — os dois itens de coerência etapa×fase ficam Ok (Story #851 §3.5)")]
+    public void Contraprova_SiSU_ClassificacaoImportadaSemEtapa_ChecklistVerde()
+    {
+        ProcessoSeletivo processo = ProcessoConforme();
+        // ProcessoConforme já não define etapas nem fase que agrupa etapas — SiSU/importação
+        // publica sem prova local. Esta contraprova torna essa premissa EXPLÍCITA.
+        processo.Etapas.Should().BeEmpty("pré-condição da contraprova: sem etapa, sob CLASSIFICACAO-IMPORTADA");
+
+        processo.AvaliarConformidade().Should().Contain(
+            i => i.Item == "Cronograma: fase que agrupa etapas só quando há etapa pontuada" && i.Ok);
+        processo.AvaliarConformidade().Should().Contain(
+            i => i.Item == "Cronograma: etapa pontuada tem fase que agrupa etapas" && i.Ok);
+
+        Result<VersaoConfiguracao> resultado = Publicar(processo);
+        resultado.IsSuccess.Should().BeTrue(resultado.Error?.Message);
+    }
+
+    [Fact(DisplayName = "Contraprova: cascata não aplicável (nenhuma modalidade SegueCascata) mantém os cinco itens de cascata Ok")]
+    public void Contraprova_CascataNaoAplicavel_ChecklistVerde()
+    {
+        ProcessoSeletivo processo = ProcessoConforme(); // modalidade única AC, RegraRemanejamentoModalidade.Nenhuma
+
+        string[] itensDeCascata =
+        [
+            "Cascata: modalidade SegueCascata usa a regra de distribuição federal",
+            "Cascata: origem SegueCascata declarada na cascata de remanejamento",
+            "Cascata: fallback e destinos resolvíveis nas modalidades ofertadas",
+            "Cascata: origem declarada corresponde a modalidade SegueCascata ofertada",
+            "Cascata: destino declarado corresponde a modalidade ofertada",
+        ];
+        IReadOnlyList<ItemConformidade> checklist = processo.AvaliarConformidade();
+        foreach (string item in itensDeCascata)
+        {
+            checklist.Should().Contain(i => i.Item == item && i.Ok, $"cascata não se aplica — \"{item}\" não pode ficar vermelho");
+        }
+    }
+
+    [Fact(DisplayName = "Contraprova: ausência de gatilho por FAIXA_ETARIA mantém os quatro itens de referência temporal Ok, mesmo com outras exigências configuradas")]
+    public void Contraprova_SemGatilhoPorFaixaEtaria_ChecklistVerde()
+    {
+        ProcessoSeletivo processo = ProcessoConforme();
+        Guid faseId = processo.CronogramaFases.Single().Id;
+        // Exigência GERAL, sem qualquer condição de gatilho — não aciona FAIXA_ETARIA.
+        DocumentoExigido exigencia = DocumentoExigido.Criar(
+            faseId, Guid.CreateVersion7(), "IDENTIDADE", "Documento de identidade", "PESSOAL",
+            Aplicabilidade.Geral, obrigatorio: true, consequenciaIndeferimento: null,
+            condicoes: [], basesLegais: [BaseLegalResolvida()], idadeMaximaEmissao: null,
+            formatosPermitidos: FormatosPermitidos.Criar(true, null).Value!, tamanhoMaximoBytes: null).Value!;
+        processo.DefinirDocumentosExigidos([NoExigencia.CriarFolha(exigencia, 0).Value!], PrecondicaoIfMatch.Ausente)
+            .IsSuccess.Should().BeTrue();
+
+        string[] itensDeReferenciaTemporal =
+        [
+            "Referência temporal de fatos: configurada quando há gatilho por faixa etária",
+            "Referência temporal de fatos: fase âncora pertence ao cronograma",
+            "Referência temporal de fatos: extremo da fase âncora definido",
+            "Referência temporal de fatos: fase de coleta com Fim definido para FIM_INSCRICAO",
+        ];
+        IReadOnlyList<ItemConformidade> checklist = processo.AvaliarConformidade();
+        foreach (string item in itensDeReferenciaTemporal)
+        {
+            checklist.Should().Contain(i => i.Item == item && i.Ok, $"sem gatilho por FAIXA_ETARIA — \"{item}\" não pode ficar vermelho");
+        }
+
+        Result<VersaoConfiguracao> resultado = Publicar(processo);
+        resultado.IsSuccess.Should().BeTrue(resultado.Error?.Message);
+    }
+}

--- a/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/Outbox/Cascading/EnvelopeFechadoE2ETests.cs
+++ b/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/Outbox/Cascading/EnvelopeFechadoE2ETests.cs
@@ -237,9 +237,14 @@ public sealed class EnvelopeFechadoE2ETests
 
         conformidade.Itens.Should().NotBeEmpty("uma lista vazia daria falso verde por AllSatisfy trivial");
         conformidade.Itens.Select(i => i.Item).Should().OnlyHaveUniqueItems("cada item do checklist aparece uma única vez");
+        // issue #1092: o checklist passou a ser bicondicional com os QUATRO gates estruturais
+        // (antes só projetava PendenciaDeConformidade) — a publicação no passo 16 só devolve 204
+        // porque os quatro gates já estão satisfeitos, então o corpus rico continua OnlyContain(Ok):
+        // a ampliação não pode criar falso vermelho no caminho HTTP completo.
         conformidade.Itens.Should().OnlyContain(i => i.Ok, "o processo está completo — nenhum item deveria estar pendente");
         conformidade.Itens.Select(i => i.Item).Should().BeEquivalentTo(
             [
+                // ── PendenciaDeConformidade (itens estruturais originais) ──
                 "Atendimento especializado",
                 "Distribuição de vagas",
                 "Classificação",
@@ -247,6 +252,30 @@ public sealed class EnvelopeFechadoE2ETests
                 "Base legal das exigências documentais",
                 "Divisor da média (fórmula local)",
                 "Cascata de remanejamento",
+                // ── PendenciaDoCronograma ──
+                "Cronograma: fase que agrupa etapas só quando há etapa pontuada",
+                "Cronograma: etapa pontuada tem fase que agrupa etapas",
+                "Cronograma: inscrição própria tem fase que coleta inscrição",
+                "Cronograma: vagas ofertadas têm fase que produz resultado",
+                // ── PendenciaDaCascata, detalhamento por razão ──
+                "Cascata: modalidade SegueCascata usa a regra de distribuição federal",
+                "Cascata: origem SegueCascata declarada na cascata de remanejamento",
+                "Cascata: fallback e destinos resolvíveis nas modalidades ofertadas",
+                "Cascata: origem declarada corresponde a modalidade SegueCascata ofertada",
+                "Cascata: destino declarado corresponde a modalidade ofertada",
+                // ── PendenciaPreCanonicalizacao ──
+                "Exigência documental: sem CONDICIONAL vazia que determina resultado",
+                "Consequência de indeferimento: REMOVE_VANTAGEM com vantagem viva (exigência)",
+                "Consequência de indeferimento: coerente com a ação da vaga (exigência)",
+                "Consequência de indeferimento: REMOVE_VANTAGEM com vantagem viva (grupo)",
+                "Consequência de indeferimento: coerente com a ação da vaga (grupo)",
+                "Referência temporal de fatos: configurada quando há gatilho por faixa etária",
+                "Referência temporal de fatos: fase âncora pertence ao cronograma",
+                "Referência temporal de fatos: extremo da fase âncora definido",
+                "Referência temporal de fatos: fase de coleta com Fim definido para FIM_INSCRICAO",
+                "Regras de derivação: fatos citados existem no processo",
+                "Regras de derivação: código contribuído pertence ao domínio ofertado",
+                "Grafo de dependência conjunto: sem ciclo",
             ],
             "o conjunto exato de itens que este corpus produz — remover um item do checklist, ou acrescentar um item indevido marcado ok, muda este conjunto");
 


### PR DESCRIPTION
`GET /conformidade` projetava dois dos quatro gates estruturais que a publicação aplica, num docblock que o chamava de "o checklist completo".

## O defeito

Um processo com `OrigemCandidatos = InscricaoPropria` e nenhuma fase que colete inscrição mostrava o checklist **inteiramente verde** e tinha a publicação recusada com `422`. O operador não tinha como saber, pela tela que existe justamente para preparar a publicação, o que corrigir — nem que havia algo a corrigir.

O item `"Cronograma de fases"` afirmava **presença** (`_cronogramaFases.Count > 0`), enquanto `PendenciaDoCronograma()` valida **coerência** por quatro razões distintas. `PendenciaPreCanonicalizacao()`, com mais doze, também não aparecia.

## A correção, e o risco que ela precisava evitar

A saída fácil seria copiar os `if` dos gates para uma segunda lista. Isso recriaria o defeito com mais código: a próxima razão acrescentada a um gate voltaria a não aparecer no checklist.

Em vez disso, cada uma das **21 razões antes não projetadas** virou um predicado nomeado no Domain — `HaInscricaoPropriaSemFaseDeColeta`, `ExisteCascataOrigemAusente`, `ReferenciaTemporalFatosExtremoDaFaseAusente` e assim por diante. As cadeias de `if` dos gates foram reescritas para chamar **esses mesmos predicados**, sem mudança de fluxo de controle, e `AvaliarConformidade()` os chama para montar os itens.

**Nenhuma condição existe em dois lugares.** É isso que impede a divergência futura.

## Prova de que o mecanismo funciona

O mutante testa a correção, não o código: uma razão de recusa foi acrescentada a um gate — um disjunto extra em `HaVagasSemFaseQueProduzResultado` — **sem tocar em `AvaliarConformidade()`**. Num estado que atinge apenas a cláusula nova, o item do checklist **ficou vermelho** e `Publicar()` recusou com o mesmo código.

Se a extração fosse falsa, o checklist teria continuado verde. Desfeito por edição reversa, não commitado.

## Precedência preservada

Coletar todos os veredictos para exibição não podia mudar qual `DomainError` a publicação devolve primeiro. `Precedencia_GatesSimultaneos_PublicarDevolveOPrimeiroNaOrdem` constrói um estado que viola o gate 1 (atendimento ausente) **e** o gate 2 (cronograma), afirma que o checklist mostra **os dois** vermelhos, e que `Publicar()` continua devolvendo `ProcessoSeletivo.ConformidadeInsuficiente` — a ordem em `Publicar`/`SucederVersao` está intocada.

## A delimitação, que não pode ser perdida

Isto é publicabilidade **estrutural do agregado**, não ensaio do command handler. Mesmo com os quatro gates verdes, a publicação ainda pode recusar por conformidade legal, documento confirmado, tipo de ato e outras leituras externas. A documentação diz "estrutural" — chamar de "publicável" sem qualificador seria trocar um texto falso por outro.

Conformidade legal continua em `/conformidade-legal`.

Também foi corrigido o docblock do DTO, que afirmava cobrir `Etapas (1..*)` — falso desde que etapa deixou de ser item incondicional, e que orientaria uma tela SiSU a exigir etapa num estado válido e publicável.

## Tamanho da resposta

De 6-7 itens para **27 num processo conforme, 28 com fórmula de média ponderada** — contados empiricamente, não estimados. É o custo de a lista ser acionável: agrupar razões para encurtá-la esconderia qual falhou, que é o defeito de origem. Agrupamento visual é decisão da UI.

Não há consumidor da rota no frontend hoje — apenas baseline OpenAPI e tipos gerados —, então a ampliação não quebra tela implementada.

## Verificação

- suíte completa: **4.630 testes, 26 assemblies, zero falhas**
- build: **0 avisos, 0 erros**
- `dotnet format --verify-no-changes`: limpo
- matriz nova com 26 casos, pareando cada código alcançável ao seu item, com contraprovas para os ramos fáceis de confundir (classificação importada sem etapa, cronograma coerente, cascata não aplicável, ausência de gatilho etário) — estados válidos que não podem virar falso vermelho

Sem migration: só avaliação e projeção de estado existente.

Closes #1092
