### PR TITLE
fix(selecao): proibir domínio vazio em fato coletado de seleção

### DIFF
--- a/contracts/openapi.selecao.json
+++ b/contracts/openapi.selecao.json
@@ -6783,6 +6783,7 @@
             }
           },
           "valoresSelecionaveis": {
+            "minItems": 1,
             "type": [
               "null",
               "array"

--- a/src/selecao/Unifesspa.UniPlus.Selecao.API/Errors/SelecaoDomainErrorRegistration.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.API/Errors/SelecaoDomainErrorRegistration.cs
@@ -434,6 +434,9 @@ internal sealed class SelecaoDomainErrorRegistration : IDomainErrorRegistration
         new("ProcessoSeletivo.ReferenciaTemporalFatosFaseInexistente", new DomainErrorMapping(StatusCodes.Status422UnprocessableEntity, "uniplus.selecao.processo_seletivo.referencia_temporal_fatos_fase_inexistente", "A fase âncora da referência temporal de fatos não pertence (mais) ao cronograma")),
         new("ProcessoSeletivo.ReferenciaTemporalFatosExtremoAusente", new DomainErrorMapping(StatusCodes.Status422UnprocessableEntity, "uniplus.selecao.processo_seletivo.referencia_temporal_fatos_extremo_ausente", "A fase âncora da referência temporal de fatos não tem o extremo (início/fim) definido")),
         new("ProcessoSeletivo.ReferenciaTemporalFatosFimInscricaoIndisponivel", new DomainErrorMapping(StatusCodes.Status422UnprocessableEntity, "uniplus.selecao.processo_seletivo.referencia_temporal_fatos_fim_inscricao_indisponivel", "FIM_INSCRICAO exige uma fase que colete inscrição com Fim definido")),
+        // issue #1077 — fato coletável de escopo do processo (CONDICAO_ATENDIMENTO/TIPO_DEFICIENCIA)
+        // sem nenhum valor ofertado publicaria um seletor sem opção para o candidato escolher.
+        new("ProcessoSeletivo.FatoColetadoSemValoresOfertados", new DomainErrorMapping(StatusCodes.Status422UnprocessableEntity, "uniplus.selecao.processo_seletivo.fato_coletado_sem_valores_ofertados", "O fato coletado é de seleção, mas a oferta do processo não declara nenhum valor para ele")),
         // Base legal 1:N (Story #554, PR #898, issue #549, ADR-0074) — DocumentoExigidoBaseLegal
         // e o gate de publicação (ValidadorBaseLegalExigencias) aflora pelo
         // ProcessoSeletivo.ConformidadeInsuficiente já registrado acima, sem código novo.

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Application/Commands/ProcessosSeletivos/ResolvedorValoresSelecionaveisCongelados.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Application/Commands/ProcessosSeletivos/ResolvedorValoresSelecionaveisCongelados.cs
@@ -101,6 +101,32 @@ internal static class ResolvedorValoresSelecionaveisCongelados
     private static Result<IReadOnlyList<ValorDominioDeclaradoCongelado>> ResolverValoresDoFato(
         string fatoCodigo, FatoCandidatoView fatoNoCatalogo, ProcessoSeletivo processo)
     {
+        Result<IReadOnlyList<ValorDominioDeclaradoCongelado>> resolvido = ResolverOrigemDosValores(fatoCodigo, fatoNoCatalogo, processo);
+        if (resolvido.IsFailure)
+        {
+            return resolvido;
+        }
+
+        // Defesa em profundidade (issue #1077): o caminho esperado para um fato de escopo-processo
+        // (CONDICAO_ATENDIMENTO/TIPO_DEFICIENCIA) sem nenhum valor ofertado é
+        // ProcessoSeletivo.PendenciaDeFatoColetadoSemValoresOfertados, avaliado ANTES deste
+        // resolvedor rodar (PendenciaPreCanonicalizacao precede a canonicalização, ADR-0109 D5).
+        // Chegar aqui com lista vazia significaria o gate e este resolvedor operando sobre
+        // estados diferentes — o resolvedor nunca pode devolver sucesso com lista vazia, mesmo
+        // que um chamador futuro esqueça de invocar o gate.
+        if (resolvido.Value!.Count == 0)
+        {
+            return Result<IReadOnlyList<ValorDominioDeclaradoCongelado>>.Failure(new DomainError(
+                "ProcessoSeletivo.FatoColetadoSemValoresOfertados",
+                $"O fato coletado '{fatoCodigo}' é de seleção, mas resolveu zero valores selecionáveis."));
+        }
+
+        return resolvido;
+    }
+
+    private static Result<IReadOnlyList<ValorDominioDeclaradoCongelado>> ResolverOrigemDosValores(
+        string fatoCodigo, FatoCandidatoView fatoNoCatalogo, ProcessoSeletivo processo)
+    {
         if (fatoNoCatalogo.ValoresDominioDeclarados is { Count: > 0 } declarados)
         {
             // Ordenação canônica própria (D2): o encoder não pode depender de o catálogo já vir

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Application/DTOs/FormularioRenderizavelDto.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Application/DTOs/FormularioRenderizavelDto.cs
@@ -10,8 +10,8 @@ public sealed record ValorSelecionavelDto(string Codigo, string? Descricao, int 
 /// <summary>
 /// Um fato coletado pronto para renderização pública (Story #559, issue #1059): mesmos campos
 /// de <see cref="FatoColetadoDto"/> mais <see cref="ValoresSelecionaveis"/> — as opções que o
-/// candidato pode escolher, presente (mesmo que vazio) quando <see cref="TipoRenderizacao"/> é
-/// de seleção, <see langword="null"/> quando não é.
+/// candidato pode escolher. Presente com cardinalidade mínima 1 (issue #1077: nunca vazio) quando
+/// <see cref="TipoRenderizacao"/> é de seleção, <see langword="null"/> quando não é.
 /// </summary>
 /// <remarks>
 /// DTO PRÓPRIO, e não reaproveitamento de <see cref="FatoColetadoDto"/>: aquele é o read-back

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Application/Queries/ProcessosSeletivos/ObterFormularioRenderizavelQueryHandler.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Application/Queries/ProcessosSeletivos/ObterFormularioRenderizavelQueryHandler.cs
@@ -228,7 +228,7 @@ public static class ObterFormularioRenderizavelQueryHandler
 
     /// <summary>
     /// Chave presente e coerente com a bicondicional (issue #1059, UNI-REQ-0072):
-    /// <c>SELECAO_UNICA</c>/<c>SELECAO_MULTIPLA</c> exige um array (possivelmente vazio);
+    /// <c>SELECAO_UNICA</c>/<c>SELECAO_MULTIPLA</c> exige um array com cardinalidade mínima 1 (issue #1077);
     /// <c>BOOLEANO</c>/<c>NUMERO</c> exige <c>null</c> explícito. <paramref name="tipoRenderizacao"/>
     /// fora dos QUATRO tokens fechados falha aqui — sem isso, um token desconhecido cairia no
     /// ramo "não é seleção" por omissão e aceitaria <c>valoresSelecionaveis: null</c> em silêncio,
@@ -286,6 +286,15 @@ public static class ObterFormularioRenderizavelQueryHandler
             }
 
             valores.Add(new ValorSelecionavelDto(valorCodigo, descricao, ordem));
+        }
+
+        // issue #1077: defesa em profundidade — o decoder já recusa um envelope persistido com
+        // array vazio para fato de seleção (EnvelopeMalformado), então este ramo é inalcançável
+        // em uso normal. Mantido para nunca projetar um seletor sem opção nenhuma caso um
+        // chamador futuro monte o JsonObject por outro caminho que não o decoder.
+        if (valores.Count == 0)
+        {
+            return false;
         }
 
         valoresSelecionaveis = valores;

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Application/Unifesspa.UniPlus.Selecao.Application.csproj
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Application/Unifesspa.UniPlus.Selecao.Application.csproj
@@ -24,4 +24,10 @@
     <ProjectReference Include="..\..\shared\Unifesspa.UniPlus.Governance.Contracts\Unifesspa.UniPlus.Governance.Contracts.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <!-- Expõe internals (ex.: ResolvedorValoresSelecionaveisCongelados) aos testes de
+         unidade — mesmo padrão de Selecao.Infrastructure/Configuracao/OrganizacaoInstitucional. -->
+    <InternalsVisibleTo Include="Unifesspa.UniPlus.Selecao.Application.UnitTests" />
+  </ItemGroup>
+
 </Project>

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Domain/Entities/ProcessoSeletivo.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Domain/Entities/ProcessoSeletivo.cs
@@ -1448,6 +1448,7 @@ public sealed class ProcessoSeletivo : SoftDeletableEntity
         new ItemConformidade("Referência temporal de fatos: extremo da fase âncora definido", !ReferenciaTemporalFatosExtremoDaFaseAusente()),
         new ItemConformidade("Referência temporal de fatos: fase de coleta com Fim definido para FIM_INSCRICAO", !ReferenciaTemporalFatosFimInscricaoIndisponivel()),
         new ItemConformidade("Regras de derivação: fatos citados existem no processo", PendenciaDeFatosCitados() is null),
+        new ItemConformidade("Fato coletável de escopo do processo: oferta declara ao menos um valor", PendenciaDeFatoColetadoSemValoresOfertados() is null),
         new ItemConformidade("Regras de derivação: código contribuído pertence ao domínio ofertado", PendenciaDoDominioDeContribuicao() is null),
         new ItemConformidade("Grafo de dependência conjunto: sem ciclo", PendenciaDoGrafoConjunto() is null),
     ];
@@ -1838,6 +1839,11 @@ public sealed class ProcessoSeletivo : SoftDeletableEntity
             return fatoCitado;
         }
 
+        if (PendenciaDeFatoColetadoSemValoresOfertados() is { } fatoSemOferta)
+        {
+            return fatoSemOferta;
+        }
+
         if (PendenciaDoDominioDeContribuicao() is { } contribuicaoForaDoDominio)
         {
             return contribuicaoForaDoDominio;
@@ -1921,6 +1927,42 @@ public sealed class ProcessoSeletivo : SoftDeletableEntity
                             + "que este processo não coleta nem deriva.");
                     }
                 }
+            }
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Um fato categórico coletável cujo domínio é derivado da oferta do próprio processo
+    /// (<c>CONDICAO_ATENDIMENTO</c>, <c>TIPO_DEFICIENCIA</c>) não pode ser publicado sem pelo
+    /// menos um valor ofertado — obrigatório ou opcional, a pessoa candidata precisa de alguma
+    /// opção para responder. Sem este gate, <c>DefinirFatosColetadosCommandHandler</c> aceita o
+    /// vínculo (rascunho aceita configuração incompleta, de propósito) e
+    /// <c>ResolvedorValoresSelecionaveisCongelados</c> congela a lista vazia — o formulário de
+    /// inscrição publicado recebe um seletor sem nenhuma opção.
+    /// </summary>
+    private DomainError? PendenciaDeFatoColetadoSemValoresOfertados()
+    {
+        foreach (FatoColetado fato in _fatosColetados)
+        {
+            if (fato.TipoRenderizacao is not (TipoRenderizacao.SelecaoUnica or TipoRenderizacao.SelecaoMultipla))
+            {
+                continue;
+            }
+
+            bool ofertaVazia = fato.FatoCodigo switch
+            {
+                "CONDICAO_ATENDIMENTO" => (OfertaAtendimento?.Condicoes.Count ?? 0) == 0,
+                "TIPO_DEFICIENCIA" => (OfertaAtendimento?.TiposDeficiencia.Count ?? 0) == 0,
+                _ => false,
+            };
+
+            if (ofertaVazia)
+            {
+                return new DomainError(
+                    "ProcessoSeletivo.FatoColetadoSemValoresOfertados",
+                    $"O fato '{fato.FatoCodigo}' é coletável, mas a oferta do processo não declara nenhum valor para ele.");
             }
         }
 

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/Canonicalization/EnvelopeCodec.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/Canonicalization/EnvelopeCodec.cs
@@ -610,8 +610,9 @@ public sealed class EnvelopeCodec : IEnvelopeCodec
         // issue #1077: a bicondicional exige array, mas array VAZIO para um fato de seleção não
         // é forma válida — um seletor publicado sem opção nenhuma não é respondível. Um envelope
         // adulterado com "valoresSelecionaveis": [] é malformado, não um caso legítimo a
-        // reidratar silenciosamente.
-        if (ehFatoDeSelecao && valores.Count == 0)
+        // reidratar silenciosamente. ehFatoDeSelecao já é garantidamente true aqui (o ramo
+        // !ehFatoDeSelecao retornou acima) — checagem redundante removida (achado CodeQL).
+        if (valores.Count == 0)
         {
             return leitor.Propagar<IReadOnlyList<ValorDominioDeclaradoCongelado>?>(new DomainError(
                 ErrosCodecEnvelope.EnvelopeMalformado,

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/Canonicalization/EnvelopeCodec.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/Canonicalization/EnvelopeCodec.cs
@@ -536,10 +536,11 @@ public sealed class EnvelopeCodec : IEnvelopeCodec
     /// <summary>
     /// Os valores selecionáveis de um fato coletado (issue #1059, UNI-REQ-0072) — bicondicional
     /// com <paramref name="tipoRenderizacao"/> (D1-bis do plano da issue): <c>SELECAO_UNICA</c>/
-    /// <c>SELECAO_MULTIPLA</c> exige array (possivelmente vazio); <c>BOOLEANO</c>/<c>NUMERO</c>
-    /// exige <see langword="null"/>. Um envelope que descumpra a bicondicional em qualquer
-    /// sentido — seletor mudo (<c>null</c> onde deveria ter array) ou vocabulário pendurado num
-    /// campo booleano/numérico — é malformado. Cada item exige <c>ordem</c> não negativa e
+    /// <c>SELECAO_MULTIPLA</c> exige array com cardinalidade mínima 1 (issue #1077: nunca vazio);
+    /// <c>BOOLEANO</c>/<c>NUMERO</c> exige <see langword="null"/>. Um envelope que descumpra a
+    /// bicondicional em qualquer sentido — seletor mudo (<c>null</c> ou <c>[]</c> onde deveria
+    /// ter opção), ou vocabulário pendurado num campo booleano/numérico — é malformado. Cada
+    /// item exige <c>ordem</c> não negativa e
     /// <c>valorCodigo</c> sem repetição, mesma disciplina que
     /// <c>EnvelopeCodecV13.LerValoresDominioDeclarados</c> aplica a <c>valoresDominioDeclarados</c>.
     /// </summary>
@@ -604,6 +605,17 @@ public sealed class EnvelopeCodec : IEnvelopeCodec
             }
 
             valores.Add(new ValorDominioDeclaradoCongelado(valorCodigo, descricao, ordem));
+        }
+
+        // issue #1077: a bicondicional exige array, mas array VAZIO para um fato de seleção não
+        // é forma válida — um seletor publicado sem opção nenhuma não é respondível. Um envelope
+        // adulterado com "valoresSelecionaveis": [] é malformado, não um caso legítimo a
+        // reidratar silenciosamente.
+        if (ehFatoDeSelecao && valores.Count == 0)
+        {
+            return leitor.Propagar<IReadOnlyList<ValorDominioDeclaradoCongelado>?>(new DomainError(
+                ErrosCodecEnvelope.EnvelopeMalformado,
+                $"'{path}' é um array vazio, mas o tipo de renderização é de seleção — a cardinalidade mínima é 1."));
         }
 
         return valores;

--- a/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/Canonicalization/SnapshotPublicacaoCanonicalizer.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.Infrastructure/Canonicalization/SnapshotPublicacaoCanonicalizer.cs
@@ -1274,7 +1274,8 @@ public sealed class SnapshotPublicacaoCanonicalizer : ISnapshotPublicacaoCanonic
     /// </summary>
     /// <remarks>
     /// <c>valoresSelecionaveis</c> obedece a bicondicional com <c>tipoRenderizacao</c>:
-    /// <c>SELECAO_UNICA</c>/<c>SELECAO_MULTIPLA</c> ⟺ array (possivelmente vazio);
+    /// <c>SELECAO_UNICA</c>/<c>SELECAO_MULTIPLA</c> ⟺ array com cardinalidade mínima 1
+    /// (issue #1077: nunca vazio — um seletor publicado sem opção nenhuma não é respondível);
     /// <c>BOOLEANO</c>/<c>NUMERO</c> ⟺ <see langword="null"/>. <paramref name="valoresSelecionaveisCongelados"/>
     /// não é revalidado contra o catálogo — quem garante que ele tem uma entrada para todo fato de
     /// seleção, ANTES de canonicalizar, é o handler (<c>ResolvedorValoresSelecionaveisCongelados</c>);
@@ -1300,6 +1301,18 @@ public sealed class SnapshotPublicacaoCanonicalizer : ISnapshotPublicacaoCanonic
                     $"O fato coletado '{fato.FatoCodigo}' é de seleção ({fato.TipoRenderizacao}), mas o dicionário " +
                     "de valores selecionáveis recebido pelo canonicalizador não tem entrada para ele — a ausência é " +
                     "erro de programação do handler, nunca lista vazia por omissão.");
+            }
+
+            if (ehFatoDeSelecao && valoresDoFato is { Count: 0 })
+            {
+                // issue #1077: o gate de pré-canonicalização (ProcessoSeletivo.
+                // PendenciaDeFatoColetadoSemValoresOfertados) já deveria ter recusado a
+                // publicação antes deste ponto — chegar aqui é erro de programação do handler
+                // (esqueceu o gate ou o resolvedor), nunca lista vazia legítima.
+                throw new InvalidOperationException(
+                    $"O fato coletado '{fato.FatoCodigo}' é de seleção ({fato.TipoRenderizacao}), mas o dicionário " +
+                    "de valores selecionáveis traz uma lista VAZIA para ele — o canonicalizador nunca serializa " +
+                    "um seletor sem opção nenhuma.");
             }
 
             if (!ehFatoDeSelecao && temEntrada && valoresDoFato is not null)

--- a/src/shared/Unifesspa.UniPlus.Infrastructure.Core/OpenApi/UniPlusSchemaTransformer.cs
+++ b/src/shared/Unifesspa.UniPlus.Infrastructure.Core/OpenApi/UniPlusSchemaTransformer.cs
@@ -5,7 +5,8 @@ using Microsoft.OpenApi;
 
 /// <summary>
 /// Schema transformer que aplica invariantes de domínio Uni+ a propriedades
-/// tipadas. Hoje cobre <c>cpf</c> (regex de 11 dígitos + nota PII).
+/// tipadas. Hoje cobre <c>cpf</c> (regex de 11 dígitos + nota PII) e
+/// <c>valoresSelecionaveis</c> (cardinalidade mínima 1, issue #1077).
 /// <para>
 /// O <c>code</c> de ProblemDetails NÃO é coberto aqui: o campo vive em
 /// <c>ProblemDetails.Extensions["code"]</c> (<c>[JsonExtensionData]</c>) e
@@ -35,14 +36,23 @@ public sealed class UniPlusSchemaTransformer : IOpenApiSchemaTransformer
             schema.Type = JsonSchemaType.String;
         }
 
-        // JsonSchemaType é [Flags] — propriedades nullable saem como
-        // String | Null, então comparação por igualdade exata pula schemas
-        // legítimos. HasFlag pega ambos os casos (String puro e String|Null).
-        if (!schema.Type.HasValue || !schema.Type.Value.HasFlag(JsonSchemaType.String))
-            return Task.CompletedTask;
-
         string? propertyName = context.JsonPropertyInfo?.Name;
         if (propertyName is null)
+            return Task.CompletedTask;
+
+        // JsonSchemaType é [Flags] — propriedades nullable saem com o flag Null somado ao
+        // tipo base (ex.: Array | Null, String | Null), então comparação por igualdade exata
+        // pula schemas legítimos. HasFlag pega o tipo base com ou sem nulidade.
+        if (schema.Type is { } tipo && tipo.HasFlag(JsonSchemaType.Array)
+            && string.Equals(propertyName, "valoresSelecionaveis", StringComparison.Ordinal))
+        {
+            // issue #1077: um seletor de SELECAO_UNICA/SELECAO_MULTIPLA publicado sem opção
+            // nenhuma não é respondível — o contrato exige pelo menos um valor selecionável
+            // quando o array está presente (null continua válido para BOOLEANO/NUMERO).
+            schema.MinItems = 1;
+        }
+
+        if (!schema.Type.HasValue || !schema.Type.Value.HasFlag(JsonSchemaType.String))
             return Task.CompletedTask;
 
         if (string.Equals(propertyName, "cpf", StringComparison.Ordinal))

--- a/tests/Unifesspa.UniPlus.Selecao.Application.UnitTests/Commands/FatoColetavelDeEscopoGateTests.cs
+++ b/tests/Unifesspa.UniPlus.Selecao.Application.UnitTests/Commands/FatoColetavelDeEscopoGateTests.cs
@@ -1,0 +1,196 @@
+namespace Unifesspa.UniPlus.Selecao.Application.UnitTests.Commands;
+
+using AwesomeAssertions;
+
+using NSubstitute;
+
+using Unifesspa.UniPlus.Application.Abstractions.Authentication;
+using Unifesspa.UniPlus.Configuracao.Contracts;
+using Unifesspa.UniPlus.Kernel.Results;
+using Unifesspa.UniPlus.Publicacoes.Contracts;
+using Unifesspa.UniPlus.Selecao.Application.Abstractions;
+using Unifesspa.UniPlus.Selecao.Application.Commands.ProcessosSeletivos;
+using Unifesspa.UniPlus.Selecao.Domain.Entities;
+using Unifesspa.UniPlus.Selecao.Domain.Enums;
+using Unifesspa.UniPlus.Selecao.Domain.Interfaces;
+using Unifesspa.UniPlus.Selecao.Domain.ValueObjects;
+
+/// <summary>
+/// Issue #1077: um fato coletável de SELEÇÃO (CONDICAO_ATENDIMENTO/TIPO_DEFICIENCIA) sem
+/// nenhum valor ofertado publicaria um seletor sem opção nenhuma para o candidato escolher.
+/// Prova, nos <b>três</b> handlers que congelam (ao lado de <see cref="ColetabilidadeDeFatosGateTests"/>
+/// e <see cref="ConformidadeLegalGateTests"/>), que o gate recusa ANTES da canonicalização.
+/// </summary>
+public sealed class FatoColetavelDeEscopoGateTests
+{
+    private static readonly string HashFixo = ProcessoSeletivoConformeBuilder.HashFixo;
+    private static readonly DateTimeOffset Agora = new(2026, 1, 1, 12, 0, 0, TimeSpan.Zero);
+
+    private static FatoColetado FatoCondicaoAtendimentoSemOferta() => FatoColetado.Criar(
+        "CONDICAO_ATENDIMENTO", 0, "Você se enquadra em alguma condição de atendimento?",
+        TipoRenderizacao.SelecaoMultipla, obrigatorio: false, null).Value!;
+
+    [Fact(DisplayName = "Publicar_ComFatoColetavelSemOferta_RecusaSemCanonicalizar — o gate precede a canonicalização")]
+    public async Task Publicar_ComFatoColetavelSemOferta_RecusaSemCanonicalizar()
+    {
+        ProcessoSeletivo processo = NovoProcessoConforme();
+        // ProcessoSeletivoConformeBuilder já oferta atendimento vazio (sem condições) — só falta o fato coletável.
+        processo.DefinirFatosColetados([FatoCondicaoAtendimentoSemOferta()], PrecondicaoIfMatch.Ausente)
+            .IsSuccess.Should().BeTrue();
+
+        ISnapshotPublicacaoCanonicalizer canonicalizer = CanonicalizerSubstituto();
+
+        (Result resposta, IEnumerable<object> eventos) = await PublicarProcessoSeletivoCommandHandler.Handle(
+            new PublicarProcessoSeletivoCommand(
+                processo.Id, "001/2026", new DateOnly(2026, 1, 1), new DateOnly(2026, 1, 31),
+                DocumentoEditalId: Guid.CreateVersion7(), Ato: NovoAto()),
+            RepositorioDoProcesso(processo),
+            RepositorioDeDocumento(processo.Id),
+            canonicalizer,
+            Substitute.For<ISelecaoUnitOfWork>(),
+            UsuarioAutenticado(),
+            TipoDeAtoReader(),
+            Substitute.For<IVagaDeLinhagemReader>(),
+            Substitute.For<IObrigatoriedadeLegalRepository>(),
+            Substitute.For<IFatoCandidatoReader>(),
+            new RelogioFixo(Agora),
+            CancellationToken.None);
+
+        resposta.IsFailure.Should().BeTrue();
+        resposta.Error!.Code.Should().Be("ProcessoSeletivo.FatoColetadoSemValoresOfertados");
+        _ = canonicalizer.DidNotReceive().Canonicalizar(Arg.Any<EntradaCanonicalizacao>());
+        eventos.Should().BeEmpty();
+        processo.Status.Should().Be(StatusProcesso.Rascunho, "a publicação recusada não transita o processo");
+    }
+
+    // RetificarProcessoSeletivoCommandHandler não aceita novo FatoColetado/OfertaAtendimento
+    // como input — re-versiona o estado JÁ existente do agregado sob um novo ato, e exige
+    // Rascunho nulo (abre e fecha uma sessão efêmera internamente). Como este gate é interno
+    // ao agregado (sem leitura cross-módulo, ao contrário da coletabilidade de fatos), não há
+    // "drift" possível entre a publicação original e uma chamada de Retificar sem sessão
+    // aberta: se o estado violasse o gate, a publicação original já teria recusado. O caminho
+    // válido para reabrir e violar o gate é a sessão de retificação explícita — coberto abaixo
+    // por FecharRetificacaoCommandHandler, que também fecha por SucederVersao (mesmo gate).
+
+    [Fact(DisplayName = "FecharRetificacao_ComFatoColetavelSemOferta_RecusaESessaoPermaneceAberta — recusa não destrói a sessão editorial")]
+    public async Task FecharRetificacao_ComFatoColetavelSemOferta_RecusaESessaoPermaneceAberta()
+    {
+        (ProcessoSeletivo processo, VersaoConfiguracao versaoAtual) = ProcessoPublicadoSemFatoColetado();
+
+        Result<RascunhoRetificacao> rascunho = processo.AbrirRetificacao(
+            "Correção do prazo", versaoAtual, "user-sub-1", Agora);
+        rascunho.IsSuccess.Should().BeTrue(rascunho.Error?.Message);
+        processo.DequeueDomainEvents();
+
+        processo.DefinirFatosColetados([FatoCondicaoAtendimentoSemOferta()], PrecondicaoIfMatch.Curinga)
+            .IsSuccess.Should().BeTrue();
+
+        ISnapshotPublicacaoCanonicalizer canonicalizer = CanonicalizerSubstituto();
+
+        IProcessoSeletivoRepository repositorio = RepositorioDoProcesso(processo);
+        repositorio.ObterVersaoAtualAsync(processo.Id, Arg.Any<CancellationToken>()).Returns(versaoAtual);
+
+        (Result resposta, IEnumerable<object> eventos) = await FecharRetificacaoCommandHandler.Handle(
+            new FecharRetificacaoCommand(
+                processo.Id, "001/2026-R1", new DateOnly(2026, 1, 1), new DateOnly(2026, 1, 31),
+                DocumentoEditalId: Guid.CreateVersion7(), Ato: NovoAto(), Precondicao: PrecondicaoIfMatch.Curinga),
+            repositorio,
+            RepositorioDeDocumento(processo.Id),
+            canonicalizer,
+            Substitute.For<ISelecaoUnitOfWork>(),
+            UsuarioAutenticado(),
+            TipoDeAtoReader(),
+            Substitute.For<IVagaDeLinhagemReader>(),
+            Substitute.For<IObrigatoriedadeLegalRepository>(),
+            Substitute.For<IFatoCandidatoReader>(),
+            new RelogioFixo(Agora),
+            CancellationToken.None);
+
+        resposta.IsFailure.Should().BeTrue();
+        resposta.Error!.Code.Should().Be("ProcessoSeletivo.FatoColetadoSemValoresOfertados");
+        _ = canonicalizer.DidNotReceive().Canonicalizar(Arg.Any<EntradaCanonicalizacao>());
+        eventos.Should().BeEmpty();
+        processo.Rascunho.Should().NotBeNull(
+            "uma recusa de fato coletável sem oferta não destrói a sessão editorial — o administrador corrige e tenta de novo");
+    }
+
+    // ══════════════════════════════════════════════════════════════════════════════
+
+    private static ISnapshotPublicacaoCanonicalizer CanonicalizerSubstituto()
+    {
+        ISnapshotPublicacaoCanonicalizer canonicalizer = Substitute.For<ISnapshotPublicacaoCanonicalizer>();
+        canonicalizer.Canonicalizar(Arg.Any<EntradaCanonicalizacao>())
+            .Returns(new SnapshotCanonico("{}"u8.ToArray(), "1.1", "canonical-json/sha256@v1"));
+        return canonicalizer;
+    }
+
+    private static IProcessoSeletivoRepository RepositorioDoProcesso(ProcessoSeletivo processo)
+    {
+        IProcessoSeletivoRepository repositorio = Substitute.For<IProcessoSeletivoRepository>();
+        repositorio.ObterParaMutacaoAsync(processo.Id, Arg.Any<CancellationToken>()).Returns(processo);
+        return repositorio;
+    }
+
+    private static IDocumentoEditalRepository RepositorioDeDocumento(Guid processoSeletivoId)
+    {
+        DocumentoEdital documento = DocumentoEdital.IniciarPendente(
+            processoSeletivoId, TimeProvider.System, TimeSpan.FromMinutes(15));
+        documento.Confirmar(1024, HashFixo, TimeProvider.System).IsSuccess.Should().BeTrue();
+
+        IDocumentoEditalRepository repositorio = Substitute.For<IDocumentoEditalRepository>();
+        repositorio.ObterPorIdAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>()).Returns(documento);
+        return repositorio;
+    }
+
+    private static ITipoAtoPublicadoReader TipoDeAtoReader()
+    {
+        ITipoAtoPublicadoReader reader = Substitute.For<ITipoAtoPublicadoReader>();
+        reader.ObterVigenteAsync("EDITAL_ABERTURA", Arg.Any<DateOnly>(), Arg.Any<CancellationToken>())
+            .Returns(new TipoAtoPublicadoView(
+                Codigo: "EDITAL_ABERTURA",
+                Nome: "Edital de abertura",
+                CongelaConfiguracao: true,
+                UnicoPorObjeto: false,
+                EfeitoIrreversivel: false));
+        return reader;
+    }
+
+    private static IUserContext UsuarioAutenticado()
+    {
+        IUserContext contexto = Substitute.For<IUserContext>();
+        contexto.UserId.Returns("user-sub-1");
+        return contexto;
+    }
+
+    private static DadosDoAto NovoAto() => new(
+        Orgao: "CEPS",
+        Serie: "EDITAL",
+        Ano: 2026,
+        DataPublicacao: new DateOnly(2026, 1, 1),
+        Assinante: "Diretor do CEPS",
+        TipoAtoCodigo: "EDITAL_ABERTURA");
+
+    /// <summary>Processo publicado SEM FatoColetado — o fato problemático é acrescentado depois, na retificação.</summary>
+    private static (ProcessoSeletivo Processo, VersaoConfiguracao VersaoAtual) ProcessoPublicadoSemFatoColetado()
+    {
+        ProcessoSeletivo processo = NovoProcessoConforme();
+
+        DadosEdital dados = DadosEdital.Criar(
+            "001/2026", new DateOnly(2026, 1, 1), new DateOnly(2026, 1, 31), Guid.CreateVersion7()).Value!;
+
+        VersaoConfiguracao versao = processo.Publicar(
+            dados, "{}"u8.ToArray(), "1.1", "canonical-json/sha256@v1", HashFixo, "user-sub-1",
+            new RelogioFixo(Agora)).Value!;
+        processo.DequeueDomainEvents();
+
+        return (processo, versao);
+    }
+
+    private static ProcessoSeletivo NovoProcessoConforme() =>
+        ProcessoSeletivoConformeBuilder.Criar("PS Gate Fato Coletável de Escopo");
+
+    private sealed class RelogioFixo(DateTimeOffset instante) : TimeProvider
+    {
+        public override DateTimeOffset GetUtcNow() => instante;
+    }
+}

--- a/tests/Unifesspa.UniPlus.Selecao.Application.UnitTests/Commands/ResolvedorValoresSelecionaveisCongeladosTests.cs
+++ b/tests/Unifesspa.UniPlus.Selecao.Application.UnitTests/Commands/ResolvedorValoresSelecionaveisCongeladosTests.cs
@@ -1,0 +1,83 @@
+namespace Unifesspa.UniPlus.Selecao.Application.UnitTests.Commands;
+
+using AwesomeAssertions;
+
+using Unifesspa.UniPlus.Configuracao.Contracts;
+using Unifesspa.UniPlus.Kernel.Results;
+using Unifesspa.UniPlus.Selecao.Application.Abstractions;
+using Unifesspa.UniPlus.Selecao.Application.Commands.ProcessosSeletivos;
+using Unifesspa.UniPlus.Selecao.Domain.Entities;
+using Unifesspa.UniPlus.Selecao.Domain.Enums;
+using Unifesspa.UniPlus.Selecao.Domain.ValueObjects;
+
+/// <summary>
+/// issue #1077 — §2: defesa em profundidade da fronteira Application. O caminho esperado para
+/// um fato de escopo-processo sem oferta é <c>ProcessoSeletivo.PendenciaDeFatoColetadoSemValoresOfertados</c>,
+/// avaliado ANTES deste resolvedor rodar — os testes abaixo chamam o resolvedor DIRETO,
+/// contornando o gate, para provar que ele também nunca devolve sucesso com lista vazia.
+/// </summary>
+public sealed class ResolvedorValoresSelecionaveisCongeladosTests
+{
+    private static ProcessoSeletivo NovoProcesso() => ProcessoSeletivo.Criar(
+        "PS Resolvedor", TipoProcesso.SiSU, OrigemCandidatos.InscricaoPropria, Guid.NewGuid(),
+        UnidadeAdministradoraSnapshot.Criar("CEPS", "ceps", "Centro de Processos Seletivos", "ADMINISTRATIVA").Value!);
+
+    private static FatoCandidatoView FatoCategoricoDeEscopoProcesso(string codigo) => new(
+        Id: Guid.CreateVersion7(),
+        Codigo: codigo,
+        Nome: codigo,
+        Descricao: null,
+        Dominio: "CATEGORICO",
+        Origem: "DECLARADO",
+        Cardinalidade: "MULTIVALORADO",
+        ValoresDominio: null,
+        PontoResolucao: "INSCRICAO",
+        Binding: $"CAMPO_INSCRICAO:{codigo}",
+        ValoresDominioDeclarados: null);
+
+    [Fact(DisplayName = "Resolver recusa CONDICAO_ATENDIMENTO coletável sem nenhuma condição ofertada")]
+    public void Resolver_CondicaoAtendimentoSemOferta_Recusa()
+    {
+        ProcessoSeletivo processo = NovoProcesso();
+        processo.DefinirOfertaAtendimento(OfertaAtendimentoEspecializado.Criar([], [], []).Value!, PrecondicaoIfMatch.Ausente)
+            .IsSuccess.Should().BeTrue();
+        processo.DefinirFatosColetados(
+            [FatoColetado.Criar("CONDICAO_ATENDIMENTO", 0, "Condição de atendimento", TipoRenderizacao.SelecaoMultipla, false, null).Value!],
+            PrecondicaoIfMatch.Ausente).IsSuccess.Should().BeTrue();
+
+        Dictionary<string, FatoCandidatoView> catalogo = new(StringComparer.Ordinal)
+        {
+            ["CONDICAO_ATENDIMENTO"] = FatoCategoricoDeEscopoProcesso("CONDICAO_ATENDIMENTO"),
+        };
+
+        Result<IReadOnlyDictionary<string, IReadOnlyList<ValorDominioDeclaradoCongelado>?>> resultado =
+            ResolvedorValoresSelecionaveisCongelados.Resolver(processo, catalogo);
+
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be("ProcessoSeletivo.FatoColetadoSemValoresOfertados");
+    }
+
+    [Fact(DisplayName = "Resolver aceita CONDICAO_ATENDIMENTO coletável com condição ofertada e devolve lista não vazia")]
+    public void Resolver_CondicaoAtendimentoComOferta_Aceita()
+    {
+        ProcessoSeletivo processo = NovoProcesso();
+        processo.DefinirOfertaAtendimento(
+            OfertaAtendimentoEspecializado.Criar(
+                [OfertaCondicao.Criar(Guid.CreateVersion7(), "PCD", "Pessoa com deficiência")], [], []).Value!,
+            PrecondicaoIfMatch.Ausente).IsSuccess.Should().BeTrue();
+        processo.DefinirFatosColetados(
+            [FatoColetado.Criar("CONDICAO_ATENDIMENTO", 0, "Condição de atendimento", TipoRenderizacao.SelecaoMultipla, false, null).Value!],
+            PrecondicaoIfMatch.Ausente).IsSuccess.Should().BeTrue();
+
+        Dictionary<string, FatoCandidatoView> catalogo = new(StringComparer.Ordinal)
+        {
+            ["CONDICAO_ATENDIMENTO"] = FatoCategoricoDeEscopoProcesso("CONDICAO_ATENDIMENTO"),
+        };
+
+        Result<IReadOnlyDictionary<string, IReadOnlyList<ValorDominioDeclaradoCongelado>?>> resultado =
+            ResolvedorValoresSelecionaveisCongelados.Resolver(processo, catalogo);
+
+        resultado.IsSuccess.Should().BeTrue(resultado.Error?.Message);
+        resultado.Value!["CONDICAO_ATENDIMENTO"].Should().ContainSingle(v => v.Codigo == "PCD");
+    }
+}

--- a/tests/Unifesspa.UniPlus.Selecao.Application.UnitTests/Commands/ValoresDeDominioAtivosGateTests.cs
+++ b/tests/Unifesspa.UniPlus.Selecao.Application.UnitTests/Commands/ValoresDeDominioAtivosGateTests.cs
@@ -145,6 +145,15 @@ public sealed class ValoresDeDominioAtivosGateTests
     public async Task Publicar_FatoDeEscopoProcessoColetado_NaoBloqueiaMesmoComOutroFatoComValorInativo()
     {
         ProcessoSeletivo processo = NovoProcessoConforme();
+        // issue #1077: um fato coletável de escopo do processo sem NENHUM valor ofertado
+        // recusaria a publicação (gate à parte deste, ProcessoSeletivo.
+        // PendenciaDeFatoColetadoSemValoresOfertados) — a oferta precisa de ao menos uma
+        // condição para que este teste continue isolando o que realmente quer provar (o
+        // vocabulário inativo de OUTRO fato é irrelevante para um fato de escopo-processo).
+        processo.DefinirOfertaAtendimento(
+            OfertaAtendimentoEspecializado.Criar(
+                [OfertaCondicao.Criar(Guid.CreateVersion7(), "PCD", "Pessoa com deficiência")], [], []).Value!,
+            PrecondicaoIfMatch.Curinga).IsSuccess.Should().BeTrue();
         FatoColetado condicaoAtendimento = FatoColetado.Criar(
             "CONDICAO_ATENDIMENTO", 0, "Condição de atendimento", TipoRenderizacao.SelecaoMultipla, obrigatorio: false, null).Value!;
         processo.DefinirFatosColetados([condicaoAtendimento], PrecondicaoIfMatch.Ausente).IsSuccess.Should().BeTrue();

--- a/tests/Unifesspa.UniPlus.Selecao.Domain.UnitTests/Entities/ConformidadePublicabilidadeEstruturalTests.cs
+++ b/tests/Unifesspa.UniPlus.Selecao.Domain.UnitTests/Entities/ConformidadePublicabilidadeEstruturalTests.cs
@@ -613,6 +613,49 @@ public sealed class ConformidadePublicabilidadeEstruturalTests
         resultado.Error!.Code.Should().Be(FatoColetadoErrorCodes.PrecondicaoCitaFatoNaoColetado);
     }
 
+    private static OfertaAtendimentoEspecializado OfertaComCondicaoPcd() => OfertaAtendimentoEspecializado.Criar(
+        [OfertaCondicao.Criar(Guid.CreateVersion7(), OfertaAtendimentoEspecializado.CodigoCondicaoPcd, "Pessoa com deficiência")],
+        [],
+        []).Value!;
+
+    [Fact(DisplayName = "Pré-canonicalização: fato coletável CONDICAO_ATENDIMENTO sem nenhuma condição ofertada — item vermelho e Publicar recusa com FatoColetadoSemValoresOfertados (cenário da issue)")]
+    public void PreCanon_FatoColetadoCondicaoAtendimentoSemValoresOfertados()
+    {
+        ProcessoSeletivo processo = ProcessoConforme();
+        // ProcessoConforme já oferta atendimento vazio (sem condições) — só falta o fato coletável.
+        FatoColetado fato = FatoColetado.Criar(
+            "CONDICAO_ATENDIMENTO", 0, "Você se enquadra em alguma condição de atendimento?",
+            TipoRenderizacao.SelecaoMultipla, obrigatorio: false, precondicoes: null).Value!;
+        processo.DefinirFatosColetados([fato], PrecondicaoIfMatch.Ausente).IsSuccess.Should().BeTrue();
+
+        processo.AvaliarConformidade().Should().ContainSingle(i => !i.Ok)
+            .Which.Item.Should().Be("Fato coletável de escopo do processo: oferta declara ao menos um valor");
+
+        Result<VersaoConfiguracao> resultado = Publicar(processo);
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be("ProcessoSeletivo.FatoColetadoSemValoresOfertados");
+    }
+
+    [Fact(DisplayName = "Pré-canonicalização: fato coletável TIPO_DEFICIENCIA sem nenhum tipo ofertado — item vermelho e Publicar recusa com FatoColetadoSemValoresOfertados")]
+    public void PreCanon_FatoColetadoTipoDeficienciaSemValoresOfertados()
+    {
+        ProcessoSeletivo processo = ProcessoConforme();
+        // Condição PcD ofertada (pré-requisito da ADR-0067), mas nenhum TipoDeficiencia —
+        // só o fato de tipo de deficiência fica sem valor para oferecer ao candidato.
+        processo.DefinirOfertaAtendimento(OfertaComCondicaoPcd(), PrecondicaoIfMatch.Curinga).IsSuccess.Should().BeTrue();
+        FatoColetado fato = FatoColetado.Criar(
+            "TIPO_DEFICIENCIA", 0, "Qual o tipo de deficiência?",
+            TipoRenderizacao.SelecaoUnica, obrigatorio: false, precondicoes: null).Value!;
+        processo.DefinirFatosColetados([fato], PrecondicaoIfMatch.Ausente).IsSuccess.Should().BeTrue();
+
+        processo.AvaliarConformidade().Should().ContainSingle(i => !i.Ok)
+            .Which.Item.Should().Be("Fato coletável de escopo do processo: oferta declara ao menos um valor");
+
+        Result<VersaoConfiguracao> resultado = Publicar(processo);
+        resultado.IsFailure.Should().BeTrue();
+        resultado.Error!.Code.Should().Be("ProcessoSeletivo.FatoColetadoSemValoresOfertados");
+    }
+
     [Fact(DisplayName = "Pré-canonicalização: MODALIDADE contribui código fora do domínio ofertado — item vermelho e Publicar recusa com RegrasDerivacaoFatoErrorCodes.ContribuiForaDoDominio")]
     public void PreCanon_ModalidadeContribuiForaDoDominio()
     {
@@ -731,6 +774,41 @@ public sealed class ConformidadePublicabilidadeEstruturalTests
         {
             checklist.Should().Contain(i => i.Item == item && i.Ok, $"cascata não se aplica — \"{item}\" não pode ficar vermelho");
         }
+    }
+
+    [Fact(DisplayName = "Contraprova: fato coletável CONDICAO_ATENDIMENTO com condição ofertada mantém o item Ok")]
+    public void Contraprova_FatoColetadoCondicaoAtendimentoComOferta_ChecklistVerde()
+    {
+        ProcessoSeletivo processo = ProcessoConforme();
+        processo.DefinirOfertaAtendimento(OfertaComCondicaoPcd(), PrecondicaoIfMatch.Curinga).IsSuccess.Should().BeTrue();
+        FatoColetado fato = FatoColetado.Criar(
+            "CONDICAO_ATENDIMENTO", 0, "Você se enquadra em alguma condição de atendimento?",
+            TipoRenderizacao.SelecaoMultipla, obrigatorio: false, precondicoes: null).Value!;
+        processo.DefinirFatosColetados([fato], PrecondicaoIfMatch.Ausente).IsSuccess.Should().BeTrue();
+
+        processo.AvaliarConformidade().Should().Contain(
+            i => i.Item == "Fato coletável de escopo do processo: oferta declara ao menos um valor" && i.Ok);
+
+        Result<VersaoConfiguracao> resultado = Publicar(processo);
+        resultado.IsSuccess.Should().BeTrue(resultado.Error?.Message);
+    }
+
+    [Fact(DisplayName = "Contraprova: fato coletável renderizado como Booleano não aciona o gate, mesmo sem oferta correspondente")]
+    public void Contraprova_FatoColetadoBooleano_NaoAcionaGate()
+    {
+        ProcessoSeletivo processo = ProcessoConforme();
+        // Mesmo código de fato do gate, mas TipoRenderizacao fora de {SelecaoUnica, SelecaoMultipla}
+        // — o gate só se aplica a campo com opções, que é o que fica vazio sem oferta.
+        FatoColetado fato = FatoColetado.Criar(
+            "CONDICAO_ATENDIMENTO", 0, "Possui alguma condição de atendimento?",
+            TipoRenderizacao.Booleano, obrigatorio: false, precondicoes: null).Value!;
+        processo.DefinirFatosColetados([fato], PrecondicaoIfMatch.Ausente).IsSuccess.Should().BeTrue();
+
+        processo.AvaliarConformidade().Should().Contain(
+            i => i.Item == "Fato coletável de escopo do processo: oferta declara ao menos um valor" && i.Ok);
+
+        Result<VersaoConfiguracao> resultado = Publicar(processo);
+        resultado.IsSuccess.Should().BeTrue(resultado.Error?.Message);
     }
 
     [Fact(DisplayName = "Contraprova: ausência de gatilho por FAIXA_ETARIA mantém os quatro itens de referência temporal Ok, mesmo com outras exigências configuradas")]

--- a/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/Outbox/Cascading/EnvelopeFechadoE2ETests.cs
+++ b/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/Outbox/Cascading/EnvelopeFechadoE2ETests.cs
@@ -274,6 +274,7 @@ public sealed class EnvelopeFechadoE2ETests
                 "Referência temporal de fatos: extremo da fase âncora definido",
                 "Referência temporal de fatos: fase de coleta com Fim definido para FIM_INSCRICAO",
                 "Regras de derivação: fatos citados existem no processo",
+                "Fato coletável de escopo do processo: oferta declara ao menos um valor",
                 "Regras de derivação: código contribuído pertence ao domínio ofertado",
                 "Grafo de dependência conjunto: sem ciclo",
             ],

--- a/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/ProcessosSeletivos/EnvelopeCanonicoGoldenTests.cs
+++ b/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/ProcessosSeletivos/EnvelopeCanonicoGoldenTests.cs
@@ -568,6 +568,35 @@ public sealed class EnvelopeCanonicoGoldenTests
                 "primeiro erro de programação que o encoder encontra");
     }
 
+    /// <summary>issue #1077 — §3, CA-12: o canonicalizer nunca serializa uma lista vazia para um fato de seleção.</summary>
+    [Fact(DisplayName = "SerializarFatosColetados lança quando o dicionário traz lista VAZIA para um fato de seleção")]
+    public void SerializarFatosColetados_ComListaVaziaParaFatoDeSelecao_Lanca()
+    {
+        // Diferente do teste acima (entrada AUSENTE): aqui a entrada existe, mas é []. O gate de
+        // pré-canonicalização (ProcessoSeletivo.PendenciaDeFatoColetadoSemValoresOfertados,
+        // issue #1077) deveria ter recusado a publicação antes deste ponto — chegar aqui com
+        // lista vazia é erro de programação do handler (esqueceu o gate ou o resolvedor), nunca
+        // um seletor legítimo sem opção.
+        ProcessoSeletivo processo = ProcessoDeReferencia();
+        DadosEdital dados = DadosDeReferencia();
+        Dictionary<string, IReadOnlyList<ValorDominioDeclaradoCongelado>?> valoresComListaVazia =
+            new(ValoresSelecionaveisDeReferencia(), StringComparer.Ordinal)
+            {
+                ["COR_RACA"] = [],
+            };
+
+        Action canonicalizarComListaVazia = () => Canonicalizer.Canonicalizar(
+            new EntradaCanonicalizacao(
+                processo, dados, HashFixo,
+                MetadadosFatosCongelados: MetadadosFatosDeReferencia(),
+                ValoresSelecionaveisCongelados: valoresComListaVazia));
+
+        canonicalizarComListaVazia.Should().Throw<InvalidOperationException>()
+            .WithMessage("*COR_RACA*",
+                "um seletor de SELECAO_UNICA/SELECAO_MULTIPLA publicado sem opção nenhuma não é respondível — " +
+                "o canonicalizer nunca emite \"valoresSelecionaveis\": []");
+    }
+
     // ── Issue #1059 (UNI-REQ-0072) — ordem: bate com a origem, é canônica e desempata por código ──
 
     [Fact(DisplayName = "valoresSelecionaveis[].ordem e metadadosFatos[].valoresDominioDeclarados[].ordem batem com a Ordem de origem, ordenados por Ordem/Codigo — independente da ordem de inserção no dicionário")]

--- a/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/ProcessosSeletivos/EnvelopeCodecRecusaTests.cs
+++ b/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/ProcessosSeletivos/EnvelopeCodecRecusaTests.cs
@@ -1000,6 +1000,21 @@ public sealed class EnvelopeCodecRecusaTests
         resultado.Error!.Code.Should().Be(ErrosCodecEnvelope.EnvelopeMalformado);
     }
 
+    /// <summary>issue #1077 — §4, CA-13: um envelope adulterado com array VAZIO para um fato de seleção é malformado, não um caso legítimo a reidratar.</summary>
+    [Fact(DisplayName = "Bicondicional: valoresSelecionaveis com array VAZIO num fato de SELEÇÃO é recusado — cardinalidade mínima 1")]
+    public void ValoresSelecionaveis_ArrayVazioEmFatoDeSelecao_Recusa()
+    {
+        Result<EnvelopeReidratado> resultado = ReidratarComEnvelopeAdulterado(envelope =>
+            FatoColetadoPorCodigo(envelope, "COR_RACA")["valoresSelecionaveis"] = new JsonArray());
+
+        resultado.IsFailure.Should().BeTrue(
+            "COR_RACA é SELECAO_UNICA — array vazio é um seletor sem opção nenhuma, tão mudo quanto null. " +
+            "A publicação original nunca teria produzido isso: o gate de pré-canonicalização " +
+            "(ProcessoSeletivo.PendenciaDeFatoColetadoSemValoresOfertados) recusa antes de canonicalizar, e " +
+            "SerializarFatosColetados também lança — só um envelope adulterado chega aqui com [] persistido");
+        resultado.Error!.Code.Should().Be(ErrosCodecEnvelope.EnvelopeMalformado);
+    }
+
     [Fact(DisplayName = "Bicondicional: valoresSelecionaveis com array num fato que NÃO é de seleção é recusado — vocabulário pendurado")]
     public void ValoresSelecionaveis_ArrayEmFatoNaoDeSelecao_Recusa()
     {


### PR DESCRIPTION
## Resumo

Um fato coletado categórico de escopo do processo (`CONDICAO_ATENDIMENTO`, `TIPO_DEFICIENCIA`) renderizado como seleção podia ser publicado sem que a oferta correspondente do processo (`OfertaAtendimento.Condicoes`/`TiposDeficiencia`) declarasse nenhum valor — o formulário de inscrição chegava ao candidato com um seletor sem opção nenhuma.

Closes #1077

## O que mudou

**Gate de domínio** (fonte única, ADR-0109 D5):
- `ProcessoSeletivo.PendenciaDeFatoColetadoSemValoresOfertados`, avaliada dentro de `PendenciaPreCanonicalizacao` — a mesma pendência que `Publicar`, `Retificar` e `FecharRetificacao` já compartilham via `SucederVersao`, então o gate vale para as três transições sem tocar nos handlers de Application.
- Item correspondente em `AvaliarConformidade()`, preservando a equivalência entre checklist estrutural e publicabilidade.

**Defesa em profundidade** (nenhum caminho abaixo é alcançável em uso normal — o gate já recusa antes):
- `ResolvedorValoresSelecionaveisCongelados` recusa ao resolver zero valores para um fato de seleção.
- `SnapshotPublicacaoCanonicalizer` lança ao serializar `valoresSelecionaveis` vazio.
- `EnvelopeCodec` recusa como `EnvelopeMalformado` um array vazio decodificado para fato de seleção.
- `ObterFormularioRenderizavelQueryHandler` não projeta seletor vazio ao endpoint público.
- OpenAPI declara `minItems: 1` em `valoresSelecionaveis` (`UniPlusSchemaTransformer`).

Sem bump de `schema_version` — a forma JSON não ganha campo novo, só fica mais estrita a validade do array existente (decisão explícita da issue, ADR-0109).

## Testes

- Domain: matriz fato × obrigatoriedade (`CONDICAO_ATENDIMENTO`/`TIPO_DEFICIENCIA`, obrigatório/opcional) em `ConformidadePublicabilidadeEstruturalTests`, com contraprovas (oferta preenchida, `TipoRenderizacao` fora do escopo do gate).
- Application: gate via `Publicar`/`FecharRetificacao` (`FatoColetavelDeEscopoGateTests`) provando que a recusa precede a canonicalização; defesa do resolvedor isolada (`ResolvedorValoresSelecionaveisCongeladosTests`).
- Canonicalização: `SerializarFatosColetados` lança para lista vazia (`EnvelopeCanonicoGoldenTests`).
- Codec: array vazio adulterado é recusado como malformado (`EnvelopeCodecRecusaTests`).
- Suíte completa local verde (build + testes + `dotnet format`).

## Fora de escopo (conforme a issue)

`Retificar` não tem caminho de teste válido para este gate específico — o handler não aceita novo `FatoColetado`/`OfertaAtendimento` como input (re-versiona o estado já existente sob `Rascunho == null`, sem sessão editorial aberta), então não há "drift" possível entre uma publicação original já compatível e uma chamada de Retificar isolada. A cobertura do mesmo gate compartilhado (`SucederVersao`) fica com `FecharRetificacao`, que suporta abrir sessão → mutar → fechar.