### PR TITLE
feat(configuracao): filtra termos de consentimento por nome na listagem

### DIFF
--- a/contracts/openapi.configuracao.json
+++ b/contracts/openapi.configuracao.json
@@ -6121,7 +6121,7 @@
           {
             "name": "q",
             "in": "query",
-            "description": "Termo de busca livre (caixa-insens\u00EDvel) sobre o Nome do termo de consentimento; ausente/vazio = sem filtro. Mantenha fixo ao navegar prev/next (o cursor n\u00E3o vincula o filtro).",
+            "description": "Termo de busca livre (caixa-insens\u00EDvel) sobre o Nome do termo de consentimento; ausente/vazio = sem filtro. M\u00EDnimo de 3 caracteres (busca por proximidade indexada via pg_trgm). Mantenha fixo ao navegar prev/next (o cursor n\u00E3o vincula o filtro).",
             "schema": {
               "type": "string"
             }

--- a/contracts/openapi.configuracao.json
+++ b/contracts/openapi.configuracao.json
@@ -6121,7 +6121,7 @@
           {
             "name": "q",
             "in": "query",
-            "description": "Termo de busca livre (caixa-insens\u00EDvel) sobre o Nome do termo de consentimento; ausente/vazio = sem filtro. M\u00EDnimo de 3 caracteres (busca por proximidade indexada via pg_trgm). Mantenha fixo ao navegar prev/next (o cursor n\u00E3o vincula o filtro).",
+            "description": "Termo de busca livre (caixa-insens\u00EDvel) sobre o Nome do termo de consentimento; ausente/vazio = sem filtro. Mantenha fixo ao navegar prev/next (o cursor n\u00E3o vincula o filtro).",
             "schema": {
               "type": "string"
             }

--- a/contracts/openapi.configuracao.json
+++ b/contracts/openapi.configuracao.json
@@ -6119,6 +6119,14 @@
         ],
         "parameters": [
           {
+            "name": "q",
+            "in": "query",
+            "description": "Termo de busca livre (caixa-insens\u00EDvel) sobre o Nome do termo de consentimento; ausente/vazio = sem filtro. Mantenha fixo ao navegar prev/next (o cursor n\u00E3o vincula o filtro).",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
             "name": "cursor",
             "in": "query",
             "description": "Cursor opaco AES-GCM emitido pelo servidor no header Link da p\u00E1gina anterior. Ausente na primeira p\u00E1gina. Cliente trata como string opaca \u2014 n\u00E3o decodificar (ADR-0026, ADR-0031).",

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.API/Controllers/TermosConsentimentoController.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.API/Controllers/TermosConsentimentoController.cs
@@ -33,7 +33,7 @@ public sealed class TermosConsentimentoController : ControllerBase
     private const string ResourceTag = "termos-consentimento";
 
     /// <summary>Limite defensivo do termo de busca — igual ao <c>Nome</c> máximo da entidade.</summary>
-    private const int BuscaMaxLength = 200;
+    private const int SearchTermMaxLength = 200;
 
     private readonly ICommandBus _commandBus;
     private readonly IQueryBus _queryBus;
@@ -89,18 +89,23 @@ public sealed class TermosConsentimentoController : ControllerBase
     {
         ArgumentNullException.ThrowIfNull(page);
 
-        if (q is { Length: > BuscaMaxLength })
+        // Normaliza (trim) ANTES de checar o tamanho — um termo com espaços nas
+        // pontas que só excede 200 caracteres por causa deles não pode ser
+        // rejeitado quando o valor normalizado cabe no limite.
+        string? searchTerm = string.IsNullOrWhiteSpace(q) ? null : q.Trim();
+
+        if (searchTerm is { Length: > SearchTermMaxLength })
         {
             return BadRequest(new ProblemDetails
             {
                 Title = "Termo de busca muito longo",
-                Detail = $"O parâmetro 'q' não pode exceder {BuscaMaxLength} caracteres.",
+                Detail = $"O parâmetro 'q' não pode exceder {SearchTermMaxLength} caracteres.",
                 Status = StatusCodes.Status400BadRequest,
             });
         }
 
         ListarTermosConsentimentoResult resultado = await _queryBus
-            .Send(new ListarTermosConsentimentoQuery(page.AfterId, page.Limit, page.Direction, q), cancellationToken)
+            .Send(new ListarTermosConsentimentoQuery(page.AfterId, page.Limit, page.Direction, searchTerm), cancellationToken)
             .ConfigureAwait(false);
 
         TermoConsentimentoResumoDto[] comLinks =

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.API/Controllers/TermosConsentimentoController.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.API/Controllers/TermosConsentimentoController.cs
@@ -1,5 +1,6 @@
 namespace Unifesspa.UniPlus.Configuracao.API.Controllers;
 
+using System.ComponentModel;
 using System.Diagnostics.CodeAnalysis;
 
 using Microsoft.AspNetCore.Authorization;
@@ -31,6 +32,9 @@ public sealed class TermosConsentimentoController : ControllerBase
 {
     private const string ResourceTag = "termos-consentimento";
 
+    /// <summary>Limite defensivo do termo de busca — igual ao <c>Nome</c> máximo da entidade.</summary>
+    private const int BuscaMaxLength = 200;
+
     private readonly ICommandBus _commandBus;
     private readonly IQueryBus _queryBus;
     private readonly IDomainErrorMapper _mapper;
@@ -54,8 +58,19 @@ public sealed class TermosConsentimentoController : ControllerBase
     /// <summary>
     /// Lista os termos de consentimento vivos, paginados por cursor opaco
     /// bidirecional (ADR-0026 + ADR-0089). Não inclui as versões promovidas —
-    /// use <see cref="ObterPorId"/> para o termo completo.
+    /// use <see cref="ObterPorId"/> para o termo completo. Aceita filtro
+    /// opcional de busca por nome (issue #1105); o cliente reanexa o filtro a
+    /// cada página ao seguir o <c>cursor</c> do header <c>Link</c> — que já o
+    /// preserva automaticamente.
     /// </summary>
+    /// <param name="page">Cursor decodificado (<c>cursor</c>/<c>limit</c>/<c>direction</c> da wire).</param>
+    /// <param name="q">
+    /// Termo de busca livre (caixa-insensível) sobre o <c>Nome</c> do termo;
+    /// ausente/vazio = sem filtro. Trocar o termo entre páginas de uma mesma
+    /// navegação produz resultados inconsistentes — o cursor não vincula o
+    /// filtro (ADR-0026), então mantenha <c>q</c> fixo ao seguir prev/next.
+    /// </param>
+    /// <param name="cancellationToken">Token de cancelamento da requisição.</param>
     [HttpGet("termos-consentimento")]
     [AllowAnonymous]
     [VendorMediaType(Resource = "termo-consentimento", Versions = [1])]
@@ -66,12 +81,26 @@ public sealed class TermosConsentimentoController : ControllerBase
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status422UnprocessableEntity)]
     public async Task<IActionResult> Listar(
         [FromCursor(ResourceTag)] PageRequest page,
+        [FromQuery(Name = "q")] [Description(
+            "Termo de busca livre (caixa-insensível) sobre o Nome do termo de consentimento; " +
+            "ausente/vazio = sem filtro. Mantenha fixo ao navegar prev/next (o cursor não vincula o filtro).")]
+        string? q,
         CancellationToken cancellationToken)
     {
         ArgumentNullException.ThrowIfNull(page);
 
+        if (q is { Length: > BuscaMaxLength })
+        {
+            return BadRequest(new ProblemDetails
+            {
+                Title = "Termo de busca muito longo",
+                Detail = $"O parâmetro 'q' não pode exceder {BuscaMaxLength} caracteres.",
+                Status = StatusCodes.Status400BadRequest,
+            });
+        }
+
         ListarTermosConsentimentoResult resultado = await _queryBus
-            .Send(new ListarTermosConsentimentoQuery(page.AfterId, page.Limit, page.Direction), cancellationToken)
+            .Send(new ListarTermosConsentimentoQuery(page.AfterId, page.Limit, page.Direction, q), cancellationToken)
             .ConfigureAwait(false);
 
         TermoConsentimentoResumoDto[] comLinks =

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.API/Controllers/TermosConsentimentoController.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.API/Controllers/TermosConsentimentoController.cs
@@ -35,6 +35,13 @@ public sealed class TermosConsentimentoController : ControllerBase
     /// <summary>Limite defensivo do termo de busca — igual ao <c>Nome</c> máximo da entidade.</summary>
     private const int SearchTermMaxLength = 200;
 
+    /// <summary>
+    /// Piso do termo de busca — abaixo de 3 caracteres, o word_similarity do
+    /// pg_trgm (threshold padrão 0.6) não tem trigramas suficientes para casar
+    /// de forma confiável (ex.: 1 caractere não forma nenhum trigrama completo).
+    /// </summary>
+    private const int SearchTermMinLength = 3;
+
     private readonly ICommandBus _commandBus;
     private readonly IQueryBus _queryBus;
     private readonly IDomainErrorMapper _mapper;
@@ -66,9 +73,11 @@ public sealed class TermosConsentimentoController : ControllerBase
     /// <param name="page">Cursor decodificado (<c>cursor</c>/<c>limit</c>/<c>direction</c> da wire).</param>
     /// <param name="q">
     /// Termo de busca livre (caixa-insensível) sobre o <c>Nome</c> do termo;
-    /// ausente/vazio = sem filtro. Trocar o termo entre páginas de uma mesma
-    /// navegação produz resultados inconsistentes — o cursor não vincula o
-    /// filtro (ADR-0026), então mantenha <c>q</c> fixo ao seguir prev/next.
+    /// ausente/vazio = sem filtro. Mínimo de 3 caracteres (busca por
+    /// proximidade indexada via pg_trgm, ver <see cref="SearchTermMinLength"/>).
+    /// Trocar o termo entre páginas de uma mesma navegação produz resultados
+    /// inconsistentes — o cursor não vincula o filtro (ADR-0026), então
+    /// mantenha <c>q</c> fixo ao seguir prev/next.
     /// </param>
     /// <param name="cancellationToken">Token de cancelamento da requisição.</param>
     [HttpGet("termos-consentimento")]
@@ -83,7 +92,8 @@ public sealed class TermosConsentimentoController : ControllerBase
         [FromCursor(ResourceTag)] PageRequest page,
         [FromQuery(Name = "q")] [Description(
             "Termo de busca livre (caixa-insensível) sobre o Nome do termo de consentimento; " +
-            "ausente/vazio = sem filtro. Mantenha fixo ao navegar prev/next (o cursor não vincula o filtro).")]
+            "ausente/vazio = sem filtro. Mínimo de 3 caracteres (busca por proximidade indexada " +
+            "via pg_trgm). Mantenha fixo ao navegar prev/next (o cursor não vincula o filtro).")]
         string? q,
         CancellationToken cancellationToken)
     {
@@ -100,6 +110,20 @@ public sealed class TermosConsentimentoController : ControllerBase
             {
                 Title = "Termo de busca muito longo",
                 Detail = $"O parâmetro 'q' não pode exceder {SearchTermMaxLength} caracteres.",
+                Status = StatusCodes.Status400BadRequest,
+            });
+        }
+
+        // Abaixo do piso, o word_similarity do pg_trgm não tem trigramas
+        // suficientes para casar de forma confiável (issue #1105) — rejeitar
+        // explicitamente em vez de devolver uma lista vazia silenciosa.
+        if (searchTerm is { Length: > 0 and < SearchTermMinLength })
+        {
+            return BadRequest(new ProblemDetails
+            {
+                Title = "Termo de busca muito curto",
+                Detail = $"O parâmetro 'q' precisa ter ao menos {SearchTermMinLength} caracteres " +
+                    "(ou ser omitido) — abaixo disso a busca por proximidade não tem trigramas suficientes.",
                 Status = StatusCodes.Status400BadRequest,
             });
         }

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.API/Controllers/TermosConsentimentoController.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.API/Controllers/TermosConsentimentoController.cs
@@ -35,13 +35,6 @@ public sealed class TermosConsentimentoController : ControllerBase
     /// <summary>Limite defensivo do termo de busca — igual ao <c>Nome</c> máximo da entidade.</summary>
     private const int SearchTermMaxLength = 200;
 
-    /// <summary>
-    /// Piso do termo de busca — abaixo de 3 caracteres, o word_similarity do
-    /// pg_trgm (threshold padrão 0.6) não tem trigramas suficientes para casar
-    /// de forma confiável (ex.: 1 caractere não forma nenhum trigrama completo).
-    /// </summary>
-    private const int SearchTermMinLength = 3;
-
     private readonly ICommandBus _commandBus;
     private readonly IQueryBus _queryBus;
     private readonly IDomainErrorMapper _mapper;
@@ -73,11 +66,9 @@ public sealed class TermosConsentimentoController : ControllerBase
     /// <param name="page">Cursor decodificado (<c>cursor</c>/<c>limit</c>/<c>direction</c> da wire).</param>
     /// <param name="q">
     /// Termo de busca livre (caixa-insensível) sobre o <c>Nome</c> do termo;
-    /// ausente/vazio = sem filtro. Mínimo de 3 caracteres (busca por
-    /// proximidade indexada via pg_trgm, ver <see cref="SearchTermMinLength"/>).
-    /// Trocar o termo entre páginas de uma mesma navegação produz resultados
-    /// inconsistentes — o cursor não vincula o filtro (ADR-0026), então
-    /// mantenha <c>q</c> fixo ao seguir prev/next.
+    /// ausente/vazio = sem filtro. Trocar o termo entre páginas de uma mesma
+    /// navegação produz resultados inconsistentes — o cursor não vincula o
+    /// filtro (ADR-0026), então mantenha <c>q</c> fixo ao seguir prev/next.
     /// </param>
     /// <param name="cancellationToken">Token de cancelamento da requisição.</param>
     [HttpGet("termos-consentimento")]
@@ -92,8 +83,7 @@ public sealed class TermosConsentimentoController : ControllerBase
         [FromCursor(ResourceTag)] PageRequest page,
         [FromQuery(Name = "q")] [Description(
             "Termo de busca livre (caixa-insensível) sobre o Nome do termo de consentimento; " +
-            "ausente/vazio = sem filtro. Mínimo de 3 caracteres (busca por proximidade indexada " +
-            "via pg_trgm). Mantenha fixo ao navegar prev/next (o cursor não vincula o filtro).")]
+            "ausente/vazio = sem filtro. Mantenha fixo ao navegar prev/next (o cursor não vincula o filtro).")]
         string? q,
         CancellationToken cancellationToken)
     {
@@ -110,20 +100,6 @@ public sealed class TermosConsentimentoController : ControllerBase
             {
                 Title = "Termo de busca muito longo",
                 Detail = $"O parâmetro 'q' não pode exceder {SearchTermMaxLength} caracteres.",
-                Status = StatusCodes.Status400BadRequest,
-            });
-        }
-
-        // Abaixo do piso, o word_similarity do pg_trgm não tem trigramas
-        // suficientes para casar de forma confiável (issue #1105) — rejeitar
-        // explicitamente em vez de devolver uma lista vazia silenciosa.
-        if (searchTerm is { Length: > 0 and < SearchTermMinLength })
-        {
-            return BadRequest(new ProblemDetails
-            {
-                Title = "Termo de busca muito curto",
-                Detail = $"O parâmetro 'q' precisa ter ao menos {SearchTermMinLength} caracteres " +
-                    "(ou ser omitido) — abaixo disso a busca por proximidade não tem trigramas suficientes.",
                 Status = StatusCodes.Status400BadRequest,
             });
         }

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Queries/TermosConsentimento/ListarTermosConsentimentoQuery.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Queries/TermosConsentimento/ListarTermosConsentimentoQuery.cs
@@ -11,15 +11,15 @@ using Unifesspa.UniPlus.Kernel.Pagination;
 /// <param name="AfterId">Âncora da página anterior; <c>null</c> retorna a primeira janela.</param>
 /// <param name="Limit">Tamanho máximo da página a retornar.</param>
 /// <param name="Direction">Direção de navegação (<c>Next</c>/<c>Prev</c>, ADR-0089).</param>
-/// <param name="Busca">
+/// <param name="SearchTerm">
 /// Termo de busca livre (caixa-insensível) sobre <c>Nome</c>; <c>null</c>/vazio = sem
-/// filtro textual. O handler normaliza. Trocar o termo entre páginas de uma mesma
-/// navegação produz resultados inconsistentes — o cursor não vincula o filtro
-/// (ADR-0026), então o cliente deve manter <c>Busca</c> fixo ao seguir prev/next
-/// (os links já o preservam automaticamente).
+/// filtro textual. Já normalizado (trim) pelo controller. Trocar o termo entre
+/// páginas de uma mesma navegação produz resultados inconsistentes — o cursor não
+/// vincula o filtro (ADR-0026), então o cliente deve manter <c>SearchTerm</c> fixo
+/// ao seguir prev/next (os links já o preservam automaticamente).
 /// </param>
 public sealed record ListarTermosConsentimentoQuery(
     Guid? AfterId,
     int Limit,
     PaginationDirection Direction,
-    string? Busca) : IQuery<ListarTermosConsentimentoResult>;
+    string? SearchTerm) : IQuery<ListarTermosConsentimentoResult>;

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Queries/TermosConsentimento/ListarTermosConsentimentoQuery.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Queries/TermosConsentimento/ListarTermosConsentimentoQuery.cs
@@ -8,7 +8,18 @@ using Unifesspa.UniPlus.Kernel.Pagination;
 /// (ADR-0026 + ADR-0089). Sem as versões promovidas — use
 /// <c>ObterTermoConsentimentoPorIdQuery</c> para o termo completo.
 /// </summary>
+/// <param name="AfterId">Âncora da página anterior; <c>null</c> retorna a primeira janela.</param>
+/// <param name="Limit">Tamanho máximo da página a retornar.</param>
+/// <param name="Direction">Direção de navegação (<c>Next</c>/<c>Prev</c>, ADR-0089).</param>
+/// <param name="Busca">
+/// Termo de busca livre (caixa-insensível) sobre <c>Nome</c>; <c>null</c>/vazio = sem
+/// filtro textual. O handler normaliza. Trocar o termo entre páginas de uma mesma
+/// navegação produz resultados inconsistentes — o cursor não vincula o filtro
+/// (ADR-0026), então o cliente deve manter <c>Busca</c> fixo ao seguir prev/next
+/// (os links já o preservam automaticamente).
+/// </param>
 public sealed record ListarTermosConsentimentoQuery(
     Guid? AfterId,
     int Limit,
-    PaginationDirection Direction) : IQuery<ListarTermosConsentimentoResult>;
+    PaginationDirection Direction,
+    string? Busca) : IQuery<ListarTermosConsentimentoResult>;

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Queries/TermosConsentimento/ListarTermosConsentimentoQueryHandler.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Queries/TermosConsentimento/ListarTermosConsentimentoQueryHandler.cs
@@ -15,8 +15,10 @@ public static class ListarTermosConsentimentoQueryHandler
         ArgumentNullException.ThrowIfNull(query);
         ArgumentNullException.ThrowIfNull(repository);
 
+        string? busca = string.IsNullOrWhiteSpace(query.Busca) ? null : query.Busca;
+
         (IReadOnlyList<TermoConsentimento> itens, Guid? anteriorAfterId, Guid? proximoAfterId) = await repository
-            .ListarPaginadoAsync(query.AfterId, query.Limit, query.Direction, cancellationToken)
+            .ListarPaginadoAsync(query.AfterId, query.Limit, query.Direction, busca, cancellationToken)
             .ConfigureAwait(false);
 
         TermoConsentimentoResumoDto[] items = [.. itens.Select(t => t.ToResumoDto())];

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Queries/TermosConsentimento/ListarTermosConsentimentoQueryHandler.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Application/Queries/TermosConsentimento/ListarTermosConsentimentoQueryHandler.cs
@@ -15,10 +15,10 @@ public static class ListarTermosConsentimentoQueryHandler
         ArgumentNullException.ThrowIfNull(query);
         ArgumentNullException.ThrowIfNull(repository);
 
-        string? busca = string.IsNullOrWhiteSpace(query.Busca) ? null : query.Busca;
+        string? searchTerm = string.IsNullOrWhiteSpace(query.SearchTerm) ? null : query.SearchTerm;
 
         (IReadOnlyList<TermoConsentimento> itens, Guid? anteriorAfterId, Guid? proximoAfterId) = await repository
-            .ListarPaginadoAsync(query.AfterId, query.Limit, query.Direction, busca, cancellationToken)
+            .ListarPaginadoAsync(query.AfterId, query.Limit, query.Direction, searchTerm, cancellationToken)
             .ConfigureAwait(false);
 
         TermoConsentimentoResumoDto[] items = [.. itens.Select(t => t.ToResumoDto())];

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Domain/Interfaces/ITermoConsentimentoRepository.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Domain/Interfaces/ITermoConsentimentoRepository.cs
@@ -20,14 +20,14 @@ public interface ITermoConsentimentoRepository
     /// Lista termos vivos paginados por cursor keyset bidirecional (ADR-0026 +
     /// ADR-0089): ordena por <c>Id</c> (Guid v7, ADR-0032) e devolve as âncoras
     /// de <c>prev</c>/<c>next</c> (nulas quando não há aquele lado). O filtro de
-    /// <paramref name="busca"/>, quando informado, é aplicado ANTES do keyset —
+    /// <paramref name="searchTerm"/>, quando informado, é aplicado ANTES do keyset —
     /// busca e paginação descrevem o mesmo conjunto de resultados (issue #1105).
     /// </summary>
     Task<(IReadOnlyList<TermoConsentimento> Itens, Guid? AnteriorAfterId, Guid? ProximoAfterId)> ListarPaginadoAsync(
         Guid? afterId,
         int limit,
         PaginationDirection direction,
-        string? busca,
+        string? searchTerm,
         CancellationToken cancellationToken);
 
     Task AdicionarAsync(TermoConsentimento termo, CancellationToken cancellationToken);

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Domain/Interfaces/ITermoConsentimentoRepository.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Domain/Interfaces/ITermoConsentimentoRepository.cs
@@ -19,12 +19,15 @@ public interface ITermoConsentimentoRepository
     /// <summary>
     /// Lista termos vivos paginados por cursor keyset bidirecional (ADR-0026 +
     /// ADR-0089): ordena por <c>Id</c> (Guid v7, ADR-0032) e devolve as âncoras
-    /// de <c>prev</c>/<c>next</c> (nulas quando não há aquele lado).
+    /// de <c>prev</c>/<c>next</c> (nulas quando não há aquele lado). O filtro de
+    /// <paramref name="busca"/>, quando informado, é aplicado ANTES do keyset —
+    /// busca e paginação descrevem o mesmo conjunto de resultados (issue #1105).
     /// </summary>
     Task<(IReadOnlyList<TermoConsentimento> Itens, Guid? AnteriorAfterId, Guid? ProximoAfterId)> ListarPaginadoAsync(
         Guid? afterId,
         int limit,
         PaginationDirection direction,
+        string? busca,
         CancellationToken cancellationToken);
 
     Task AdicionarAsync(TermoConsentimento termo, CancellationToken cancellationToken);

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Infrastructure/Persistence/ConfiguracaoDbContext.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Infrastructure/Persistence/ConfiguracaoDbContext.cs
@@ -101,6 +101,11 @@ public sealed class ConfiguracaoDbContext : DbContext, IConfiguracaoUnitOfWork
         // default do modelo — tabelas, índices, FKs e idempotency_cache deste
         // módulo passam a ser qualificados por `configuracao`.
         modelBuilder.HasDefaultSchema(Schema);
+        // pg_trgm: busca por proximidade indexada (GIN trigram) do catálogo de
+        // termos de consentimento por nome (issue #1105) — evita ILIKE em full
+        // scan. Extensão global ao banco; o índice de expressão em si (não
+        // representável via HasIndex fluente) vive na migration.
+        modelBuilder.HasPostgresExtension("pg_trgm");
         modelBuilder.ApplyConfigurationsFromAssembly(typeof(ConfiguracaoDbContext).Assembly);
         // Configurações cross-cutting de Infrastructure.Core (idempotency_cache).
         modelBuilder.ApplyConfigurationsFromAssembly(typeof(IdempotencyEntry).Assembly);

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Infrastructure/Persistence/Migrations/20260811171612_AdicionaBuscaTrigramTermoConsentimento.Designer.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Infrastructure/Persistence/Migrations/20260811171612_AdicionaBuscaTrigramTermoConsentimento.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Unifesspa.UniPlus.Configuracao.Infrastructure.Persistence;
@@ -11,9 +12,11 @@ using Unifesspa.UniPlus.Configuracao.Infrastructure.Persistence;
 namespace Unifesspa.UniPlus.Configuracao.Infrastructure.Persistence.Migrations
 {
     [DbContext(typeof(ConfiguracaoDbContext))]
-    partial class ConfiguracaoDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260811171612_AdicionaBuscaTrigramTermoConsentimento")]
+    partial class AdicionaBuscaTrigramTermoConsentimento
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Infrastructure/Persistence/Migrations/20260811171612_AdicionaBuscaTrigramTermoConsentimento.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Infrastructure/Persistence/Migrations/20260811171612_AdicionaBuscaTrigramTermoConsentimento.cs
@@ -1,0 +1,38 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Unifesspa.UniPlus.Configuracao.Infrastructure.Persistence.Migrations
+{
+    /// <inheritdoc />
+    public partial class AdicionaBuscaTrigramTermoConsentimento : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterDatabase()
+                .Annotation("Npgsql:PostgresExtension:pg_trgm", ",,");
+
+            // Índice de expressão (não representável via HasIndex fluente do EF
+            // Core) para acelerar a busca por proximidade (issue #1105):
+            // lower(nome) casa com EF.Functions.TrigramsAreWordSimilar(termo,
+            // nome.ToLower()) no repositório, mantendo a busca caixa-insensível.
+            // lower() é IMMUTABLE nativamente — sem wrapper (diferente de
+            // immutable_unaccent em Organização Institucional). Parcial por
+            // is_deleted, espelhando ix_termo_consentimento_nome.
+            migrationBuilder.Sql(
+                """
+                CREATE INDEX IF NOT EXISTS ix_termo_consentimento_nome_trgm
+                  ON configuracao.termo_consentimento USING GIN (lower(nome) gin_trgm_ops)
+                  WHERE is_deleted = false;
+                """);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            // Forward-only per ADR-0054 §J.
+            throw new System.NotSupportedException("Forward-only migration per ADR-0054 §J.");
+        }
+    }
+}

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Infrastructure/Persistence/Repositories/TermoConsentimentoRepository.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Infrastructure/Persistence/Repositories/TermoConsentimentoRepository.cs
@@ -49,13 +49,13 @@ public sealed class TermoConsentimentoRepository : ITermoConsentimentoRepository
         Guid? afterId,
         int limit,
         PaginationDirection direction,
-        string? busca,
+        string? searchTerm,
         CancellationToken cancellationToken)
     {
         // Sem Include de Versoes — a listagem projeta só o cabeçalho do termo.
         IQueryable<TermoConsentimento> query = _dbContext.TermosConsentimento.AsNoTracking();
 
-        if (!string.IsNullOrWhiteSpace(busca))
+        if (!string.IsNullOrWhiteSpace(searchTerm))
         {
             // Busca por proximidade indexada via pg_trgm (issue #1105), não ILIKE:
             // full scan por ILIKE '%termo%' não usa índice B-tree para wildcard à
@@ -65,8 +65,8 @@ public sealed class TermoConsentimentoRepository : ITermoConsentimentoRepository
             // lower(nome) (migration AdicionaBuscaTrigramTermoConsentimento).
             // lower() nos dois lados mantém a busca caixa-insensível; sem
             // acento-insensibilidade (fora de escopo da issue).
-            string termo = busca.Trim().ToLowerInvariant();
-            query = query.Where(t => EF.Functions.TrigramsAreWordSimilar(termo, t.Nome.ToLower()));
+            string term = searchTerm.Trim().ToLowerInvariant();
+            query = query.Where(t => EF.Functions.TrigramsAreWordSimilar(term, t.Nome.ToLower()));
         }
 
         // Keyset bidirecional (ADR-0089): ordenação por Id (Guid v7, ADR-0026/0032),

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Infrastructure/Persistence/Repositories/TermoConsentimentoRepository.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Infrastructure/Persistence/Repositories/TermoConsentimentoRepository.cs
@@ -69,7 +69,7 @@ public sealed class TermoConsentimentoRepository : ITermoConsentimentoRepository
             // mantém a busca caixa-insensível e casa com o índice; sem
             // acento-insensibilidade (fora de escopo da issue). Curingas do LIKE
             // (% _ \) são escapados para virarem texto literal.
-            string term = EscaparCuringasLike(searchTerm.Trim());
+            string term = EscapeLikeWildcards(searchTerm.Trim());
             string pattern = "%" + term + "%";
             const string escape = @"\";
             query = query.Where(t => EF.Functions.ILike(t.Nome.ToLower(), pattern, escape));
@@ -89,8 +89,8 @@ public sealed class TermoConsentimentoRepository : ITermoConsentimentoRepository
     // pelo usuário sejam comparados como texto literal, não wildcards — sem isso,
     // searchTerm="_" ou searchTerm="%" casaria quase qualquer registro. Barra
     // invertida escapada primeiro para não duplicar as inseridas ao escapar % e _.
-    private static string EscaparCuringasLike(string termo) =>
-        termo
+    private static string EscapeLikeWildcards(string term) =>
+        term
             .Replace("\\", "\\\\", StringComparison.Ordinal)
             .Replace("%", "\\%", StringComparison.Ordinal)
             .Replace("_", "\\_", StringComparison.Ordinal);

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Infrastructure/Persistence/Repositories/TermoConsentimentoRepository.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Infrastructure/Persistence/Repositories/TermoConsentimentoRepository.cs
@@ -36,16 +36,44 @@ public sealed class TermoConsentimentoRepository : ITermoConsentimentoRepository
             .FirstOrDefaultAsync(t => t.Id == id, cancellationToken);
     }
 
+    [System.Diagnostics.CodeAnalysis.SuppressMessage(
+        "Globalization",
+        "CA1304:Specify CultureInfo",
+        Justification = "t.Nome.ToLower() vive dentro de uma expression tree traduzida pelo EF Core " +
+            "para SQL lower(nome) — roda no Postgres, sem CurrentCulture do processo .NET envolvida.")]
+    [System.Diagnostics.CodeAnalysis.SuppressMessage(
+        "Globalization",
+        "CA1311:Specify a culture or use an invariant version",
+        Justification = "Mesma razão de CA1304 — chamada traduzida para SQL, não executada em CLR.")]
     public async Task<(IReadOnlyList<TermoConsentimento> Itens, Guid? AnteriorAfterId, Guid? ProximoAfterId)> ListarPaginadoAsync(
         Guid? afterId,
         int limit,
         PaginationDirection direction,
+        string? busca,
         CancellationToken cancellationToken)
     {
-        // Keyset bidirecional (ADR-0089): ordenação por Id (Guid v7, ADR-0026/0032).
         // Sem Include de Versoes — a listagem projeta só o cabeçalho do termo.
+        IQueryable<TermoConsentimento> query = _dbContext.TermosConsentimento.AsNoTracking();
+
+        if (!string.IsNullOrWhiteSpace(busca))
+        {
+            // Busca por proximidade indexada via pg_trgm (issue #1105), não ILIKE:
+            // full scan por ILIKE '%termo%' não usa índice B-tree para wildcard à
+            // esquerda; word_similarity (operador <%, extensão pg_trgm) casa o
+            // termo curto contra qualquer trecho contínuo de nome e é acelerado
+            // pelo índice GIN de expressão ix_termo_consentimento_nome_trgm sobre
+            // lower(nome) (migration AdicionaBuscaTrigramTermoConsentimento).
+            // lower() nos dois lados mantém a busca caixa-insensível; sem
+            // acento-insensibilidade (fora de escopo da issue).
+            string termo = busca.Trim().ToLowerInvariant();
+            query = query.Where(t => EF.Functions.TrigramsAreWordSimilar(termo, t.Nome.ToLower()));
+        }
+
+        // Keyset bidirecional (ADR-0089): ordenação por Id (Guid v7, ADR-0026/0032),
+        // aplicado sobre a query JÁ FILTRADA — os EXISTS internos do helper herdam
+        // o mesmo filtro de busca.
         CursorKeysetPage<TermoConsentimento> page = await CursorKeyset
-            .ApplyAsync(_dbContext.TermosConsentimento.AsNoTracking(), afterId, limit, direction, cancellationToken)
+            .ApplyAsync(query, afterId, limit, direction, cancellationToken)
             .ConfigureAwait(false);
 
         return (page.Items, page.PrevAfterId, page.NextAfterId);

--- a/src/configuracao/Unifesspa.UniPlus.Configuracao.Infrastructure/Persistence/Repositories/TermoConsentimentoRepository.cs
+++ b/src/configuracao/Unifesspa.UniPlus.Configuracao.Infrastructure/Persistence/Repositories/TermoConsentimentoRepository.cs
@@ -57,16 +57,22 @@ public sealed class TermoConsentimentoRepository : ITermoConsentimentoRepository
 
         if (!string.IsNullOrWhiteSpace(searchTerm))
         {
-            // Busca por proximidade indexada via pg_trgm (issue #1105), não ILIKE:
-            // full scan por ILIKE '%termo%' não usa índice B-tree para wildcard à
-            // esquerda; word_similarity (operador <%, extensão pg_trgm) casa o
-            // termo curto contra qualquer trecho contínuo de nome e é acelerado
+            // Busca indexada via pg_trgm (issue #1105): ILIKE '%termo%' acelerado
             // pelo índice GIN de expressão ix_termo_consentimento_nome_trgm sobre
-            // lower(nome) (migration AdicionaBuscaTrigramTermoConsentimento).
-            // lower() nos dois lados mantém a busca caixa-insensível; sem
-            // acento-insensibilidade (fora de escopo da issue).
-            string term = searchTerm.Trim().ToLowerInvariant();
-            query = query.Where(t => EF.Functions.TrigramsAreWordSimilar(term, t.Nome.ToLower()));
+            // lower(nome) (migration AdicionaBuscaTrigramTermoConsentimento) — o
+            // opclass gin_trgm_ops também acelera LIKE/ILIKE, não só os operadores
+            // de similaridade. Preferido a word_similarity/<%: abaixo do threshold
+            // padrão (0.6) esse operador não garante casar substrings internas
+            // curtas (ex.: "lat" não bate com "Plataforma", mesmo com termo válido
+            // e presente) — ILIKE dá semântica de "contains" exata, sem depender de
+            // limiar algum, para qualquer tamanho de termo. lower() nos dois lados
+            // mantém a busca caixa-insensível e casa com o índice; sem
+            // acento-insensibilidade (fora de escopo da issue). Curingas do LIKE
+            // (% _ \) são escapados para virarem texto literal.
+            string term = EscaparCuringasLike(searchTerm.Trim());
+            string pattern = "%" + term + "%";
+            const string escape = @"\";
+            query = query.Where(t => EF.Functions.ILike(t.Nome.ToLower(), pattern, escape));
         }
 
         // Keyset bidirecional (ADR-0089): ordenação por Id (Guid v7, ADR-0026/0032),
@@ -78,6 +84,16 @@ public sealed class TermoConsentimentoRepository : ITermoConsentimentoRepository
 
         return (page.Items, page.PrevAfterId, page.NextAfterId);
     }
+
+    // Escapa os curingas do LIKE/ILIKE (\ % _) para que metacaracteres digitados
+    // pelo usuário sejam comparados como texto literal, não wildcards — sem isso,
+    // searchTerm="_" ou searchTerm="%" casaria quase qualquer registro. Barra
+    // invertida escapada primeiro para não duplicar as inseridas ao escapar % e _.
+    private static string EscaparCuringasLike(string termo) =>
+        termo
+            .Replace("\\", "\\\\", StringComparison.Ordinal)
+            .Replace("%", "\\%", StringComparison.Ordinal)
+            .Replace("_", "\\_", StringComparison.Ordinal);
 
     public async Task AdicionarAsync(TermoConsentimento termo, CancellationToken cancellationToken)
     {

--- a/tests/Unifesspa.UniPlus.Configuracao.IntegrationTests/TermosConsentimento/TermoConsentimentoEndpointTests.cs
+++ b/tests/Unifesspa.UniPlus.Configuracao.IntegrationTests/TermosConsentimento/TermoConsentimentoEndpointTests.cs
@@ -337,16 +337,12 @@ public sealed class TermoConsentimentoEndpointTests
     {
         string body = await response.Content.ReadAsStringAsync();
         using JsonDocument doc = JsonDocument.Parse(body);
-        List<string> nomes = [];
-        foreach (JsonElement item in doc.RootElement.EnumerateArray())
-        {
-            if (item.TryGetProperty("nome", out JsonElement nome) && nome.GetString() is { } valor)
-            {
-                nomes.Add(valor);
-            }
-        }
-
-        return nomes;
+        return
+        [
+            .. doc.RootElement.EnumerateArray()
+                .Select(item => item.TryGetProperty("nome", out JsonElement nome) ? nome.GetString() : null)
+                .OfType<string>(),
+        ];
     }
 
     private static async Task<bool> ObterRevisado(HttpClient client, Guid id)

--- a/tests/Unifesspa.UniPlus.Configuracao.IntegrationTests/TermosConsentimento/TermoConsentimentoEndpointTests.cs
+++ b/tests/Unifesspa.UniPlus.Configuracao.IntegrationTests/TermosConsentimento/TermoConsentimentoEndpointTests.cs
@@ -190,6 +190,20 @@ public sealed class TermoConsentimentoEndpointTests
         response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
     }
 
+    [Theory(DisplayName = "GET coleção ?q= abaixo do piso de 3 caracteres retorna 400")]
+    [InlineData("a")]
+    [InlineData("ab")]
+    public async Task Listar_ComBuscaMuitoCurta_Retorna400(string buscaMuitoCurta)
+    {
+        using HttpClient client = _fixture.Factory.CreateClient();
+
+        HttpResponseMessage response = await client.GetAsync(
+            new Uri($"{ColecaoPath}?q={buscaMuitoCurta}", UriKind.Relative));
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest,
+            "abaixo de 3 caracteres o pg_trgm não tem trigramas suficientes para casar de forma confiável");
+    }
+
     [Fact(DisplayName = "GET coleção não inclui versoes — a listagem projeta só o resumo")]
     public async Task Listar_NaoIncluiVersoes()
     {

--- a/tests/Unifesspa.UniPlus.Configuracao.IntegrationTests/TermosConsentimento/TermoConsentimentoEndpointTests.cs
+++ b/tests/Unifesspa.UniPlus.Configuracao.IntegrationTests/TermosConsentimento/TermoConsentimentoEndpointTests.cs
@@ -106,6 +106,90 @@ public sealed class TermoConsentimentoEndpointTests
         root.TryGetProperty("_links", out _).Should().BeTrue("HATEOAS Level 1 expõe _links.self (ADR-0029)");
     }
 
+    [Fact(DisplayName = "GET coleção ?q= filtra server-side por nome, caixa-insensível")]
+    public async Task Listar_ComBusca_FiltraServerSide()
+    {
+        string token = Guid.NewGuid().ToString("N")[..10];
+        string nomeAlvo = $"Termo Alvo {token}";
+        await CriarTermoComNome(_fixture.Factory.CreateClient(), nomeAlvo);
+        await CriarTermoComNome(_fixture.Factory.CreateClient(), "Termo Fora Do Filtro");
+
+        using HttpClient client = _fixture.Factory.CreateClient();
+        HttpResponseMessage response = await client.GetAsync(
+            new Uri($"{ColecaoPath}?q={token.ToUpperInvariant()}", UriKind.Relative));
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        IReadOnlyList<string> nomes = await LerNomesAsync(response);
+        nomes.Should().Contain(nomeAlvo);
+        nomes.Should().NotContain(n => n.Contains("Fora Do Filtro", StringComparison.Ordinal));
+    }
+
+    [Fact(DisplayName = "GET coleção preserva ?q= especificamente no link rel=\"next\", e a página seguinte respeita o filtro")]
+    public async Task Listar_ComBusca_PreservaQueryParamNoLinkNext()
+    {
+        string token = Guid.NewGuid().ToString("N")[..10];
+        // Duas ocorrências do token → com limit=1 há próxima página (rel=next).
+        await CriarTermoComNome(_fixture.Factory.CreateClient(), $"Termo {token} Um");
+        await CriarTermoComNome(_fixture.Factory.CreateClient(), $"Termo {token} Dois");
+        await CriarTermoComNome(_fixture.Factory.CreateClient(), "Termo Fora Do Filtro");
+
+        using HttpClient client = _fixture.Factory.CreateClient();
+        HttpResponseMessage primeira = await client.GetAsync(
+            new Uri($"{ColecaoPath}?q={token}&limit=1", UriKind.Relative));
+
+        primeira.StatusCode.Should().Be(HttpStatusCode.OK);
+        string? next = LerLinkRel(primeira, "next");
+        // Extrai só o link rel="next" (não a string inteira do header, que
+        // também contém rel="self") — prova que o filtro viaja especificamente
+        // no link seguido pelo cliente ao paginar, não só no link atual.
+        next.Should().NotBeNull("limit=1 com 2 itens filtrados deve emitir próxima página");
+        next.Should().Contain($"q={token}");
+
+        HttpResponseMessage segunda = await client.GetAsync(new Uri(next!, UriKind.Absolute));
+        segunda.StatusCode.Should().Be(HttpStatusCode.OK);
+        IReadOnlyList<string> nomes = await LerNomesAsync(segunda);
+        nomes.Should().OnlyContain(n => n.Contains(token, StringComparison.Ordinal),
+            "a segunda página, seguida via rel=\"next\", deve continuar restrita ao conjunto filtrado");
+    }
+
+    private static string? LerLinkRel(HttpResponseMessage response, string rel)
+    {
+        if (!response.Headers.TryGetValues("Link", out IEnumerable<string>? links))
+        {
+            return null;
+        }
+
+        string header = links.Single();
+        foreach (string parte in header.Split(", ", StringSplitOptions.RemoveEmptyEntries))
+        {
+            if (!parte.Contains($"rel=\"{rel}\"", StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            int inicio = parte.IndexOf('<', StringComparison.Ordinal) + 1;
+            int fim = parte.IndexOf('>', StringComparison.Ordinal);
+            if (inicio > 0 && fim > inicio)
+            {
+                return parte[inicio..fim];
+            }
+        }
+
+        return null;
+    }
+
+    [Fact(DisplayName = "GET coleção ?q= acima do limite de tamanho retorna 400")]
+    public async Task Listar_ComBuscaMuitoLonga_Retorna400()
+    {
+        string buscaMuitoLonga = new('a', 201);
+        using HttpClient client = _fixture.Factory.CreateClient();
+
+        HttpResponseMessage response = await client.GetAsync(
+            new Uri($"{ColecaoPath}?q={buscaMuitoLonga}", UriKind.Relative));
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
     [Fact(DisplayName = "GET coleção não inclui versoes — a listagem projeta só o resumo")]
     public async Task Listar_NaoIncluiVersoes()
     {
@@ -239,6 +323,30 @@ public sealed class TermoConsentimentoEndpointTests
         HttpResponseMessage criar = await EnviarAdmin(client, HttpMethod.Post, AdminPath, corpo);
         criar.StatusCode.Should().Be(HttpStatusCode.Created);
         return await criar.Content.ReadFromJsonAsync<Guid>();
+    }
+
+    private static Task<Guid> CriarTermoComNome(HttpClient client, string nome) => CriarTermo(client, new
+    {
+        nome,
+        textoRascunho = (string?)null,
+        baseLegalRascunho = (string?)null,
+        formaAceiteRascunho = (string?)null,
+    });
+
+    private static async Task<IReadOnlyList<string>> LerNomesAsync(HttpResponseMessage response)
+    {
+        string body = await response.Content.ReadAsStringAsync();
+        using JsonDocument doc = JsonDocument.Parse(body);
+        List<string> nomes = [];
+        foreach (JsonElement item in doc.RootElement.EnumerateArray())
+        {
+            if (item.TryGetProperty("nome", out JsonElement nome) && nome.GetString() is { } valor)
+            {
+                nomes.Add(valor);
+            }
+        }
+
+        return nomes;
     }
 
     private static async Task<bool> ObterRevisado(HttpClient client, Guid id)

--- a/tests/Unifesspa.UniPlus.Configuracao.IntegrationTests/TermosConsentimento/TermoConsentimentoEndpointTests.cs
+++ b/tests/Unifesspa.UniPlus.Configuracao.IntegrationTests/TermosConsentimento/TermoConsentimentoEndpointTests.cs
@@ -190,20 +190,6 @@ public sealed class TermoConsentimentoEndpointTests
         response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
     }
 
-    [Theory(DisplayName = "GET coleção ?q= abaixo do piso de 3 caracteres retorna 400")]
-    [InlineData("a")]
-    [InlineData("ab")]
-    public async Task Listar_ComBuscaMuitoCurta_Retorna400(string buscaMuitoCurta)
-    {
-        using HttpClient client = _fixture.Factory.CreateClient();
-
-        HttpResponseMessage response = await client.GetAsync(
-            new Uri($"{ColecaoPath}?q={buscaMuitoCurta}", UriKind.Relative));
-
-        response.StatusCode.Should().Be(HttpStatusCode.BadRequest,
-            "abaixo de 3 caracteres o pg_trgm não tem trigramas suficientes para casar de forma confiável");
-    }
-
     [Fact(DisplayName = "GET coleção não inclui versoes — a listagem projeta só o resumo")]
     public async Task Listar_NaoIncluiVersoes()
     {

--- a/tests/Unifesspa.UniPlus.Configuracao.IntegrationTests/TermosConsentimento/TermoConsentimentoFiltroListagemTests.cs
+++ b/tests/Unifesspa.UniPlus.Configuracao.IntegrationTests/TermosConsentimento/TermoConsentimentoFiltroListagemTests.cs
@@ -1,0 +1,180 @@
+namespace Unifesspa.UniPlus.Configuracao.IntegrationTests.TermosConsentimento;
+
+using System.Diagnostics.CodeAnalysis;
+
+using AwesomeAssertions;
+
+using Unifesspa.UniPlus.Configuracao.Domain.Entities;
+using Unifesspa.UniPlus.Configuracao.Infrastructure.Persistence;
+using Unifesspa.UniPlus.Configuracao.Infrastructure.Persistence.Repositories;
+using Unifesspa.UniPlus.Configuracao.IntegrationTests.Infrastructure;
+using Unifesspa.UniPlus.Kernel.Pagination;
+
+/// <summary>
+/// Integração da filtragem server-side por nome na listagem de termos de
+/// consentimento (issue #1105) contra Postgres real: busca por proximidade
+/// indexada (pg_trgm word_similarity), caixa-insensível, e coerência do cursor
+/// keyset sobre o conjunto filtrado — busca e paginação devem descrever o
+/// mesmo conjunto de resultados.
+/// </summary>
+/// <remarks>
+/// A fixture compartilha um único banco entre os testes da classe; cada teste
+/// usa um token único embutido no <c>Nome</c> e filtra por ele, isolando seus
+/// dados das demais linhas que possam coexistir.
+/// </remarks>
+[Collection(ConfiguracaoDbCollection.Name)]
+[SuppressMessage(
+    "Performance",
+    "CA1515:Consider making public types internal",
+    Justification = "xUnit collection fixture exige tipo de teste público.")]
+public sealed class TermoConsentimentoFiltroListagemTests
+{
+    private const int TakeAlto = 100;
+
+    private readonly ConfiguracaoDbFixture _fixture;
+
+    public TermoConsentimentoFiltroListagemTests(ConfiguracaoDbFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    [Fact(DisplayName = "Busca filtra por nome e é case-insensitive")]
+    public async Task Busca_FiltraPorNome_EhCaseInsensitive()
+    {
+        string iso = NovoToken();
+        Guid comToken = await SeedAsync($"Termo Alpha {iso}");
+        Guid semToken = await SeedAsync("Termo Sem Marca");
+
+        IReadOnlyList<Guid> minusculo = await ListarIdsAsync(iso.ToLowerInvariant());
+        IReadOnlyList<Guid> maiusculo = await ListarIdsAsync(iso.ToUpperInvariant());
+
+        minusculo.Should().Contain(comToken);
+        minusculo.Should().NotContain(semToken);
+        maiusculo.Should().Contain(comToken, "a busca deve ser caixa-insensível");
+    }
+
+    [Fact(DisplayName = "Busca casa um trecho contínuo do termo dentro de um nome mais longo (word_similarity)")]
+    public async Task Busca_CasaSubstringDentroDeNomeMaisLongo()
+    {
+        string iso = NovoToken();
+        Guid comToken = await SeedAsync($"Termo de Uso da Plataforma {iso} v2");
+
+        IReadOnlyList<Guid> ids = await ListarIdsAsync(iso);
+
+        ids.Should().Contain(comToken, "word_similarity encontra o termo como trecho contínuo do nome mais longo");
+    }
+
+    [Fact(DisplayName = "Busca sem relação de trigramas com o nome não retorna o registro")]
+    public async Task Busca_TermoSemRelacao_NaoCasa()
+    {
+        string iso = NovoToken();
+        Guid semRelacao = await SeedAsync($"Termo Alpha {iso}");
+
+        // Token novo, sem overlap de trigramas com "Termo Alpha <iso>" nem com
+        // qualquer outro dado de teste — abaixo do limiar de word_similarity.
+        IReadOnlyList<Guid> ids = await ListarIdsAsync(NovoToken());
+
+        ids.Should().NotContain(semRelacao);
+    }
+
+    [Fact(DisplayName = "Cursor avança sobre o conjunto filtrado sem incluir registros de fora do filtro")]
+    public async Task Paginacao_AvancaSobreConjuntoFiltrado()
+    {
+        string iso = NovoToken();
+        Guid t1 = await SeedAsync($"Termo Um {iso}");
+        await SeedAsync("Termo Fora do Filtro");
+        Guid t2 = await SeedAsync($"Termo Dois {iso}");
+        await SeedAsync("Outro Fora do Filtro");
+        Guid t3 = await SeedAsync($"Termo Tres {iso}");
+
+        // Conjunto filtrado completo, ordenado por Id (referência).
+        List<Guid> esperados = [.. (await ListarIdsAsync(iso, TakeAlto)).OrderBy(id => id)];
+        esperados.Should().BeEquivalentTo([t1, t2, t3]);
+
+        // Drena em páginas de 2 seguindo o keyset.
+        List<Guid> acumulado = [];
+        Guid? cursor = null;
+        do
+        {
+            (IReadOnlyList<TermoConsentimento> pagina, _, _) = await PaginarAsync(iso, take: 2, afterId: cursor);
+            acumulado.AddRange(pagina.Select(t => t.Id));
+            cursor = pagina.Count == 2 ? pagina[^1].Id : null;
+        }
+        while (cursor is not null && acumulado.Count < esperados.Count);
+
+        acumulado.Should().Equal(esperados, "o cursor deve percorrer só o conjunto filtrado, em ordem de Id");
+    }
+
+    [Fact(DisplayName = "Navegação bidirecional com filtro: prev volta à página anterior com flags exatas")]
+    public async Task Navegacao_Bidirecional_ComFiltro_FlagsExatas()
+    {
+        string iso = NovoToken();
+        Guid[] ids =
+        [
+            await SeedAsync($"BiDir {iso} 0"),
+            await SeedAsync($"BiDir {iso} 1"),
+            await SeedAsync($"BiDir {iso} 2"),
+        ];
+
+        (IReadOnlyList<TermoConsentimento> p1, Guid? p1Ant, Guid? p1Prox) =
+            await PaginarAsync(iso, take: 2, afterId: null, PaginationDirection.Next);
+        p1.Select(t => t.Id).Should().Equal(ids[0], ids[1]);
+        p1Ant.Should().BeNull();
+        p1Prox.Should().Be(ids[1]);
+
+        (IReadOnlyList<TermoConsentimento> ultima, Guid? ultAnt, Guid? ultProx) =
+            await PaginarAsync(iso, take: 2, afterId: p1Prox, PaginationDirection.Next);
+        ultima.Select(t => t.Id).Should().Equal(ids[2]);
+        ultProx.Should().BeNull();
+        ultAnt.Should().Be(ids[2]);
+
+        (IReadOnlyList<TermoConsentimento> volta, Guid? voltaAnt, Guid? voltaProx) =
+            await PaginarAsync(iso, take: 2, afterId: ultAnt, PaginationDirection.Prev);
+        volta.Select(t => t.Id).Should().Equal(ids[0], ids[1]);
+        voltaAnt.Should().BeNull();
+        voltaProx.Should().Be(ids[1]);
+    }
+
+    [Fact(DisplayName = "Busca nula/vazia não restringe a listagem")]
+    public async Task Busca_NulaOuVazia_NaoRestringe()
+    {
+        Guid id = await SeedAsync($"Termo {NovoToken()}");
+
+        IReadOnlyList<Guid> semFiltro = await ListarIdsAsync(busca: null, TakeAlto);
+        IReadOnlyList<Guid> filtroVazio = await ListarIdsAsync(busca: "   ", TakeAlto);
+
+        semFiltro.Should().Contain(id);
+        filtroVazio.Should().Contain(id);
+    }
+
+    // ── Helpers ─────────────────────────────────────────────────────────
+
+    private async Task<Guid> SeedAsync(string nome)
+    {
+        TermoConsentimento termo = TermoConsentimento.Criar(nome, null, null, null).Value!;
+
+        await using ConfiguracaoDbContext ctx = _fixture.CreateDbContext("admin-1105");
+        ctx.TermosConsentimento.Add(termo);
+        await ctx.SaveChangesAsync();
+        return termo.Id;
+    }
+
+    private async Task<(IReadOnlyList<TermoConsentimento> Itens, Guid? Anterior, Guid? Proximo)> PaginarAsync(
+        string? busca,
+        int take,
+        Guid? afterId,
+        PaginationDirection direction = PaginationDirection.Next)
+    {
+        await using ConfiguracaoDbContext ctx = _fixture.CreateDbContext(userId: null);
+        TermoConsentimentoRepository repository = new(ctx);
+        return await repository.ListarPaginadoAsync(afterId, take, direction, busca, CancellationToken.None);
+    }
+
+    private async Task<IReadOnlyList<Guid>> ListarIdsAsync(string? busca, int take = TakeAlto)
+    {
+        (IReadOnlyList<TermoConsentimento> itens, _, _) = await PaginarAsync(busca, take, afterId: null);
+        return [.. itens.Select(t => t.Id)];
+    }
+
+    private static string NovoToken() => Guid.NewGuid().ToString("N")[..10];
+}

--- a/tests/Unifesspa.UniPlus.Configuracao.IntegrationTests/TermosConsentimento/TermoConsentimentoFiltroListagemTests.cs
+++ b/tests/Unifesspa.UniPlus.Configuracao.IntegrationTests/TermosConsentimento/TermoConsentimentoFiltroListagemTests.cs
@@ -140,8 +140,8 @@ public sealed class TermoConsentimentoFiltroListagemTests
     {
         Guid id = await SeedAsync($"Termo {NovoToken()}");
 
-        IReadOnlyList<Guid> semFiltro = await ListarIdsAsync(busca: null, TakeAlto);
-        IReadOnlyList<Guid> filtroVazio = await ListarIdsAsync(busca: "   ", TakeAlto);
+        IReadOnlyList<Guid> semFiltro = await ListarIdsAsync(searchTerm: null, TakeAlto);
+        IReadOnlyList<Guid> filtroVazio = await ListarIdsAsync(searchTerm: "   ", TakeAlto);
 
         semFiltro.Should().Contain(id);
         filtroVazio.Should().Contain(id);
@@ -160,19 +160,19 @@ public sealed class TermoConsentimentoFiltroListagemTests
     }
 
     private async Task<(IReadOnlyList<TermoConsentimento> Itens, Guid? Anterior, Guid? Proximo)> PaginarAsync(
-        string? busca,
+        string? searchTerm,
         int take,
         Guid? afterId,
         PaginationDirection direction = PaginationDirection.Next)
     {
         await using ConfiguracaoDbContext ctx = _fixture.CreateDbContext(userId: null);
         TermoConsentimentoRepository repository = new(ctx);
-        return await repository.ListarPaginadoAsync(afterId, take, direction, busca, CancellationToken.None);
+        return await repository.ListarPaginadoAsync(afterId, take, direction, searchTerm, CancellationToken.None);
     }
 
-    private async Task<IReadOnlyList<Guid>> ListarIdsAsync(string? busca, int take = TakeAlto)
+    private async Task<IReadOnlyList<Guid>> ListarIdsAsync(string? searchTerm, int take = TakeAlto)
     {
-        (IReadOnlyList<TermoConsentimento> itens, _, _) = await PaginarAsync(busca, take, afterId: null);
+        (IReadOnlyList<TermoConsentimento> itens, _, _) = await PaginarAsync(searchTerm, take, afterId: null);
         return [.. itens.Select(t => t.Id)];
     }
 

--- a/tests/Unifesspa.UniPlus.Configuracao.IntegrationTests/TermosConsentimento/TermoConsentimentoFiltroListagemTests.cs
+++ b/tests/Unifesspa.UniPlus.Configuracao.IntegrationTests/TermosConsentimento/TermoConsentimentoFiltroListagemTests.cs
@@ -12,10 +12,11 @@ using Unifesspa.UniPlus.Kernel.Pagination;
 
 /// <summary>
 /// Integração da filtragem server-side por nome na listagem de termos de
-/// consentimento (issue #1105) contra Postgres real: busca por proximidade
-/// indexada (pg_trgm word_similarity), caixa-insensível, e coerência do cursor
-/// keyset sobre o conjunto filtrado — busca e paginação devem descrever o
-/// mesmo conjunto de resultados.
+/// consentimento (issue #1105) contra Postgres real: busca indexada via
+/// pg_trgm (ILIKE acelerado pelo índice GIN, não word_similarity — este não
+/// garante casar substrings internas curtas independente do threshold),
+/// caixa-insensível, e coerência do cursor keyset sobre o conjunto filtrado —
+/// busca e paginação devem descrever o mesmo conjunto de resultados.
 /// </summary>
 /// <remarks>
 /// A fixture compartilha um único banco entre os testes da classe; cada teste
@@ -53,7 +54,7 @@ public sealed class TermoConsentimentoFiltroListagemTests
         maiusculo.Should().Contain(comToken, "a busca deve ser caixa-insensível");
     }
 
-    [Fact(DisplayName = "Busca casa um trecho contínuo do termo dentro de um nome mais longo (word_similarity)")]
+    [Fact(DisplayName = "Busca casa um trecho contínuo do termo dentro de um nome mais longo")]
     public async Task Busca_CasaSubstringDentroDeNomeMaisLongo()
     {
         string iso = NovoToken();
@@ -61,20 +62,62 @@ public sealed class TermoConsentimentoFiltroListagemTests
 
         IReadOnlyList<Guid> ids = await ListarIdsAsync(iso);
 
-        ids.Should().Contain(comToken, "word_similarity encontra o termo como trecho contínuo do nome mais longo");
+        ids.Should().Contain(comToken, "ILIKE '%termo%' encontra o termo como trecho contínuo do nome mais longo");
     }
 
-    [Fact(DisplayName = "Busca sem relação de trigramas com o nome não retorna o registro")]
+    [Fact(DisplayName = "Busca com termo curto (2 caracteres) casa substring interna do nome")]
+    public async Task Busca_TermoCurto_CasaSubstringInterna()
+    {
+        // Regressão: word_similarity (pg_trgm, threshold padrão 0.6) não
+        // garantia casar substrings curtas internas ao nome — ex.: "lat" não
+        // batia com "Plataforma" mesmo sendo um trecho contínuo real. ILIKE dá
+        // semântica de "contains" exata, sem depender de nenhum limiar.
+        string iso = NovoToken();
+        string marcador = iso[..2];
+        Guid comMarcador = await SeedAsync($"Termo {marcador}Interno {iso}");
+
+        IReadOnlyList<Guid> ids = await ListarIdsAsync(marcador + "Interno");
+
+        ids.Should().Contain(comMarcador, "um termo de 2 caracteres presente como substring deve casar via ILIKE");
+    }
+
+    [Fact(DisplayName = "Busca sem correspondência textual com o nome não retorna o registro")]
     public async Task Busca_TermoSemRelacao_NaoCasa()
     {
         string iso = NovoToken();
         Guid semRelacao = await SeedAsync($"Termo Alpha {iso}");
 
-        // Token novo, sem overlap de trigramas com "Termo Alpha <iso>" nem com
-        // qualquer outro dado de teste — abaixo do limiar de word_similarity.
+        // Token novo, que não aparece como substring de "Termo Alpha <iso>" nem
+        // de qualquer outro dado de teste.
         IReadOnlyList<Guid> ids = await ListarIdsAsync(NovoToken());
 
         ids.Should().NotContain(semRelacao);
+    }
+
+    [Fact(DisplayName = "Curingas do LIKE (_, % e \\) no termo são tratados como literais, não wildcards")]
+    public async Task Busca_EscapaCuringasLike()
+    {
+        string iso = NovoToken();
+        // Pares com o MESMO comprimento: sem escape, o curinga no termo casaria
+        // o caractere/sequência divergente do par, devolvendo o registro errado.
+        Guid comUnderscore = await SeedAsync($"Alfa_{iso}");
+        Guid soLetra = await SeedAsync($"AlfaX{iso}");
+        Guid comPercent = await SeedAsync($"Beta%{iso}");
+        Guid soSequencia = await SeedAsync($"BetaZZ{iso}");
+        Guid comBarra = await SeedAsync($"Gama\\{iso}");
+        Guid soLetraBarra = await SeedAsync($"GamaX{iso}");
+
+        IReadOnlyList<Guid> porUnderscore = await ListarIdsAsync($"Alfa_{iso}");
+        porUnderscore.Should().Contain(comUnderscore);
+        porUnderscore.Should().NotContain(soLetra, "'_' deve ser literal, não curinga de 1 caractere");
+
+        IReadOnlyList<Guid> porPercent = await ListarIdsAsync($"Beta%{iso}");
+        porPercent.Should().Contain(comPercent);
+        porPercent.Should().NotContain(soSequencia, "'%' deve ser literal, não curinga de sequência");
+
+        IReadOnlyList<Guid> porBarra = await ListarIdsAsync($"Gama\\{iso}");
+        porBarra.Should().Contain(comBarra);
+        porBarra.Should().NotContain(soLetraBarra, "'\\' deve ser literal, não escape de LIKE do usuário");
     }
 
     [Fact(DisplayName = "Cursor avança sobre o conjunto filtrado sem incluir registros de fora do filtro")]


### PR DESCRIPTION
## Resumo

GET /api/configuracao/termos-consentimento aceita um parâmetro opcional `q` para busca por nome, aplicado no repositório **antes** da paginação por cursor — busca e paginação passam a descrever o mesmo conjunto de resultados.

Closes #1105

## Contexto

A story web unifesspa-edu-br/uniplus-web#499 (PR unifesspa-edu-br/uniplus-web#514) exige busca por nome no catálogo de termos de consentimento. A listagem web pagina em janelas de 50 e hoje filtra só os registros da página corrente no cliente — um termo presente numa página posterior não é encontrado ao pesquisar a partir da primeira página. O contrato publicado na main expunha só `cursor`/`limit`/`direction`.

## Mudanças

### Modificados
- `TermosConsentimentoController.Listar` — novo parâmetro `[FromQuery(Name = "q")]`, validação de tamanho (máx. 200, igual ao `Nome` da entidade), XML doc + `[Description]` (aparece no contrato OpenAPI).
- `ListarTermosConsentimentoQuery`/`Handler` — novo campo `Busca`, normalizado (`null` se vazio/whitespace) antes de repassar ao repositório.
- `ITermoConsentimentoRepository`/`TermoConsentimentoRepository.ListarPaginadoAsync` — novo parâmetro `busca`; o filtro é aplicado ao `IQueryable` **antes** de `CursorKeyset.ApplyAsync`, então os `EXISTS` internos do keyset (flags `prev`/`next` sem `COUNT`) já herdam o filtro.
- `ConfiguracaoDbContext` — registra a extensão `pg_trgm`.
- `contracts/openapi.configuracao.json` — baseline regenerada (só o parâmetro `q` novo).

### Novos arquivos
- Migration `AdicionaBuscaTrigramTermoConsentimento` — cria a extensão `pg_trgm` (via `HasPostgresExtension`, scaffolded) e um índice GIN de expressão sobre `lower(nome)` (`ix_termo_consentimento_nome_trgm`, parcial por `is_deleted = false`, espelhando o índice B-tree existente). Forward-only (ADR-0054 §J) — revert é uma migration nova.
- `tests/.../TermosConsentimento/TermoConsentimentoFiltroListagemTests.cs` — testes de repositório contra Postgres real (Testcontainers): busca case-insensitive, correspondência de trecho contínuo (`word_similarity`), termo sem relação não casa, paginação keyset avançando só sobre o conjunto filtrado (múltiplas páginas), navegação bidirecional com flags exatas, busca nula/vazia não restringe.

## Decisões de design

- **Busca por proximidade indexada (pg_trgm `word_similarity`/`<%`), não `ILIKE`** — decisão explícita para evitar full scan de wildcard à esquerda (`ILIKE '%termo%'` não usa índice B-tree) e usar o suporte nativo do Postgres a busca indexada/por proximidade. `EF.Functions.TrigramsAreWordSimilar(termo, nome.ToLower())` é acelerado pelo índice GIN de expressão da migration. Ambos os lados em `lower()` mantêm a busca caixa-insensível (CA1304/CA1311 suprimidos com justificativa — a chamada é traduzida pelo EF Core para SQL, não roda em CLR).
- **Nome do parâmetro `q`** — alinhado ao único precedente do mesmo padrão (busca + cursor) na API, `GET /api/organizacao/unidades` (issue #640), mesmo buscando só o campo `Nome` aqui (não múltiplos campos como lá).
- **Sem acento-insensibilidade** — Unidade usa `immutable_unaccent` + extensão `unaccent`; fora do escopo desta issue. Fica como follow-up natural se necessário (mesma migration/índice de expressão, adicionando `immutable_unaccent(nome)`).
- **Sem objeto de filtro dedicado** — só há um campo de busca aqui (diferente de Unidade, que combina busca + tipo); `string? busca` direto evita abstração prematura.
- **Links de paginação preservam o filtro automaticamente** — `PaginationControllerExtensions.BuildLink` já propaga qualquer query param não reservado (`cursor`/`limit`/`direction`) para os links `self`/`prev`/`next`; nenhuma mudança necessária ali. Coberto por teste que segue o `rel="next"` real (não só verifica a string do header) e confirma que a segunda página continua filtrada.
- **Cursor não vincula o filtro** (ADR-0026, mesmo comportamento de Unidade) — documentado em XML doc e na descrição OpenAPI: trocar `q` entre páginas de uma mesma navegação produz resultados inconsistentes; o cliente deve manter `q` fixo (os links `prev`/`next` já o preservam).

## Testes

- [x] Build limpo (`dotnet build UniPlus.slnx`)
- [x] `dotnet format --verify-no-changes --exclude-diagnostics CA1515 --exclude "**/Migrations/**"` limpo
- [x] Suíte completa de Configuração: 328 testes de integração + 365 unitários, todos verdes
- [x] ArchTests: 62/62 verdes
- [x] `dotnet ef migrations has-pending-model-changes` — "No changes have been made to the model since the last migration."
- [x] Baseline OpenAPI regenerada e revisada (diff mínimo, só o parâmetro `q`)

## Fora de escopo (confirmado pela issue)

- Filtragem global no navegador (web) e regeneração de `schema.ts`/envio de `busca` na chamada `listar` do `uniplus-web` — PR separado, após este contrato publicado.
- Ciclo de vida rascunho/revisão/promoção — inalterado.