### PR TITLE
fix(selecao): desacopla pendencias do código de erro na recusa 422

### DIFF
--- a/src/selecao/Unifesspa.UniPlus.Selecao.API/Controllers/ProcessoSeletivoController.cs
+++ b/src/selecao/Unifesspa.UniPlus.Selecao.API/Controllers/ProcessoSeletivoController.cs
@@ -537,8 +537,10 @@ public sealed class ProcessoSeletivoController : ControllerBase
     /// Publica o processo (RN08): valida a conformidade, congela a versão 1 da
     /// configuração (append-only) e transita o status para Publicado, tudo na mesma
     /// transação — junto da requisição durável que registra o ato em Publicações
-    /// (ADR-0108). Quando a publicação é recusada por conformidade insuficiente
-    /// (CA-03), o corpo do 422 carrega <c>Extensions["pendencias"]</c> com o checklist.
+    /// (ADR-0108). Toda recusa 422 é reavaliada contra o checklist estrutural
+    /// (issue #1096): havendo item vermelho no estado atual, o corpo carrega
+    /// <c>Extensions["pendencias"]</c>, qualquer que seja o código do erro que
+    /// efetivamente recusou.
     /// <para>
     /// O bloco <c>ato</c> é o MESMO que a retificação recebe: o tipo do ato vem
     /// declarado pelo operador e é conferido contra o catálogo de Publicações — nunca
@@ -570,23 +572,29 @@ public sealed class ProcessoSeletivoController : ControllerBase
         }
 
         IActionResult actionResult = resultado.ToActionResult(_mapper);
-        actionResult = await EnriquecerComPendenciasEstruturaisAsync(resultado, actionResult, id, cancellationToken)
+        actionResult = await EnriquecerComPendenciasEstruturaisAsync(actionResult, id, cancellationToken)
             .ConfigureAwait(false);
         return await EnriquecerComObrigatoriedadesReprovadasAsync(
             resultado, actionResult, id, request.PeriodoInscricaoInicio, cancellationToken).ConfigureAwait(false);
     }
 
     /// <summary>
-    /// CA-03: enriquece o 422 de conformidade ESTRUTURAL insuficiente com o checklist de
+    /// Issue #1096: enriquece TODA recusa HTTP 422 da publicação com o checklist de
     /// pendências — reconsulta <see cref="ObterConformidadeProcessoSeletivoQuery"/> (mesmo
-    /// <c>ProcessoSeletivo.AvaliarConformidade()</c> por trás do gate, sem duplicar a regra)
-    /// para montar <c>Extensions["pendencias"]</c>.
+    /// <c>ProcessoSeletivo.AvaliarConformidade()</c> por trás dos quatro gates estruturais,
+    /// sem duplicar a regra nem manter lista paralela de códigos de erro no controller) e
+    /// anexa <c>Extensions["pendencias"]</c> quando o estado atual tiver item vermelho —
+    /// independentemente de qual gate produziu o 422 (CA-01/CA-02/CA-03/CA-04/CA-06). Quando
+    /// o checklist estiver 100% verde, a extensão é omitida — nunca <c>pendencias: []</c>
+    /// (CA-05/CA-07).
     /// </summary>
     private async Task<IActionResult> EnriquecerComPendenciasEstruturaisAsync(
-        Result resultado, IActionResult actionResult, Guid id, CancellationToken cancellationToken)
+        IActionResult actionResult, Guid id, CancellationToken cancellationToken)
     {
-        if (!resultado.HasErrorCode("ProcessoSeletivo.ConformidadeInsuficiente")
-            || actionResult is not ObjectResult { Value: ProblemDetails problem })
+        if (actionResult is not ObjectResult
+            {
+                StatusCode: StatusCodes.Status422UnprocessableEntity, Value: ProblemDetails problem,
+            })
         {
             return actionResult;
         }
@@ -594,12 +602,14 @@ public sealed class ProcessoSeletivoController : ControllerBase
         ConformidadeProcessoSeletivoDto? conformidade = await _queryBus
             .Send(new ObterConformidadeProcessoSeletivoQuery(id), cancellationToken)
             .ConfigureAwait(false);
-        if (conformidade is not null)
+
+        string[] pendencias = conformidade?.Itens
+            .Where(item => !item.Ok)
+            .Select(item => item.Item)
+            .ToArray() ?? [];
+        if (pendencias.Length > 0)
         {
-            problem.Extensions["pendencias"] = conformidade.Itens
-                .Where(item => !item.Ok)
-                .Select(item => item.Item)
-                .ToArray();
+            problem.Extensions["pendencias"] = pendencias;
         }
 
         return actionResult;

--- a/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/Outbox/Cascading/ProcessoSeletivoPendenciasSeeder.cs
+++ b/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/Outbox/Cascading/ProcessoSeletivoPendenciasSeeder.cs
@@ -1,0 +1,263 @@
+namespace Unifesspa.UniPlus.Selecao.IntegrationTests.Outbox.Cascading;
+
+using AwesomeAssertions;
+
+using Domain.Entities;
+using Domain.Enums;
+using Domain.ValueObjects;
+
+using Kernel.Results;
+
+using Unifesspa.UniPlus.Selecao.Infrastructure.Persistence;
+using Unifesspa.UniPlus.Selecao.Infrastructure.Persistence.Repositories;
+
+/// <summary>
+/// Variantes de <see cref="ProcessoSeletivoPublicavelSeeder"/> — cada método isola UM defeito
+/// estrutural específico (issue #1096), para provar via HTTP que
+/// <c>Extensions["pendencias"]</c> aparece em toda recusa 422 com checklist vermelho, não só
+/// quando o erro é <c>ProcessoSeletivo.ConformidadeInsuficiente</c>.
+/// </summary>
+internal static class ProcessoSeletivoPendenciasSeeder
+{
+    // 64 caracteres hex minúsculos — shape de SHA-256 exigido por
+    // HashCanonicalComputer.IsValidHashShape; valor arbitrário (não é recomputado).
+    private static readonly string HashFixo = string.Concat(Enumerable.Repeat("ab01234567", 7))[..64];
+
+    /// <summary>
+    /// Igual a <see cref="ProcessoSeletivoPublicavelSeeder.SemearAsync"/>, exceto que a única
+    /// fase do cronograma NÃO coleta inscrição — com <c>OrigemCandidatos.InscricaoPropria</c>,
+    /// isso deixa vermelho só "Cronograma: inscrição própria tem fase que coleta inscrição" e
+    /// <c>Publicar</c> recusa com <c>ProcessoSeletivo.InscricaoPropriaSemFaseDeColeta</c> — o
+    /// cenário Gherkin da issue #1096.
+    /// </summary>
+    public static async Task<(ProcessoSeletivo Processo, DocumentoEdital Documento)> SemearComCronogramaNaoConformeAsync(
+        SelecaoDbContext db, string nome)
+    {
+        ProcessoSeletivo processo = ProcessoBaseConforme(nome, out FaseCronogramaBuilder faseBuilder);
+
+        Result cronogramaResult = processo.DefinirCronogramaFases(
+            [faseBuilder(coletaInscricao: false)], [], PrecondicaoIfMatch.Ausente);
+        cronogramaResult.IsSuccess.Should().BeTrue(cronogramaResult.Error?.Message);
+
+        return await PersistirComDocumentoConfirmadoAsync(db, processo);
+    }
+
+    /// <summary>
+    /// Igual à base, exceto que a distribuição de vagas usa a regra Institucional (fora do
+    /// regime da Lei 12.711) com uma modalidade <c>SegueCascata</c> — vermelho em "Cascata de
+    /// remanejamento" e no detalhamento "Cascata: modalidade SegueCascata usa a regra de
+    /// distribuição federal"; <c>Publicar</c> recusa com
+    /// <c>ProcessoSeletivo.CascataForaDoRegimeFederal</c>.
+    /// </summary>
+    public static async Task<(ProcessoSeletivo Processo, DocumentoEdital Documento)> SemearComCascataNaoConformeAsync(
+        SelecaoDbContext db, string nome)
+    {
+        ModalidadeSelecionada ampla = ModalidadeSelecionada.Criar(
+            modalidadeOrigemId: Guid.CreateVersion7(), codigo: "AC", descricao: "Ampla concorrência",
+            naturezaLegal: NaturezaLegalModalidade.Ampla, composicaoVagas: ComposicaoVagasModalidade.ResidualDoVo,
+            composicaoOrigemCodigo: null, regraRemanejamento: RegraRemanejamentoModalidade.Nenhuma,
+            remanejamentoDestino: null, remanejamentoPar: null, remanejamentoFallback: null,
+            criteriosCumulativos: [], acaoQuandoIndeferido: null, baseLegal: "Res. Unifesspa 532/2021",
+            quantidadeDeclarada: 8).Value!;
+        ModalidadeSelecionada cotaSegueCascataForaDoFederal = ModalidadeSelecionada.Criar(
+            modalidadeOrigemId: Guid.CreateVersion7(), codigo: "LB_PPI", descricao: "Baixa renda PPI",
+            naturezaLegal: NaturezaLegalModalidade.CotaReservada, composicaoVagas: ComposicaoVagasModalidade.DentroDoVr,
+            composicaoOrigemCodigo: null, regraRemanejamento: RegraRemanejamentoModalidade.SegueCascata,
+            remanejamentoDestino: null, remanejamentoPar: null, remanejamentoFallback: null,
+            criteriosCumulativos: [], acaoQuandoIndeferido: null, baseLegal: "Res. Unifesspa 532/2021",
+            quantidadeDeclarada: 2).Value!;
+        Result<ConfiguracaoDistribuicaoVagas> distribuicaoResult = ConfiguracaoDistribuicaoVagas.Criar(
+            ofertaCursoOrigemId: Guid.CreateVersion7(), voBase: 10, pr: 1m,
+            regraDistribuicao: ReferenciaRegra.Criar(RegraDistribuicaoVagasCodigo.Institucional, "v1", HashFixo).Value!,
+            regraAjuste: null, referenciaDemografica: null, modalidades: [ampla, cotaSegueCascataForaDoFederal]);
+        distribuicaoResult.IsSuccess.Should().BeTrue(distribuicaoResult.Error?.Message);
+
+        ProcessoSeletivo processo = ProcessoBaseConforme(nome, out FaseCronogramaBuilder faseBuilder, distribuicao: [distribuicaoResult.Value!]);
+
+        Result cronogramaResult = processo.DefinirCronogramaFases(
+            [faseBuilder(coletaInscricao: true)], [], PrecondicaoIfMatch.Ausente);
+        cronogramaResult.IsSuccess.Should().BeTrue(cronogramaResult.Error?.Message);
+
+        return await PersistirComDocumentoConfirmadoAsync(db, processo);
+    }
+
+    /// <summary>
+    /// Igual à base, mais uma exigência documental CONDICIONAL sem nenhuma condição de
+    /// gatilho — vermelho em "Exigência documental: sem CONDICIONAL vazia que determina
+    /// resultado"; <c>Publicar</c> recusa com
+    /// <c>DocumentoExigido.CondicionalVaziaDeterminaResultado</c>.
+    /// </summary>
+    public static async Task<(ProcessoSeletivo Processo, DocumentoEdital Documento)> SemearComPreCanonicalizacaoNaoConformeAsync(
+        SelecaoDbContext db, string nome)
+    {
+        ProcessoSeletivo processo = ProcessoBaseConforme(nome, out FaseCronogramaBuilder faseBuilder);
+        Result cronogramaResult = processo.DefinirCronogramaFases(
+            [faseBuilder(coletaInscricao: true)], [], PrecondicaoIfMatch.Ausente);
+        cronogramaResult.IsSuccess.Should().BeTrue(cronogramaResult.Error?.Message);
+
+        Guid faseId = processo.CronogramaFases.Single().Id;
+        DocumentoExigidoBaseLegal baseLegal = DocumentoExigidoBaseLegal.Criar(
+            "Lei 12.711/2012, art. 3º", TipoAbrangencia.InternaEdital, StatusBaseLegal.Resolvido, null).Value!;
+        DocumentoExigido exigencia = DocumentoExigido.Criar(
+            faseId, Guid.CreateVersion7(), "CERTIDAO_RESERVISTA", "Certidão de reservista", "MILITAR",
+            Aplicabilidade.Condicional, obrigatorio: true, consequenciaIndeferimento: null,
+            condicoes: [], basesLegais: [baseLegal], idadeMaximaEmissao: null,
+            formatosPermitidos: FormatosPermitidos.Criar(true, null).Value!, tamanhoMaximoBytes: null).Value!;
+        Result exigenciaResult = processo.DefinirDocumentosExigidos(
+            [NoExigencia.CriarFolha(exigencia, 0).Value!], PrecondicaoIfMatch.Curinga);
+        exigenciaResult.IsSuccess.Should().BeTrue(exigenciaResult.Error?.Message);
+
+        return await PersistirComDocumentoConfirmadoAsync(db, processo);
+    }
+
+    /// <summary>
+    /// Igual à base, exceto que <c>DefinirOfertaAtendimento</c> nunca é chamado — vermelho em
+    /// "Atendimento especializado"; <c>Publicar</c> recusa com o gate agregador
+    /// <c>ProcessoSeletivo.ConformidadeInsuficiente</c> (já funcionava antes da issue #1096 —
+    /// serve de regressão).
+    /// </summary>
+    /// <param name="documentoConfirmado">
+    /// Quando <see langword="false"/>, o documento fica pendente (nunca confirmado): a
+    /// publicação recusa por <c>ProcessoSeletivo.DocumentoNaoConfirmado</c> — um erro
+    /// completamente alheio à conformidade estrutural — antes de alcançar o gate de
+    /// conformidade. Usado para provar que <c>pendencias</c> aparece mesmo quando o 422 não
+    /// tem nada a ver com o item vermelho (CA-06).
+    /// </param>
+    public static async Task<(ProcessoSeletivo Processo, DocumentoEdital Documento)> SemearComCadastroProprioNaoConformeAsync(
+        SelecaoDbContext db, string nome, bool documentoConfirmado = true)
+    {
+        ProcessoSeletivo processo = ProcessoBaseConforme(nome, out FaseCronogramaBuilder faseBuilder, definirOfertaAtendimento: false);
+        Result cronogramaResult = processo.DefinirCronogramaFases(
+            [faseBuilder(coletaInscricao: true)], [], PrecondicaoIfMatch.Ausente);
+        cronogramaResult.IsSuccess.Should().BeTrue(cronogramaResult.Error?.Message);
+
+        return documentoConfirmado
+            ? await PersistirComDocumentoConfirmadoAsync(db, processo)
+            : await PersistirComDocumentoPendenteAsync(db, processo);
+    }
+
+    /// <summary>
+    /// Semeia uma obrigatoriedade legal universal (Story #853) que exige uma etapa que o
+    /// processo base (<see cref="ProcessoSeletivoPublicavelSeeder"/>) não tem — a publicação
+    /// recusa por <c>ProcessoSeletivo.ConformidadeLegalInsuficiente</c> com o checklist
+    /// ESTRUTURAL 100% verde (CA-05/CA-07: <c>obrigatoriedadesReprovadas</c> aparece,
+    /// <c>pendencias</c> não).
+    /// </summary>
+    public static async Task<Guid> SemearObrigatoriedadeNaoAtendidaAsync(SelecaoDbContext db, string regraCodigo)
+    {
+        ObrigatoriedadeLegal regra = ObrigatoriedadeLegal.Criar(
+            tipoProcessoCodigo: ObrigatoriedadeLegal.TipoProcessoUniversal,
+            categoria: CategoriaObrigatoriedade.Outros,
+            regraCodigo: regraCodigo,
+            predicado: new EtapaObrigatoria("ENTREVISTA_NAO_OFERTADA"),
+            descricaoHumana: "Etapa de entrevista obrigatória (teste de integração issue #1096)",
+            baseLegal: "Base legal de teste",
+            vigenciaInicio: new DateOnly(2020, 1, 1)).Value!;
+
+        ObrigatoriedadeLegalRepository repository = new(db, TimeProvider.System);
+        await repository.AdicionarAsync(regra, CancellationToken.None);
+        await db.SaveChangesAsync();
+
+        return regra.Id;
+    }
+
+    private delegate FaseCronograma FaseCronogramaBuilder(bool coletaInscricao);
+
+    private static ConfiguracaoDistribuicaoVagas DistribuicaoAmplaPadrao()
+    {
+        ModalidadeSelecionada modalidade = ModalidadeSelecionada.Criar(
+            modalidadeOrigemId: Guid.CreateVersion7(), codigo: "AC", descricao: "Ampla concorrência",
+            naturezaLegal: NaturezaLegalModalidade.Ampla, composicaoVagas: ComposicaoVagasModalidade.ResidualDoVo,
+            composicaoOrigemCodigo: null, regraRemanejamento: RegraRemanejamentoModalidade.Nenhuma,
+            remanejamentoDestino: null, remanejamentoPar: null, remanejamentoFallback: null,
+            criteriosCumulativos: [], acaoQuandoIndeferido: null, baseLegal: "Res. Unifesspa 532/2021",
+            quantidadeDeclarada: 40).Value!;
+        return ConfiguracaoDistribuicaoVagas.Criar(
+            ofertaCursoOrigemId: Guid.CreateVersion7(), voBase: 40, pr: 1m,
+            regraDistribuicao: ReferenciaRegra.Criar(RegraDistribuicaoVagasCodigo.Institucional, "v1", HashFixo).Value!,
+            regraAjuste: null, referenciaDemografica: null, modalidades: [modalidade]).Value!;
+    }
+
+    private static ProcessoSeletivo ProcessoBaseConforme(
+        string nome,
+        out FaseCronogramaBuilder faseBuilder,
+        bool definirOfertaAtendimento = true,
+        IReadOnlyList<ConfiguracaoDistribuicaoVagas>? distribuicao = null)
+    {
+        ProcessoSeletivo processo = ProcessoSeletivo.Criar(
+            nome, TipoProcesso.SiSU, OrigemCandidatos.InscricaoPropria, Guid.NewGuid(),
+            UnidadeAdministradoraSnapshot.Criar("CEPS", "ceps", "Centro de Processos Seletivos", "ADMINISTRATIVA").Value!);
+
+        Result etapasResult = processo.DefinirEtapas([
+            EtapaProcesso.Criar(
+                "Prova Objetiva", CaraterEtapa.Classificatoria,
+                TipoEtapaSnapshot.Criar(Guid.CreateVersion7(), "PROVA_OBJETIVA", "Prova Objetiva").Value!,
+                peso: 1m, notaMinima: null, ordem: 1),
+        ], PrecondicaoIfMatch.Ausente);
+        etapasResult.IsSuccess.Should().BeTrue(etapasResult.Error?.Message);
+
+        if (definirOfertaAtendimento)
+        {
+            Result ofertaResult = processo.DefinirOfertaAtendimento(
+                OfertaAtendimentoEspecializado.Criar([], [], []).Value!, PrecondicaoIfMatch.Ausente);
+            ofertaResult.IsSuccess.Should().BeTrue(ofertaResult.Error?.Message);
+        }
+
+        IReadOnlyList<ConfiguracaoDistribuicaoVagas> distribuicaoEfetiva = distribuicao ?? [DistribuicaoAmplaPadrao()];
+        Result distribuicaoDefinirResult = processo.DefinirDistribuicaoVagas(distribuicaoEfetiva, PrecondicaoIfMatch.Ausente);
+        distribuicaoDefinirResult.IsSuccess.Should().BeTrue(distribuicaoDefinirResult.Error?.Message);
+
+        ReferenciaRegra regraCalculo = ReferenciaRegra.Criar(
+            RegraCalculoCodigo.ClassificacaoImportada, "v1", HashFixo).Value!;
+        ReferenciaRegra regraOrdemAlocacao = ReferenciaRegra.Criar(
+            RegraOrdemAlocacaoCodigo.AlocacaoOpcoesRn04, "v1", HashFixo).Value!;
+        Result<ConfiguracaoClassificacao> classificacaoResult = ConfiguracaoClassificacao.Criar(
+            regraCalculo: regraCalculo, regraArredondamento: null, casasArredondamento: null,
+            regraOrdemAlocacao: regraOrdemAlocacao, nOpcoesAlocacao: 1, regrasEliminacao: [], baseadoEmEnem: false);
+        classificacaoResult.IsSuccess.Should().BeTrue(classificacaoResult.Error?.Message);
+        Result classificacaoDefinirResult = processo.DefinirClassificacao(classificacaoResult.Value!, PrecondicaoIfMatch.Ausente);
+        classificacaoDefinirResult.IsSuccess.Should().BeTrue(classificacaoDefinirResult.Error?.Message);
+
+        faseBuilder = coletaInscricao => FaseCronograma.Criar(
+            ordem: 1, faseCanonicaOrigemId: Guid.CreateVersion7(), codigo: "RESULTADO_FINAL",
+            donoInstitucional: "CEPS", origemData: OrigemDataFase.Propria,
+            agrupaEtapas: true, permiteComplementacao: false, produzResultado: true, resultadoDefinitivo: true,
+            coletaInscricao: coletaInscricao,
+            inicio: new DateTimeOffset(2026, 1, 1, 0, 0, 0, TimeSpan.Zero),
+            fim: new DateTimeOffset(2026, 1, 31, 0, 0, 0, TimeSpan.Zero),
+            atoProduzidoCodigo: "RESULTADO_FINAL", atoProduzidoEfeitoIrreversivel: false,
+            bancasRequeridas: [], regraRecurso: null).Value!;
+
+        return processo;
+    }
+
+    private static async Task<(ProcessoSeletivo Processo, DocumentoEdital Documento)> PersistirComDocumentoConfirmadoAsync(
+        SelecaoDbContext db, ProcessoSeletivo processo)
+    {
+        await db.ProcessosSeletivos.AddAsync(processo);
+
+        DocumentoEdital documento = DocumentoEdital.IniciarPendente(processo.Id, TimeProvider.System, TimeSpan.FromMinutes(15));
+        Result confirmarResult = documento.Confirmar(1024, HashFixo, TimeProvider.System);
+        confirmarResult.IsSuccess.Should().BeTrue(confirmarResult.Error?.Message);
+        await db.DocumentosEdital.AddAsync(documento);
+
+        await db.SaveChangesAsync();
+        processo.DequeueDomainEvents();
+
+        return (processo, documento);
+    }
+
+    private static async Task<(ProcessoSeletivo Processo, DocumentoEdital Documento)> PersistirComDocumentoPendenteAsync(
+        SelecaoDbContext db, ProcessoSeletivo processo)
+    {
+        await db.ProcessosSeletivos.AddAsync(processo);
+
+        DocumentoEdital documento = DocumentoEdital.IniciarPendente(processo.Id, TimeProvider.System, TimeSpan.FromMinutes(15));
+        await db.DocumentosEdital.AddAsync(documento);
+
+        await db.SaveChangesAsync();
+        processo.DequeueDomainEvents();
+
+        return (processo, documento);
+    }
+}

--- a/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/Outbox/Cascading/PublicarProcessoSeletivoEndpointTests.cs
+++ b/tests/Unifesspa.UniPlus.Selecao.IntegrationTests/Outbox/Cascading/PublicarProcessoSeletivoEndpointTests.cs
@@ -1,6 +1,7 @@
 namespace Unifesspa.UniPlus.Selecao.IntegrationTests.Outbox.Cascading;
 
 using System.Globalization;
+using System.Linq;
 using System.Net;
 using System.Net.Http.Headers;
 using System.Net.Http.Json;
@@ -114,6 +115,143 @@ public sealed class PublicarProcessoSeletivoEndpointTests
         using JsonDocument doc = JsonDocument.Parse(await segunda.Content.ReadAsStringAsync());
         doc.RootElement.GetProperty("code").GetString()
             .Should().Be("uniplus.selecao.processo_seletivo.transicao_invalida");
+        // issue #1096 CA-07: processo já publicado tem o checklist estrutural 100% verde —
+        // "pendencias" nunca aparece vazio, e aqui nem deveria aparecer.
+        doc.RootElement.TryGetProperty("pendencias", out _).Should().BeFalse();
+    }
+
+    [Fact(DisplayName =
+        "POST /processos-seletivos/{id}/publicacao com cadastro próprio não conforme — 422 ConformidadeInsuficiente inclui pendencias (issue #1096 CA-04, regressão)")]
+    public async Task Publicar_QuandoCadastroProprioNaoConforme_Retorna422ComPendencias() =>
+        await AssertGateEstruturalNaoConformeAsync(
+            (db, nome) => ProcessoSeletivoPendenciasSeeder.SemearComCadastroProprioNaoConformeAsync(db, nome),
+            "uniplus.selecao.processo_seletivo.conformidade_insuficiente",
+            "Atendimento especializado",
+            nameof(Publicar_QuandoCadastroProprioNaoConforme_Retorna422ComPendencias));
+
+    [Fact(DisplayName =
+        "POST /processos-seletivos/{id}/publicacao com cronograma não conforme (InscricaoPropria sem fase de coleta) — 422 inclui pendencias (issue #1096 CA-01, cenário Gherkin da issue)")]
+    public async Task Publicar_QuandoCronogramaNaoConforme_Retorna422ComPendencias() =>
+        await AssertGateEstruturalNaoConformeAsync(
+            ProcessoSeletivoPendenciasSeeder.SemearComCronogramaNaoConformeAsync,
+            "uniplus.selecao.processo_seletivo.inscricao_propria_sem_fase_de_coleta",
+            "Cronograma: inscrição própria tem fase que coleta inscrição",
+            nameof(Publicar_QuandoCronogramaNaoConforme_Retorna422ComPendencias));
+
+    [Fact(DisplayName =
+        "POST /processos-seletivos/{id}/publicacao com cascata não conforme (fora do regime federal) — 422 inclui pendencias (issue #1096 CA-02)")]
+    public async Task Publicar_QuandoCascataNaoConforme_Retorna422ComPendencias() =>
+        await AssertGateEstruturalNaoConformeAsync(
+            ProcessoSeletivoPendenciasSeeder.SemearComCascataNaoConformeAsync,
+            "uniplus.selecao.processo_seletivo.cascata_fora_do_regime_federal",
+            "Cascata: modalidade SegueCascata usa a regra de distribuição federal",
+            nameof(Publicar_QuandoCascataNaoConforme_Retorna422ComPendencias));
+
+    [Fact(DisplayName =
+        "POST /processos-seletivos/{id}/publicacao com pré-canonicalização não conforme (CONDICIONAL vazia) — 422 inclui pendencias (issue #1096 CA-03)")]
+    public async Task Publicar_QuandoPreCanonicalizacaoNaoConforme_Retorna422ComPendencias() =>
+        await AssertGateEstruturalNaoConformeAsync(
+            ProcessoSeletivoPendenciasSeeder.SemearComPreCanonicalizacaoNaoConformeAsync,
+            "uniplus.selecao.documento_exigido.condicional_vazia_determina_resultado",
+            "Exigência documental: sem CONDICIONAL vazia que determina resultado",
+            nameof(Publicar_QuandoPreCanonicalizacaoNaoConforme_Retorna422ComPendencias));
+
+    /// <summary>
+    /// Semeia via <paramref name="semear"/>, publica e confirma que o 422 tem o <paramref
+    /// name="codigoEsperado"/> e que <c>pendencias</c> contém <paramref
+    /// name="itemVermelhoEsperado"/> — corpo comum aos quatro grupos de gate estrutural da
+    /// issue #1096 (CA-01 a CA-04).
+    /// </summary>
+    private async Task AssertGateEstruturalNaoConformeAsync(
+        Func<SelecaoDbContext, string, Task<(ProcessoSeletivo Processo, DocumentoEdital Documento)>> semear,
+        string codigoEsperado,
+        string itemVermelhoEsperado,
+        string nomeDoCenario)
+    {
+        ArgumentNullException.ThrowIfNull(semear);
+
+        CascadingApiFactory api = _fixture.Factory;
+        await TiposDeAtoSeeder.SemearAsync(api.Services);
+        using HttpClient client = api.CreateClient();
+
+        await using AsyncServiceScope scope = api.Services.CreateAsyncScope();
+        SelecaoDbContext db = scope.ServiceProvider.GetRequiredService<SelecaoDbContext>();
+        (ProcessoSeletivo processo, DocumentoEdital documento) = await semear(db, $"{nomeDoCenario} {Guid.CreateVersion7()}");
+
+        HttpResponseMessage response = await PostPublicarAsync(client, processo.Id, documento.Id, MakeIdempotencyKey());
+
+        response.StatusCode.Should().Be(HttpStatusCode.UnprocessableEntity);
+        using JsonDocument doc = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        doc.RootElement.GetProperty("code").GetString().Should().Be(codigoEsperado);
+        doc.RootElement.GetProperty("pendencias").EnumerateArray().Select(e => e.GetString())
+            .Should().Contain(itemVermelhoEsperado);
+    }
+
+    [Fact(DisplayName =
+        "POST /processos-seletivos/{id}/publicacao recusado por obrigatoriedade legal com checklist estrutural verde — 422 com obrigatoriedadesReprovadas e SEM pendencias (issue #1096 CA-05/CA-07)")]
+    public async Task Publicar_QuandoSoObrigatoriedadeLegalReprovada_Retorna422SemPendencias()
+    {
+        CascadingApiFactory api = _fixture.Factory;
+        await TiposDeAtoSeeder.SemearAsync(api.Services);
+        using HttpClient client = api.CreateClient();
+
+        await using AsyncServiceScope scope = api.Services.CreateAsyncScope();
+        SelecaoDbContext db = scope.ServiceProvider.GetRequiredService<SelecaoDbContext>();
+        Guid regraId = await ProcessoSeletivoPendenciasSeeder.SemearObrigatoriedadeNaoAtendidaAsync(
+            db, $"TEST_GATE_{Guid.CreateVersion7():N}");
+        try
+        {
+            (ProcessoSeletivo processo, DocumentoEdital documento) = await ProcessoSeletivoPublicavelSeeder
+                .SemearAsync(db, nameof(Publicar_QuandoSoObrigatoriedadeLegalReprovada_Retorna422SemPendencias));
+
+            HttpResponseMessage response = await PostPublicarAsync(client, processo.Id, documento.Id, MakeIdempotencyKey());
+
+            response.StatusCode.Should().Be(HttpStatusCode.UnprocessableEntity);
+            using JsonDocument doc = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+            doc.RootElement.GetProperty("code").GetString()
+                .Should().Be("uniplus.selecao.processo_seletivo.conformidade_legal_insuficiente");
+            doc.RootElement.GetProperty("obrigatoriedadesReprovadas").GetArrayLength().Should().BeGreaterThan(0);
+            doc.RootElement.TryGetProperty("pendencias", out _).Should().BeFalse(
+                "o checklist estrutural está 100% verde — só a obrigatoriedade legal reprovou");
+        }
+        finally
+        {
+            // A regra é universal (TipoProcessoUniversal) e sem vigenciaFim — sem esta limpeza,
+            // ela continuaria reprovando todo processo SiSU publicado depois dela neste mesmo
+            // container Postgres, compartilhado por toda a classe via CascadingFixture (afeta
+            // até os testes que esperam 204, como Publicar_FluxoCompleto_DispatchaCascadingMessages).
+            await db.Database.ExecuteSqlAsync($"UPDATE selecao.obrigatoriedades_legais SET is_deleted = true WHERE id = {regraId}");
+        }
+    }
+
+    [Fact(DisplayName =
+        "POST /processos-seletivos/{id}/publicacao recusado por documento não confirmado, com checklist estrutural vermelho — 422 inclui pendencias mesmo sendo erro alheio à conformidade (issue #1096 CA-06)")]
+    public async Task Publicar_QuandoOutroErro422EChecklistAindaVermelho_IncluiPendencias()
+    {
+        CascadingApiFactory api = _fixture.Factory;
+        await TiposDeAtoSeeder.SemearAsync(api.Services);
+        using HttpClient client = api.CreateClient();
+
+        await using AsyncServiceScope scope = api.Services.CreateAsyncScope();
+        SelecaoDbContext db = scope.ServiceProvider.GetRequiredService<SelecaoDbContext>();
+        (ProcessoSeletivo processo, DocumentoEdital documento) = await ProcessoSeletivoPendenciasSeeder
+            .SemearComCadastroProprioNaoConformeAsync(
+                db,
+                nameof(Publicar_QuandoOutroErro422EChecklistAindaVermelho_IncluiPendencias),
+                documentoConfirmado: false);
+
+        HttpResponseMessage response = await PostPublicarAsync(client, processo.Id, documento.Id, MakeIdempotencyKey());
+
+        response.StatusCode.Should().Be(HttpStatusCode.UnprocessableEntity);
+        using JsonDocument doc = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        // A recusa é por documento não confirmado — nada a ver com conformidade estrutural —,
+        // mas o checklist reconsultado no momento do enriquecimento ainda tem item vermelho, e
+        // o contrato (issue #1096) diz que "pendencias" é um retrato do estado atual, não uma
+        // tradução exclusiva do código de erro que efetivamente recusou.
+        doc.RootElement.GetProperty("code").GetString()
+            .Should().Be("uniplus.selecao.processo_seletivo.documento_nao_confirmado");
+        doc.RootElement.GetProperty("pendencias").EnumerateArray().Select(e => e.GetString())
+            .Should().Contain("Atendimento especializado");
     }
 
     [Fact(DisplayName =


### PR DESCRIPTION
## O que muda

`EnriquecerComPendenciasEstruturaisAsync` (controller) só reconsultava o checklist estrutural e anexava `Extensions["pendencias"]` quando o `Result` trazia o código `ProcessoSeletivo.ConformidadeInsuficiente` — o primeiro dos quatro gates estruturais que `ProcessoSeletivo.AvaliarConformidade()` cobre desde a issue #1092. Recusas de cronograma, cascata ou pré-canonicalização, com códigos de erro próprios, saíam com 422 mas sem a lista acionável.

A correção troca a checagem por código de erro por checagem de status: qualquer 422 da tentativa de publicação reconsulta `AvaliarConformidade()` (via `ObterConformidadeProcessoSeletivoQuery`) e anexa `pendencias` quando houver item vermelho no estado atual — sem manter lista paralela de códigos no controller. Quando o checklist estiver 100% verde, a extensão é omitida (nunca `pendencias: []`).

Isso também cobre o caso de um 422 alheio à conformidade estrutural (ex.: documento não confirmado) ocorrer enquanto o checklist ainda tem pendência: a extensão é um retrato do estado no momento do enriquecimento, não uma tradução exclusiva do código que efetivamente recusou.

## Critérios de aceite (issue #1096)

- [x] CA-01 — Falha no gate de cadastro próprio (inscrição própria sem fase de coleta) retorna 422 com a pendência correspondente.
- [x] CA-02 — Falha no gate de cascata retorna 422 com a pendência correspondente.
- [x] CA-03 — Falha no gate de pré-canonicalização retorna 422 com a pendência correspondente.
- [x] CA-04 — Falha no gate estrutural principal (conformidade) continua retornando a lista, sem regressão.
- [x] CA-05 — Falha exclusivamente legal retorna `obrigatoriedadesReprovadas` e omite `pendencias` quando o checklist estrutural estiver verde.
- [x] CA-06 — Outro erro 422 (documento não confirmado) inclui pendências estruturais quando elas existem no estado atual.
- [x] CA-07 — Quando não houver item vermelho, a extensão `pendencias` é omitida.
- [x] CA-08 — O controller não mantém lista de códigos de erro estruturais nem replica predicados do domínio.

## Testes

Não havia nenhum teste de integração HTTP cobrindo o campo `pendencias` antes deste PR. Adiciona:

- Um cenário por grupo de gate estrutural (`ProcessoSeletivoPendenciasSeeder`, novo): cronograma, cascata, pré-canonicalização e cadastro próprio (regressão do comportamento já existente antes da issue).
- Cenário de obrigatoriedade legal isolada — 422 com `obrigatoriedadesReprovadas` e sem `pendencias`.
- Cenário de erro alheio à conformidade (documento não confirmado) com checklist ainda vermelho — prova o desacoplamento entre código de erro e enriquecimento.
- Reforço em `Publicar_QuandoJaPublicado_Retorna422` (já existente): assert de ausência de `pendencias` quando o processo já publicado tem checklist verde.

Suíte completa do módulo Seleção rodada localmente: 907 (Domain.UnitTests) + 353 (Application.UnitTests) + 100 (ArchTests) + 617 (IntegrationTests) testes, todos verdes.

Closes #1096